### PR TITLE
Add project ID filtering to GL Transaction Listings and refactor shared parsing

### DIFF
--- a/datamart/StoredProcedures/usp_GetGLTransactionListings.sql
+++ b/datamart/StoredProcedures/usp_GetGLTransactionListings.sql
@@ -1,5 +1,6 @@
 CREATE PROCEDURE dbo.usp_GetGLTransactionListings
-    @FinancialDept VARCHAR(7),
+    @FinancialDept VARCHAR(7) = NULL,
+    @ProjectIds VARCHAR(MAX) = NULL,
     @StartDate DATE = NULL,
     @EndDate DATE = NULL,
     @ApplicationName NVARCHAR(128) = NULL
@@ -7,8 +8,22 @@ AS
 BEGIN
     SET NOCOUNT ON;
 
-    -- Validate FinancialDept
-    EXEC dbo.usp_ValidateFinancialDept @FinancialDept;
+    -- Validate: exactly one filter must be provided
+    IF (@FinancialDept IS NULL AND @ProjectIds IS NULL)
+    BEGIN
+        RAISERROR('Either @FinancialDept or @ProjectIds must be provided', 16, 1);
+        RETURN;
+    END;
+
+    IF (@FinancialDept IS NOT NULL AND @ProjectIds IS NOT NULL)
+    BEGIN
+        RAISERROR('Cannot specify both @FinancialDept and @ProjectIds', 16, 1);
+        RETURN;
+    END;
+
+    -- Validate FinancialDept if provided
+    IF @FinancialDept IS NOT NULL
+        EXEC dbo.usp_ValidateFinancialDept @FinancialDept;
 
     -- Validate date range if both are provided
     IF @StartDate IS NOT NULL AND @EndDate IS NOT NULL AND @EndDate < @StartDate
@@ -31,10 +46,20 @@ BEGIN
     EXEC dbo.usp_SanitizeInputString @ApplicationName OUTPUT;
 
     -- Sanitize FinancialDept for SQL injection protection (defense in depth)
-    EXEC dbo.usp_SanitizeInputString @FinancialDept OUTPUT;
+    IF @FinancialDept IS NOT NULL
+        EXEC dbo.usp_SanitizeInputString @FinancialDept OUTPUT;
 
-    -- Build filter clause
-    SET @FilterClause = ' WHERE financial_department = ''' + @FinancialDept + '''';
+    -- Parse and validate ProjectIds if provided
+    DECLARE @ProjectIdFilter NVARCHAR(MAX);
+
+    IF @ProjectIds IS NOT NULL
+        EXEC dbo.usp_ParseProjectIdFilter @ProjectIds, @ProjectIdFilter OUTPUT;
+
+    -- Build filter clause based on which parameter was provided
+    IF @FinancialDept IS NOT NULL
+        SET @FilterClause = ' WHERE financial_department = ''' + @FinancialDept + '''';
+    ELSE
+        SET @FilterClause = ' WHERE PROJECT IN (' + @ProjectIdFilter + ')';
 
     -- Add date filters
     IF @StartDate IS NOT NULL
@@ -64,6 +89,7 @@ BEGIN
     SET @ParametersJSON = (
         SELECT
             @FinancialDept AS FinancialDept,
+            @ProjectIds AS ProjectIds,
             CONVERT(VARCHAR(10), @StartDate, 120) AS StartDate,
             CONVERT(VARCHAR(10), @EndDate, 120) AS EndDate,
             COALESCE(@ApplicationName, APP_NAME()) AS ApplicationName

--- a/datamart/StoredProcedures/usp_GetPositionBudgets.sql
+++ b/datamart/StoredProcedures/usp_GetPositionBudgets.sql
@@ -39,37 +39,11 @@ BEGIN
     IF @FinancialDept IS NOT NULL
         EXEC dbo.usp_SanitizeInputString @FinancialDept OUTPUT;
 
-    -- Build ProjectId filter if provided
+    -- Parse and validate ProjectIds if provided
     DECLARE @ProjectIdFilter NVARCHAR(MAX);
 
     IF @ProjectIds IS NOT NULL
-    BEGIN
-        DECLARE @ProjectId VARCHAR(15);
-        DECLARE @ValidatedProjects TABLE (ProjectId VARCHAR(15));
-
-        -- Parse comma-separated list into table
-        INSERT INTO @ValidatedProjects (ProjectId)
-        SELECT TRIM(value)
-        FROM STRING_SPLIT(@ProjectIds, ',')
-        WHERE TRIM(value) <> '';
-
-        -- Validate each project ID format
-        DECLARE ProjectCursor CURSOR FOR
-            SELECT ProjectId FROM @ValidatedProjects;
-        OPEN ProjectCursor;
-        FETCH NEXT FROM ProjectCursor INTO @ProjectId;
-        WHILE @@FETCH_STATUS = 0
-        BEGIN
-            EXEC dbo.usp_ValidateAggieEnterpriseProject @ProjectId;
-            FETCH NEXT FROM ProjectCursor INTO @ProjectId;
-        END;
-        CLOSE ProjectCursor;
-        DEALLOCATE ProjectCursor;
-
-        -- Build IN clause for Oracle query (e.g., 'PROJ001','PROJ002')
-        SELECT @ProjectIdFilter = STRING_AGG('''' + ProjectId + '''', ',')
-        FROM @ValidatedProjects;
-    END
+        EXEC dbo.usp_ParseProjectIdFilter @ProjectIds, @ProjectIdFilter OUTPUT;
 
     -- Build Oracle query joining budget and position data
     SET @OracleQuery = '

--- a/datamart/StoredProcedures/usp_ParseProjectIdFilter.sql
+++ b/datamart/StoredProcedures/usp_ParseProjectIdFilter.sql
@@ -1,0 +1,41 @@
+CREATE PROCEDURE dbo.usp_ParseProjectIdFilter
+    @ProjectIds VARCHAR(MAX),
+    @ProjectIdFilter NVARCHAR(MAX) OUTPUT
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    DECLARE @ProjectId VARCHAR(15);
+    DECLARE @ValidatedProjects TABLE (ProjectId VARCHAR(15));
+
+    -- Parse comma-separated list into table, filtering out empty strings and literal 'null' values
+    INSERT INTO @ValidatedProjects (ProjectId)
+    SELECT TRIM(value)
+    FROM STRING_SPLIT(@ProjectIds, ',')
+    WHERE TRIM(value) <> '' AND LOWER(TRIM(value)) <> 'null';
+
+    -- Validate that at least one project ID was provided
+    IF NOT EXISTS (SELECT 1 FROM @ValidatedProjects)
+    BEGIN
+        RAISERROR('No valid project IDs provided', 16, 1);
+        RETURN;
+    END;
+
+    -- Validate each project ID format
+    DECLARE ProjectCursor CURSOR FOR
+        SELECT ProjectId FROM @ValidatedProjects;
+    OPEN ProjectCursor;
+    FETCH NEXT FROM ProjectCursor INTO @ProjectId;
+    WHILE @@FETCH_STATUS = 0
+    BEGIN
+        EXEC dbo.usp_ValidateAggieEnterpriseProject @ProjectId;
+        FETCH NEXT FROM ProjectCursor INTO @ProjectId;
+    END;
+    CLOSE ProjectCursor;
+    DEALLOCATE ProjectCursor;
+
+    -- Build IN clause filter string (e.g., 'K30GS7777','K30GS8888')
+    SELECT @ProjectIdFilter = STRING_AGG('''' + ProjectId + '''', ',')
+    FROM @ValidatedProjects;
+END;
+GO


### PR DESCRIPTION
- Create usp_ParseProjectIdFilter for shared project ID parsing logic
  - Filters empty strings and literal 'null' values
  - Validates at least one valid project ID exists
  - Validates each project ID format
  - Returns filter string for IN clause

- Add @ProjectIds parameter to usp_GetGLTransactionListings
- Add @ProjectIds parameter to usp_GetFacultyDeptPortfolio
- Update usp_GetPositionBudgets to use shared parser (fixes missing null/empty checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Project ID filtering across faculty portfolio, GL transaction, and position budget reports, and a new centralized Project ID parser to support comma-separated inputs.

* **Enhancements**
  * Made financial-department vs. project-ID filters mutually exclusive and required one to be provided.
  * Improved input validation and conditional sanitization for filter parameters and included Project IDs in report parameters output.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->