### PR TITLE
fix: limit homepage search placeholder for non-financial users

### DIFF
--- a/web/client/src/routes/(authenticated)/index.tsx
+++ b/web/client/src/routes/(authenticated)/index.tsx
@@ -17,6 +17,12 @@ import { getErrorPresentation } from '@/lib/errorPresentation.ts';
 
 type Tab = 'pis' | 'projects' | 'reports';
 
+const FINANCIAL_SEARCH_ROLES = new Set([
+  'admin',
+  'financialviewer',
+  'projectmanager',
+]);
+
 export const Route = createFileRoute('/(authenticated)/')({
   component: RouteComponent,
 });
@@ -41,6 +47,14 @@ function RouteComponent() {
 
   const showPiTab = isProjectManager;
   const showProjectsTab = isPrincipalInvestigator;
+
+  const canViewFinancials = user.roles.some((role) =>
+    FINANCIAL_SEARCH_ROLES.has(role.toLowerCase())
+  );
+
+  const searchPlaceholder = canViewFinancials
+    ? 'Search PIs, Projects, Personnel...'
+    : 'Search projects and reports...';
 
   const tabs = useMemo(() => {
     const base: Array<{ id: Tab; label: string }> = [];
@@ -106,10 +120,7 @@ function RouteComponent() {
       </div>
 
       <div className="home-search relative mx-auto w-full sm:max-w-[90%] md:max-w-[80%] xl:max-w-[66%]">
-        <SearchButton
-          className="w-full"
-          placeholder="Search PIs, Projects, Personnel..."
-        />
+        <SearchButton className="w-full" placeholder={searchPlaceholder} />
       </div>
 
       {isProjectManager && <PiProjectAlerts managedPis={managedPis} />}

--- a/web/client/src/test/routes/(authenticated)/index.test.tsx
+++ b/web/client/src/test/routes/(authenticated)/index.test.tsx
@@ -78,6 +78,66 @@ describe('home route', () => {
     }
   });
 
+  it('shows broad search placeholder for users with financial access', async () => {
+    const user = {
+      email: 'alpha@example.com',
+      employeeId: '1000',
+      id: 'user-1',
+      kerberos: 'alpha',
+      name: 'Alpha User',
+      roles: ['FinancialViewer'],
+    };
+
+    server.use(
+      http.get('/api/user/me', () => HttpResponse.json(user)),
+      http.get('/api/project/managed/:employeeId', () => HttpResponse.json([])),
+      http.get('/api/project/:employeeId', () => HttpResponse.json([])),
+      http.get('/api/project/personnel', () => HttpResponse.json([]))
+    );
+
+    const { cleanup } = renderRoute({ initialPath: '/' });
+
+    try {
+      expect(
+        await screen.findByRole('button', {
+          name: /Search PIs, Projects, Personnel/i,
+        })
+      ).toBeInTheDocument();
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('shows limited search placeholder for users without financial access', async () => {
+    const user = {
+      email: 'alpha@example.com',
+      employeeId: '1000',
+      id: 'user-1',
+      kerberos: 'alpha',
+      name: 'Alpha User',
+      roles: [],
+    };
+
+    server.use(
+      http.get('/api/user/me', () => HttpResponse.json(user)),
+      http.get('/api/project/managed/:employeeId', () => HttpResponse.json([])),
+      http.get('/api/project/:employeeId', () => HttpResponse.json([])),
+      http.get('/api/project/personnel', () => HttpResponse.json([]))
+    );
+
+    const { cleanup } = renderRoute({ initialPath: '/' });
+
+    try {
+      expect(
+        await screen.findByRole('button', {
+          name: /Search projects and reports/i,
+        })
+      ).toBeInTheDocument();
+    } finally {
+      cleanup();
+    }
+  });
+
   it('shows projects table when user is not a PM', async () => {
     const user = {
       email: 'alpha@example.com',


### PR DESCRIPTION
## Summary
Update the home-page search placeholder so it only mentions PI/personnel search for users who can view financial-wide search results.

## Behavior change
- Users with financial search access (`Admin`, `FinancialViewer`, `ProjectManager`) see:
  - `Search PIs, Projects, Personnel...`
- Everyone else (including PI/non-financial users) sees:
  - `Search projects and reports...`

## Implementation
- Added role-based `canViewFinancials` check in `web/client/src/routes/(authenticated)/index.tsx`
- Made `SearchButton` placeholder dynamic based on that check

## Tests
Added coverage in `web/client/src/test/routes/(authenticated)/index.test.tsx`:
- financial-access user gets the broad placeholder
- non-financial user gets the limited placeholder

Validated with:
- `cd web/client && npm test -- --run src/test/routes/(authenticated)/index.test.tsx`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Dynamic search guidance based on user role: The search placeholder now personalizes based on permissions. Users with financial access see "Search PIs, Projects, Personnel..." enabling comprehensive discovery of financial data and resources, while standard users see "Search projects and reports..." for routine searches. This tailored interface ensures users see relevant search options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->