### PR TITLE
Displays project PI on projects page

### DIFF
--- a/web/client/src/routes/(authenticated)/projects/$employeeId/index.tsx
+++ b/web/client/src/routes/(authenticated)/projects/$employeeId/index.tsx
@@ -59,7 +59,11 @@ function RouteComponent() {
   return (
     <main className="flex-1">
       <section className="mt-8 section-margin">
-        <h1 className="h1">All Projects for {projects[0].pi}</h1>
+        <h1 className="h1">
+          {projects[0].pi
+            ? `All Projects for ${projects[0].pi}`
+            : 'All Projects'}
+        </h1>
       </section>
 
       <section className="section-margin">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Project list heading now dynamically displays the project's principal investigator (e.g., "All Projects for [PI]") when available, with a fallback to the original "All Projects" title if not.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->