### PR TITLE
Tweaks to Personnel table

### DIFF
--- a/web/client/src/components/project/PersonnelTable.tsx
+++ b/web/client/src/components/project/PersonnelTable.tsx
@@ -138,10 +138,10 @@ function DistributionSubtable({
               <span className="flex justify-end w-full">Funding End</span>
             </th>
             <th>
-              <span className="flex justify-end w-full">Monthly Rate</span>
+              <span className="flex justify-end w-full">Monthly Salary</span>
             </th>
             <th>
-              <span className="flex justify-end w-full">Monthly Fringe</span>
+              <span className="flex justify-end w-full">Monthly CBR</span>
             </th>
             <th>
               <span className="flex justify-end w-full">Monthly Total</span>
@@ -213,10 +213,10 @@ const personnelCsvColumns = [
   { header: 'FTE', key: 'fte' as const },
   { header: 'Project', key: 'projectDescription' as const },
   { header: 'Dist %', key: 'distributionPercent' as const },
-  { format: 'date' as const, header: 'Effective Date', key: 'fundingEffectiveDate' as const },
+  { format: 'date' as const, header: 'Eff. Date', key: 'fundingEffectiveDate' as const },
   { format: 'date' as const, header: 'End Date', key: 'fundingEndDate' as const },
-  { format: 'currency' as const, header: 'Monthly Rate', key: 'monthlyRate' as const },
-  { format: 'currency' as const, header: 'Monthly Fringe', key: 'monthlyFringe' as const },
+  { format: 'currency' as const, header: 'Monthly Salary (1.0 FTE)', key: 'monthlyRate' as const },
+  { format: 'currency' as const, header: 'Monthly CBR (1.0 FTE)', key: 'monthlyFringe' as const },
   { format: 'currency' as const, header: 'Monthly Total', key: 'monthlyTotal' as const },
 ];
 
@@ -257,15 +257,17 @@ export function PersonnelTable({
                 <ChevronDownIcon className="w-4 h-4" />
               )
             ) : null}
-            {safeText(row.original.name)} -{' '}
+            {row.original.name
+              ? `${row.original.name} (${row.original.employeeId}) - `
+              : ''}
             {safeText(row.original.positionDescription)}
           </div>
         ),
         footer: showTotals ? () => 'Totals' : undefined,
-        header: 'Position/Project',
+        header: 'Position',
         id: 'positionProject',
-        minSize: 260,
-        size: 320,
+        minSize: 300,
+        size: 380,
         sortingFn: (a, b) =>
           safeText(a.original.name).localeCompare(safeText(b.original.name)),
       }),
@@ -282,7 +284,7 @@ export function PersonnelTable({
           </span>
         ),
         header: () => (
-          <span className="flex justify-end w-full">Effective Date</span>
+          <span className="flex justify-end w-full">Eff. Date</span>
         ),
       }),
       columnHelper.accessor('jobEndDate', {
@@ -305,7 +307,7 @@ export function PersonnelTable({
           );
         },
         header: () => (
-          <span className="flex justify-end w-full">Expected End Date</span>
+          <span className="flex justify-end w-full">End Date</span>
         ),
       }),
       columnHelper.accessor('monthlyRate', {
@@ -329,7 +331,10 @@ export function PersonnelTable({
             )
           : undefined,
         header: () => (
-          <span className="flex justify-end w-full">Monthly Rate</span>
+          <span className="flex flex-col items-end w-full">
+            <span>Monthly Salary</span>
+            <span className="text-xs font-normal">(1.0 FTE)</span>
+          </span>
         ),
       }),
       columnHelper.accessor('monthlyFringe', {
@@ -353,7 +358,10 @@ export function PersonnelTable({
             )
           : undefined,
         header: () => (
-          <span className="flex justify-end w-full">Monthly Fringe</span>
+          <span className="flex flex-col items-end w-full">
+            <span>Monthly CBR</span>
+            <span className="text-xs font-normal">(1.0 FTE)</span>
+          </span>
         ),
       }),
       columnHelper.accessor('monthlyTotal', {

--- a/web/client/src/test/components/PersonnelTable.test.tsx
+++ b/web/client/src/test/components/PersonnelTable.test.tsx
@@ -86,7 +86,7 @@ describe('PersonnelTable', () => {
 
     render(<PersonnelTable data={records} />);
 
-    expect(screen.getByText('Smith, John - PROF-FY')).toBeInTheDocument();
+    expect(screen.getByText('Smith, John (1001) - PROF-FY')).toBeInTheDocument();
   });
 
   it('displays FTE column', () => {
@@ -153,7 +153,7 @@ describe('PersonnelTable', () => {
     expect(screen.queryByText('Project')).not.toBeInTheDocument();
 
     await user.click(
-      screen.getByRole('cell', { name: 'Smith, John - PROF-FY' })
+      screen.getByRole('cell', { name: 'Smith, John (1001) - PROF-FY' })
     );
 
     expect(screen.getByText('Project')).toBeInTheDocument();
@@ -173,7 +173,7 @@ describe('PersonnelTable', () => {
 
     render(<PersonnelTable data={records} />);
 
-    expect(screen.getByText('Smith, John - PROF-FY')).toBeInTheDocument();
+    expect(screen.getByText('Smith, John (1001) - PROF-FY')).toBeInTheDocument();
     expect(screen.queryByText(/STDT 3/)).not.toBeInTheDocument();
   });
 
@@ -233,7 +233,7 @@ describe('PersonnelTable', () => {
 
     render(<PersonnelTable data={filtered} />);
 
-    expect(screen.getByText('Adams, Alice - PROF-FY')).toBeInTheDocument();
-    expect(screen.queryByText('Baker, Bob - PROF-FY')).not.toBeInTheDocument();
+    expect(screen.getByText('Adams, Alice (1001) - PROF-FY')).toBeInTheDocument();
+    expect(screen.queryByText('Baker, Bob (1002) - PROF-FY')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
- Show employee ID in parentheses after name, omit for unfilled positions
- Rename column headers: Position, Eff. Date, End Date, Monthly Salary (1.0 FTE), Monthly CBR (1.0 FTE)
- Update subtable and CSV export headers to match
- Widen position column

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated Personnel Table column headers for improved clarity: Monthly Salary (formerly Monthly Rate), Monthly CBR (formerly Monthly Fringe), Eff. Date (formerly Effective Date)
  * Personnel entries now display employee ID alongside name in the table
  * CSV export headers updated to align with new terminology

<!-- end of auto-generated comment: release notes by coderabbit.ai -->