### PR TITLE
Disable database health checks

### DIFF
--- a/web/server/Program.cs
+++ b/web/server/Program.cs
@@ -78,7 +78,8 @@ builder.Services.AddScoped<IUserProfileOrchestrator, UserProfileOrchestrator>();
 builder.Services.AddDbContextPool<AppDbContext>(o => o.UseSqlServer(conn, opt => opt.MigrationsAssembly("server.core")));
 
 builder.Services
-    .AddHealthChecks();
+    .AddHealthChecks()
+    .AddDbContextCheck<AppDbContext>();
 
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();


### PR DESCRIPTION
Because it's Redshift on demand, off hour Healthchecks against the AE data warehouse were costing thousands of dollars. This PR disables those healthchecks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Simplified the health endpoint by removing the custom connectivity check; health reporting now relies solely on the database context validation, reducing monitored checks while keeping the endpoint operational.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->