### PR TITLE
Refactor usp_GetFacultyDeptPortfolio for project ids

### DIFF
--- a/datamart/StoredProcedures/usp_GetFacultyDeptPortfolio.sql
+++ b/datamart/StoredProcedures/usp_GetFacultyDeptPortfolio.sql
@@ -57,11 +57,18 @@ BEGIN
         DECLARE @ProjectId VARCHAR(15);
         DECLARE @ValidatedProjects TABLE (ProjectId VARCHAR(15));
 
-        -- Parse comma-separated list into table
+        -- Parse comma-separated list into table, filtering out empty strings and literal 'null' values
         INSERT INTO @ValidatedProjects (ProjectId)
         SELECT TRIM(value)
         FROM STRING_SPLIT(@ProjectIds, ',')
-        WHERE TRIM(value) <> '';
+        WHERE TRIM(value) <> '' AND LOWER(TRIM(value)) <> 'null';
+
+        -- Validate that at least one project ID was provided
+        IF NOT EXISTS (SELECT 1 FROM @ValidatedProjects)
+        BEGIN
+            RAISERROR('No valid project IDs provided', 16, 1);
+            RETURN;
+        END;
 
         -- Validate each project ID format
         DECLARE ProjectCursor CURSOR FOR


### PR DESCRIPTION
Adds Project ID as a parameter for usp_GetFacultyDeptPortfolio. This allows the Walter app to query data based on a comma-separated list of AE project IDs.

Adds simple validation proc for project IDs. This validation is necessary since openquery queries cannot be parametrized so we need checks to protect against sql injection. In the future, if we move to a data warehouse where we can parametrize these queries, these checks may not be needed.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added filtering by project identifiers for department portfolio queries.

* **Enhancements**
  * Department filter now optional and mutual-exclusive with project filter.
  * Improved validation and parsing for comma-separated project IDs, with clearer error handling.
  * Expanded request logging to include project IDs and tightened input sanitization.
  * Date-range overlap behavior and overall execution flow preserved.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->