### PR TITLE
Use WalterTest variable group for test deployments

### DIFF
--- a/web/azure-pipelines.yml
+++ b/web/azure-pipelines.yml
@@ -74,7 +74,7 @@ stages:
     dependsOn: BuildAndTest
     condition: and(succeeded(),eq(variables['Build.SourceBranch'], 'refs/heads/main'))
     variables:
-      - group: "WalterDev"
+      - group: "WalterTest"
     jobs:
       - deployment: Deploy_Test
         displayName: Deploy package to Azure test site


### PR DESCRIPTION
The big change is that walter-test will use the datamart on CAES-ROBERTO.WalterTest instead of CAES-ROBERTO-WalterDev.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD variable group assignment for test environment deployment stage to reflect new access configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->