### PR TITLE
break word on tables

### DIFF
--- a/web/client/src/main.css
+++ b/web/client/src/main.css
@@ -178,7 +178,6 @@
   color: var(--color-dark-font);
   white-space: normal;
   overflow-wrap: anywhere;
-  word-break: break-word;
 }
 
 .walter-table tr {


### PR DESCRIPTION
close #126 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved table cell wrapping and overflow handling so long or unbroken text will wrap and break appropriately, preventing layout issues and enhancing readability across table views. This improves content legibility on narrow screens and when displaying long strings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->