### PR TITLE
Refactor usp_GetPositionBudgets for project id

### DIFF
--- a/datamart/StoredProcedures/usp_GetPositionBudgets.sql
+++ b/datamart/StoredProcedures/usp_GetPositionBudgets.sql
@@ -1,12 +1,27 @@
 CREATE PROCEDURE dbo.usp_GetPositionBudgets
-    @FinancialDept VARCHAR(7),
+    @FinancialDept VARCHAR(7) = NULL,
+    @ProjectIds VARCHAR(MAX) = NULL,
     @ApplicationName NVARCHAR(128) = NULL
 AS
 BEGIN
     SET NOCOUNT ON;
 
-    -- Validate FinancialDept
-    EXEC dbo.usp_ValidateFinancialDept @FinancialDept;
+    -- Validate: exactly one filter must be provided
+    IF (@FinancialDept IS NULL AND @ProjectIds IS NULL)
+    BEGIN
+        RAISERROR('Either @FinancialDept or @ProjectIds must be provided', 16, 1);
+        RETURN;
+    END;
+
+    IF (@FinancialDept IS NOT NULL AND @ProjectIds IS NOT NULL)
+    BEGIN
+        RAISERROR('Cannot specify both @FinancialDept and @ProjectIds', 16, 1);
+        RETURN;
+    END;
+
+    -- Validate FinancialDept if provided
+    IF @FinancialDept IS NOT NULL
+        EXEC dbo.usp_ValidateFinancialDept @FinancialDept;
 
     DECLARE @OracleQuery NVARCHAR(MAX);
     DECLARE @TSQLCommand NVARCHAR(MAX);
@@ -17,11 +32,44 @@ BEGIN
     DECLARE @ErrorMsg NVARCHAR(MAX);
     DECLARE @ParametersJSON NVARCHAR(MAX);
 
-    -- Sanitize ApplicationName for injection protection (whitelist: alphanumeric + spaces only)
+    -- Sanitize ApplicationName for injection protection
     EXEC dbo.usp_SanitizeInputString @ApplicationName OUTPUT;
 
-    -- Sanitize FinancialDept for SQL injection protection (defense in depth)
-    EXEC dbo.usp_SanitizeInputString @FinancialDept OUTPUT;
+    -- Sanitize FinancialDept for SQL injection protection
+    IF @FinancialDept IS NOT NULL
+        EXEC dbo.usp_SanitizeInputString @FinancialDept OUTPUT;
+
+    -- Build ProjectId filter if provided
+    DECLARE @ProjectIdFilter NVARCHAR(MAX);
+
+    IF @ProjectIds IS NOT NULL
+    BEGIN
+        DECLARE @ProjectId VARCHAR(15);
+        DECLARE @ValidatedProjects TABLE (ProjectId VARCHAR(15));
+
+        -- Parse comma-separated list into table
+        INSERT INTO @ValidatedProjects (ProjectId)
+        SELECT TRIM(value)
+        FROM STRING_SPLIT(@ProjectIds, ',')
+        WHERE TRIM(value) <> '';
+
+        -- Validate each project ID format
+        DECLARE ProjectCursor CURSOR FOR
+            SELECT ProjectId FROM @ValidatedProjects;
+        OPEN ProjectCursor;
+        FETCH NEXT FROM ProjectCursor INTO @ProjectId;
+        WHILE @@FETCH_STATUS = 0
+        BEGIN
+            EXEC dbo.usp_ValidateAggieEnterpriseProject @ProjectId;
+            FETCH NEXT FROM ProjectCursor INTO @ProjectId;
+        END;
+        CLOSE ProjectCursor;
+        DEALLOCATE ProjectCursor;
+
+        -- Build IN clause for Oracle query (e.g., 'PROJ001','PROJ002')
+        SELECT @ProjectIdFilter = STRING_AGG('''' + ProjectId + '''', ',')
+        FROM @ValidatedProjects;
+    END
 
     -- Build Oracle query joining budget and position data
     SET @OracleQuery = '
@@ -51,7 +99,11 @@ BEGIN
                 ON budget.ACCT_CD = acct.ACCT_CD
             WHERE budget.DML_IND != ''D''
               AND acct.DML_IND != ''D''
-              AND acct.DEPTID_CF = ''' + @FinancialDept + '''
+              ' + CASE
+                    WHEN @FinancialDept IS NOT NULL
+                    THEN 'AND acct.DEPTID_CF = ''' + @FinancialDept + ''''
+                    ELSE 'AND acct.PROJECT_ID IN (' + @ProjectIdFilter + ')'
+                END + '
         ),
         LatestPosition AS (
             SELECT
@@ -132,6 +184,7 @@ BEGIN
     SET @ParametersJSON = (
         SELECT
             @FinancialDept AS FinancialDept,
+            @ProjectIds AS ProjectIds,
             COALESCE(@ApplicationName, APP_NAME()) AS ApplicationName
         FOR JSON PATH, WITHOUT_ARRAY_WRAPPER
     );

--- a/datamart/StoredProcedures/usp_ValidateAggieEnterpriseProject.sql
+++ b/datamart/StoredProcedures/usp_ValidateAggieEnterpriseProject.sql
@@ -1,0 +1,20 @@
+CREATE PROCEDURE dbo.usp_ValidateAggieEnterpriseProject
+    @ProjectId VARCHAR(15)
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    IF @ProjectId IS NULL
+    BEGIN
+        RAISERROR('ProjectId is required', 16, 1);
+        RETURN;
+    END;
+
+    -- Validate: exactly 10 alphanumeric characters
+    IF LEN(@ProjectId) != 10 OR @ProjectId LIKE '%[^A-Z0-9]%'
+    BEGIN
+        RAISERROR('Invalid Project ID format (must be exactly 10 alphanumeric characters)', 16, 1);
+        RETURN;
+    END;
+END;
+GO


### PR DESCRIPTION
Adds Project ID as a parameter for usp_GetPositionBudgets. This allows the Walter app to query data based on a comma-separated list of AE project IDs.

Creates simple validation proc for project IDs. This validation is necessary since openquery queries cannot be parametrized so we need checks to protect against sql injection. In the future, if we move to a data warehouse where we can parametrize these queries, these checks may not be needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Position budget queries now support filtering by project IDs, providing an alternative to the existing financial department filter for greater flexibility in data retrieval.

* **Improvements**
  * Added project ID validation to enforce consistent formatting standards, requiring exactly 10 uppercase alphanumeric characters for all project identifiers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->