### PR TITLE
add DM health check

### DIFF
--- a/web/server/HealthChecks/DmConnectivityHealthCheck.cs
+++ b/web/server/HealthChecks/DmConnectivityHealthCheck.cs
@@ -1,0 +1,75 @@
+using System.Data;
+using Dapper;
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace server.HealthChecks;
+
+public sealed class DmConnectivityHealthCheck : IHealthCheck
+{
+    private sealed record DmConnectivityResult(string Status, int SourcesTested, int SourcesFailed);
+
+    private readonly IConfiguration _configuration;
+    private readonly ILogger<DmConnectivityHealthCheck> _logger;
+
+    public DmConnectivityHealthCheck(
+        IConfiguration configuration,
+        ILogger<DmConnectivityHealthCheck> logger)
+    {
+        _configuration = configuration;
+        _logger = logger;
+    }
+
+    public async Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context,
+        CancellationToken ct = default)
+    {
+        var connectionString = _configuration["DM_CONNECTION"];
+
+        if (string.IsNullOrWhiteSpace(connectionString))
+        {
+            return new HealthCheckResult(
+                status: context.Registration.FailureStatus,
+                description: "DM_CONNECTION is not set.");
+        }
+
+        try
+        {
+            await using var conn = new SqlConnection(connectionString);
+            await conn.OpenAsync(ct);
+
+            var cmd = new CommandDefinition(
+                commandText: "dbo.usp_HealthCheck_Connectivity",
+                commandType: CommandType.StoredProcedure,
+                commandTimeout: 60,
+                cancellationToken: ct);
+
+            var result = await conn.QuerySingleAsync<DmConnectivityResult>(cmd);
+
+            var data = new Dictionary<string, object>
+            {
+                ["sourcesTested"] = result.SourcesTested,
+                ["sourcesFailed"] = result.SourcesFailed,
+            };
+
+            if (result.SourcesFailed > 0)
+            {
+                return new HealthCheckResult(
+                    status: context.Registration.FailureStatus,
+                    description: result.Status,
+                    data: data);
+            }
+
+            return HealthCheckResult.Healthy(description: result.Status, data: data);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Datamart connectivity health check failed.");
+
+            return new HealthCheckResult(
+                status: context.Registration.FailureStatus,
+                description: ex.Message,
+                exception: ex);
+        }
+    }
+}

--- a/web/server/Program.cs
+++ b/web/server/Program.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using server.core.Data;
+using server.HealthChecks;
 using server.Helpers;
 using Server.Services;
 using server.core.Services;
@@ -74,7 +75,12 @@ builder.Services.AddDbContextPool<AppDbContext>(o => o.UseSqlServer(conn, opt =>
 
 builder.Services
     .AddHealthChecks()
-    .AddDbContextCheck<AppDbContext>();
+    .AddDbContextCheck<AppDbContext>()
+    .AddCheck<DmConnectivityHealthCheck>(
+        name: "datamart_connectivity",
+        failureStatus: HealthStatus.Unhealthy,
+        tags: null,
+        timeout: TimeSpan.FromSeconds(60));
 
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();


### PR DESCRIPTION
calls `usp_HealthCheck_Connectivity` and uses that status as part of the /health endpoint. We can later add this to statuspage or anywhere else.  

closes #25 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a health check that monitors data management system connectivity and reports source availability status with diagnostic details.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->