### PR TITLE
Track actual user during emulation in audit logs

### DIFF
--- a/datamart/StoredProcedures/usp_GetFacultyDeptPortfolio.sql
+++ b/datamart/StoredProcedures/usp_GetFacultyDeptPortfolio.sql
@@ -3,7 +3,8 @@ CREATE PROCEDURE dbo.usp_GetFacultyDeptPortfolio
     @StartDate DATE = NULL,
     @EndDate DATE = NULL,
     @ApplicationName NVARCHAR(128) = NULL,
-    @ApplicationUser NVARCHAR(256) = NULL
+    @ApplicationUser NVARCHAR(256) = NULL,
+    @EmulatingUser NVARCHAR(256) = NULL
 AS
 BEGIN
     SET NOCOUNT ON;
@@ -119,6 +120,7 @@ BEGIN
             @Parameters = @ParametersJSON,
             @ApplicationName = @ApplicationName,
             @ApplicationUser = @ApplicationUser,
+            @EmulatingUser = @EmulatingUser,
             @Success = 1;
     END TRY
     BEGIN CATCH
@@ -132,6 +134,7 @@ BEGIN
             @Parameters = @ParametersJSON,
             @ApplicationName = @ApplicationName,
             @ApplicationUser = @ApplicationUser,
+            @EmulatingUser = @EmulatingUser,
             @Success = 0,
             @ErrorMessage = @ErrorMsg;
 

--- a/datamart/StoredProcedures/usp_GetFacultyDeptPortfolioElzar.sql
+++ b/datamart/StoredProcedures/usp_GetFacultyDeptPortfolioElzar.sql
@@ -5,7 +5,8 @@ CREATE PROCEDURE dbo.usp_GetFacultyDeptPortfolioElzar
     @StartDate DATE = NULL,
     @EndDate DATE = NULL,
     @ApplicationName NVARCHAR(128) = NULL,
-    @ApplicationUser NVARCHAR(256) = NULL
+    @ApplicationUser NVARCHAR(256) = NULL,
+    @EmulatingUser NVARCHAR(256) = NULL
 AS
 BEGIN
     SET NOCOUNT ON;
@@ -132,6 +133,7 @@ BEGIN
             @Parameters = @ParametersJSON,
             @ApplicationName = @ApplicationName,
             @ApplicationUser = @ApplicationUser,
+            @EmulatingUser = @EmulatingUser,
             @Success = 1;
     END TRY
     BEGIN CATCH
@@ -145,6 +147,7 @@ BEGIN
             @Parameters = @ParametersJSON,
             @ApplicationName = @ApplicationName,
             @ApplicationUser = @ApplicationUser,
+            @EmulatingUser = @EmulatingUser,
             @Success = 0,
             @ErrorMessage = @ErrorMsg;
 

--- a/datamart/StoredProcedures/usp_GetGLPPMReconciliation.sql
+++ b/datamart/StoredProcedures/usp_GetGLPPMReconciliation.sql
@@ -1,7 +1,8 @@
 CREATE PROCEDURE dbo.usp_GetGLPPMReconciliation
     @ProjectIds VARCHAR(MAX),
     @ApplicationName NVARCHAR(128) = NULL,
-    @ApplicationUser NVARCHAR(256) = NULL
+    @ApplicationUser NVARCHAR(256) = NULL,
+    @EmulatingUser NVARCHAR(256) = NULL
 AS
 BEGIN
     SET NOCOUNT ON;
@@ -134,6 +135,7 @@ BEGIN
             @Parameters = @ParametersJSON,
             @ApplicationName = @ApplicationName,
             @ApplicationUser = @ApplicationUser,
+            @EmulatingUser = @EmulatingUser,
             @Success = 1;
     END TRY
     BEGIN CATCH
@@ -147,6 +149,7 @@ BEGIN
             @Parameters = @ParametersJSON,
             @ApplicationName = @ApplicationName,
             @ApplicationUser = @ApplicationUser,
+            @EmulatingUser = @EmulatingUser,
             @Success = 0,
             @ErrorMessage = @ErrorMsg;
 

--- a/datamart/StoredProcedures/usp_GetGLTransactionListings.sql
+++ b/datamart/StoredProcedures/usp_GetGLTransactionListings.sql
@@ -4,7 +4,8 @@ CREATE PROCEDURE dbo.usp_GetGLTransactionListings
     @StartDate DATE = NULL,
     @EndDate DATE = NULL,
     @ApplicationName NVARCHAR(128) = NULL,
-    @ApplicationUser NVARCHAR(256) = NULL
+    @ApplicationUser NVARCHAR(256) = NULL,
+    @EmulatingUser NVARCHAR(256) = NULL
 AS
 BEGIN
     SET NOCOUNT ON;
@@ -118,6 +119,7 @@ BEGIN
             @Parameters = @ParametersJSON,
             @ApplicationName = @ApplicationName,
             @ApplicationUser = @ApplicationUser,
+            @EmulatingUser = @EmulatingUser,
             @Success = 1;
     END TRY
     BEGIN CATCH
@@ -131,6 +133,7 @@ BEGIN
             @Parameters = @ParametersJSON,
             @ApplicationName = @ApplicationName,
             @ApplicationUser = @ApplicationUser,
+            @EmulatingUser = @EmulatingUser,
             @Success = 0,
             @ErrorMessage = @ErrorMsg;
 

--- a/datamart/StoredProcedures/usp_GetLaborLedgerData.sql
+++ b/datamart/StoredProcedures/usp_GetLaborLedgerData.sql
@@ -3,7 +3,8 @@ CREATE PROCEDURE dbo.usp_GetLaborLedgerData
     @StartDate DATE = NULL,
     @EndDate DATE = NULL,
     @ApplicationName NVARCHAR(128) = NULL,
-    @ApplicationUser NVARCHAR(256) = NULL
+    @ApplicationUser NVARCHAR(256) = NULL,
+    @EmulatingUser NVARCHAR(256) = NULL
 AS
 BEGIN
     SET NOCOUNT ON;
@@ -135,6 +136,7 @@ BEGIN
             @Parameters = @ParametersJSON,
             @ApplicationName = @ApplicationName,
             @ApplicationUser = @ApplicationUser,
+            @EmulatingUser = @EmulatingUser,
             @Success = 1;
     END TRY
     BEGIN CATCH
@@ -148,6 +150,7 @@ BEGIN
             @Parameters = @ParametersJSON,
             @ApplicationName = @ApplicationName,
             @ApplicationUser = @ApplicationUser,
+            @EmulatingUser = @EmulatingUser,
             @Success = 0,
             @ErrorMessage = @ErrorMsg;
 

--- a/datamart/StoredProcedures/usp_GetPositionBudgets.sql
+++ b/datamart/StoredProcedures/usp_GetPositionBudgets.sql
@@ -2,7 +2,8 @@ CREATE PROCEDURE dbo.usp_GetPositionBudgets
     @ProjectIds VARCHAR(MAX),
     @FiscalYear VARCHAR(4) = NULL,
     @ApplicationName NVARCHAR(128) = NULL,
-    @ApplicationUser NVARCHAR(256) = NULL
+    @ApplicationUser NVARCHAR(256) = NULL,
+    @EmulatingUser NVARCHAR(256) = NULL
 AS
 BEGIN
     SET NOCOUNT ON;
@@ -303,6 +304,7 @@ BEGIN
             @Parameters = @ParametersJSON,
             @ApplicationName = @ApplicationName,
             @ApplicationUser = @ApplicationUser,
+            @EmulatingUser = @EmulatingUser,
             @Success = 1;
     END TRY
     BEGIN CATCH
@@ -322,6 +324,7 @@ BEGIN
             @Parameters = @ParametersJSON,
             @ApplicationName = @ApplicationName,
             @ApplicationUser = @ApplicationUser,
+            @EmulatingUser = @EmulatingUser,
             @Success = 0,
             @ErrorMessage = @ErrorMsg;
 

--- a/datamart/StoredProcedures/usp_GetProjectSummary.sql
+++ b/datamart/StoredProcedures/usp_GetProjectSummary.sql
@@ -1,7 +1,8 @@
 CREATE PROCEDURE dbo.usp_GetProjectSummary
     @ProjectIds VARCHAR(MAX),
     @ApplicationName NVARCHAR(128) = NULL,
-    @ApplicationUser NVARCHAR(256) = NULL
+    @ApplicationUser NVARCHAR(256) = NULL,
+    @EmulatingUser NVARCHAR(256) = NULL
 AS
 BEGIN
     SET NOCOUNT ON;
@@ -218,6 +219,7 @@ BEGIN
             @Parameters = @ParametersJSON,
             @ApplicationName = @ApplicationName,
             @ApplicationUser = @ApplicationUser,
+            @EmulatingUser = @EmulatingUser,
             @Success = 1;
     END TRY
     BEGIN CATCH
@@ -231,6 +233,7 @@ BEGIN
             @Parameters = @ParametersJSON,
             @ApplicationName = @ApplicationName,
             @ApplicationUser = @ApplicationUser,
+            @EmulatingUser = @EmulatingUser,
             @Success = 0,
             @ErrorMessage = @ErrorMsg;
 

--- a/datamart/StoredProcedures/usp_GetProjectSummaryElzar.sql
+++ b/datamart/StoredProcedures/usp_GetProjectSummaryElzar.sql
@@ -3,7 +3,8 @@
 CREATE PROCEDURE dbo.usp_GetProjectSummaryElzar
     @ProjectIds VARCHAR(MAX),
     @ApplicationName NVARCHAR(128) = NULL,
-    @ApplicationUser NVARCHAR(256) = NULL
+    @ApplicationUser NVARCHAR(256) = NULL,
+    @EmulatingUser NVARCHAR(256) = NULL
 AS
 BEGIN
     SET NOCOUNT ON;
@@ -287,6 +288,7 @@ BEGIN
             @Parameters = @ParametersJSON,
             @ApplicationName = @ApplicationName,
             @ApplicationUser = @ApplicationUser,
+            @EmulatingUser = @EmulatingUser,
             @Success = 1;
     END TRY
     BEGIN CATCH
@@ -300,6 +302,7 @@ BEGIN
             @Parameters = @ParametersJSON,
             @ApplicationName = @ApplicationName,
             @ApplicationUser = @ApplicationUser,
+            @EmulatingUser = @EmulatingUser,
             @Success = 0,
             @ErrorMessage = @ErrorMsg;
 

--- a/datamart/StoredProcedures/usp_LogProcedureExecution.sql
+++ b/datamart/StoredProcedures/usp_LogProcedureExecution.sql
@@ -6,6 +6,7 @@ CREATE PROCEDURE [dbo].[usp_LogProcedureExecution]
     @Parameters NVARCHAR(MAX) = NULL,
     @ApplicationName NVARCHAR(128) = NULL,
     @ApplicationUser NVARCHAR(256) = NULL,
+    @EmulatingUser NVARCHAR(256) = NULL,
     @Success BIT = 1,
     @ErrorMessage NVARCHAR(MAX) = NULL
 AS
@@ -30,6 +31,7 @@ BEGIN
         [Parameters],
         [ApplicationName],
         [ApplicationUser],
+        [EmulatingUser],
         [HostName],
         [DatabaseName],
         [SessionID],
@@ -46,6 +48,7 @@ BEGIN
         @Parameters,
         @ApplicationName,
         @ApplicationUser,
+        @EmulatingUser,
         HOST_NAME(),
         DB_NAME(),
         @@SPID,

--- a/datamart/Tables/AuditLog.sql
+++ b/datamart/Tables/AuditLog.sql
@@ -9,6 +9,7 @@ CREATE TABLE [dbo].[AuditLog]
     [Parameters] NVARCHAR(MAX) NULL,
     [ApplicationName] NVARCHAR(128) NULL,
     [ApplicationUser] NVARCHAR(256) NULL,
+    [EmulatingUser] NVARCHAR(256) NULL,
     [HostName] NVARCHAR(128) NULL,
     [DatabaseName] NVARCHAR(128) NULL,
     [SessionID] INT NULL,

--- a/web/server/Controllers/ProjectController.cs
+++ b/web/server/Controllers/ProjectController.cs
@@ -96,7 +96,8 @@ public sealed class ProjectController : ApiControllerBase
                     .FirstOrDefault(m => m.RoleName == PpmRole.ProjectManager)?.EmployeeId);
 
         var applicationUser = User.GetUserIdentifier();
-        var projects = await _datamartService.GetFacultyPortfolioAsync(projectNumbers, applicationUser, cancellationToken);
+        var emulatingUser = User.GetEmulatingUser();
+        var projects = await _datamartService.GetFacultyPortfolioAsync(projectNumbers, applicationUser, emulatingUser, cancellationToken);
 
         var activeProjects = projects
             .Where(p => p.ProjectStatus == "ACTIVE")
@@ -125,7 +126,8 @@ public sealed class ProjectController : ApiControllerBase
 
         var codes = projectCodes.Split(',', StringSplitOptions.RemoveEmptyEntries);
         var applicationUser = User.GetUserIdentifier();
-        var projects = await _datamartService.GetFacultyPortfolioAsync(codes, applicationUser, cancellationToken);
+        var emulatingUser = User.GetEmulatingUser();
+        var projects = await _datamartService.GetFacultyPortfolioAsync(codes, applicationUser, emulatingUser, cancellationToken);
 
         return Ok(projects.Where(p => p.ProjectStatus == "ACTIVE").ToList());
     }
@@ -184,7 +186,8 @@ public sealed class ProjectController : ApiControllerBase
         }
 
         var applicationUser = User.GetUserIdentifier();
-        var personnel = await _datamartService.GetPositionBudgetsAsync(codes, applicationUser, cancellationToken);
+        var emulatingUser = User.GetEmulatingUser();
+        var personnel = await _datamartService.GetPositionBudgetsAsync(codes, applicationUser, emulatingUser, cancellationToken);
 
         return Ok(personnel);
     }
@@ -200,7 +203,8 @@ public sealed class ProjectController : ApiControllerBase
 
         var codes = projectCodes.Split(',', StringSplitOptions.RemoveEmptyEntries);
         var applicationUser = User.GetUserIdentifier();
-        var transactions = await _datamartService.GetGLTransactionListingsAsync(codes, applicationUser, cancellationToken);
+        var emulatingUser = User.GetEmulatingUser();
+        var transactions = await _datamartService.GetGLTransactionListingsAsync(codes, applicationUser, emulatingUser, cancellationToken);
 
         return Ok(transactions);
     }
@@ -216,7 +220,8 @@ public sealed class ProjectController : ApiControllerBase
 
         var codes = projectCodes.Split(',', StringSplitOptions.RemoveEmptyEntries);
         var applicationUser = User.GetUserIdentifier();
-        var reconciliation = await _datamartService.GetGLPPMReconciliationAsync(codes, applicationUser, cancellationToken);
+        var emulatingUser = User.GetEmulatingUser();
+        var reconciliation = await _datamartService.GetGLPPMReconciliationAsync(codes, applicationUser, emulatingUser, cancellationToken);
 
         return Ok(reconciliation);
     }

--- a/web/server/Controllers/SystemController.cs
+++ b/web/server/Controllers/SystemController.cs
@@ -28,6 +28,15 @@ public class SystemController : ApiControllerBase
             return BadRequest("Identifier is required.");
         }
 
+        // Block chained emulation — end current emulation first
+        if (User.FindFirst("emulating_user") != null)
+        {
+            return BadRequest("Already emulating a user. End the current emulation before starting a new one.");
+        }
+
+        // Preserve the actual user's identity for audit logging
+        var actualUserIdentifier = User.GetUserIdentifier();
+
         User? user;
 
         if (Guid.TryParse(identifier, out var userId))
@@ -54,6 +63,11 @@ public class SystemController : ApiControllerBase
             new(ClaimTypes.Email, user.Email ?? string.Empty),
             new("kerberos", user.Kerberos),
         };
+
+        if (!string.IsNullOrEmpty(actualUserIdentifier))
+        {
+            claims.Add(new Claim("emulating_user", actualUserIdentifier));
+        }
 
         foreach (var role in roles)
         {

--- a/web/server/Helpers/ClaimsPrincipalExtensions.cs
+++ b/web/server/Helpers/ClaimsPrincipalExtensions.cs
@@ -41,4 +41,13 @@ public static class ClaimsPrincipalExtensions
             ?? principal.FindFirstValue(ClaimTypes.Email)
             ?? principal.FindFirstValue("preferred_username"); // email w/ our entra setup
     }
+
+    /// <summary>
+    /// Returns the emulating user's identifier if the current session is an emulation, otherwise null.
+    /// </summary>
+    public static string? GetEmulatingUser(this ClaimsPrincipal principal)
+    {
+        ArgumentNullException.ThrowIfNull(principal);
+        return principal.FindFirstValue("emulating_user");
+    }
 }

--- a/web/server/Helpers/LoggingMiddlewareHelper.cs
+++ b/web/server/Helpers/LoggingMiddlewareHelper.cs
@@ -37,6 +37,9 @@ public static class LoggingMiddlewareHelper
                 userIdentifier = ctx.User.GetUserIdentifier();
             }
 
+            // Track actual user when emulating
+            var emulatingUser = ctx.User.FindFirst("emulating_user")?.Value;
+
             // client IP (respects ForwardedHeaders above)
             var clientIp = ctx.Connection.RemoteIpAddress?.ToString();
 
@@ -48,6 +51,7 @@ public static class LoggingMiddlewareHelper
             {
                 ["user.id"] = userId,
                 ["user.identifier"] = userIdentifier,
+                ["user.emulating"] = emulatingUser,
                 ["request.id"] = requestId,
                 ["trace.id"] = traceId,
                 ["span.id"] = spanId,

--- a/web/server/Services/DatamartService.cs
+++ b/web/server/Services/DatamartService.cs
@@ -10,16 +10,16 @@ namespace server.Services;
 public interface IDatamartService
 {
     Task<IReadOnlyList<FacultyPortfolioRecord>> GetFacultyPortfolioAsync(
-        IEnumerable<string> projectNumbers, string? applicationUser = null, CancellationToken ct = default);
+        IEnumerable<string> projectNumbers, string? applicationUser = null, string? emulatingUser = null, CancellationToken ct = default);
 
     Task<IReadOnlyList<PositionBudgetRecord>> GetPositionBudgetsAsync(
-        IEnumerable<string> projectNumbers, string? applicationUser = null, CancellationToken ct = default);
+        IEnumerable<string> projectNumbers, string? applicationUser = null, string? emulatingUser = null, CancellationToken ct = default);
 
     Task<IReadOnlyList<GLPPMReconciliationRecord>> GetGLPPMReconciliationAsync(
-        IEnumerable<string> projectNumbers, string? applicationUser = null, CancellationToken ct = default);
+        IEnumerable<string> projectNumbers, string? applicationUser = null, string? emulatingUser = null, CancellationToken ct = default);
 
     Task<IReadOnlyList<GLTransactionRecord>> GetGLTransactionListingsAsync(
-        IEnumerable<string> projectNumbers, string? applicationUser = null, CancellationToken ct = default);
+        IEnumerable<string> projectNumbers, string? applicationUser = null, string? emulatingUser = null, CancellationToken ct = default);
 }
 
 public sealed class DatamartService : IDatamartService
@@ -46,42 +46,42 @@ public sealed class DatamartService : IDatamartService
     }
 
     public async Task<IReadOnlyList<FacultyPortfolioRecord>> GetFacultyPortfolioAsync(
-        IEnumerable<string> projectNumbers, string? applicationUser = null, CancellationToken ct = default)
+        IEnumerable<string> projectNumbers, string? applicationUser = null, string? emulatingUser = null, CancellationToken ct = default)
     {
         var projectNumbersParam = string.Join(",", projectNumbers);
         return await ExecuteSprocAsync<FacultyPortfolioRecord>(
             "dbo.usp_GetProjectSummaryElzar",
-            new { ProjectIds = projectNumbersParam, ApplicationName = _appName, ApplicationUser = applicationUser },
+            new { ProjectIds = projectNumbersParam, ApplicationName = _appName, ApplicationUser = applicationUser, EmulatingUser = emulatingUser },
             ct: ct);
     }
 
     public async Task<IReadOnlyList<PositionBudgetRecord>> GetPositionBudgetsAsync(
-        IEnumerable<string> projectNumbers, string? applicationUser = null, CancellationToken ct = default)
+        IEnumerable<string> projectNumbers, string? applicationUser = null, string? emulatingUser = null, CancellationToken ct = default)
     {
         var projectNumbersParam = string.Join(",", projectNumbers);
         return await ExecuteSprocAsync<PositionBudgetRecord>(
             "dbo.usp_GetPositionBudgets",
-            new { ProjectIds = projectNumbersParam, ApplicationName = _appName, ApplicationUser = applicationUser },
+            new { ProjectIds = projectNumbersParam, ApplicationName = _appName, ApplicationUser = applicationUser, EmulatingUser = emulatingUser },
             ct: ct);
     }
 
     public async Task<IReadOnlyList<GLPPMReconciliationRecord>> GetGLPPMReconciliationAsync(
-        IEnumerable<string> projectNumbers, string? applicationUser = null, CancellationToken ct = default)
+        IEnumerable<string> projectNumbers, string? applicationUser = null, string? emulatingUser = null, CancellationToken ct = default)
     {
         var projectNumbersParam = string.Join(",", projectNumbers);
         return await ExecuteSprocAsync<GLPPMReconciliationRecord>(
             "dbo.usp_GetGLPPMReconciliation",
-            new { ProjectIds = projectNumbersParam, ApplicationName = _appName, ApplicationUser = applicationUser },
+            new { ProjectIds = projectNumbersParam, ApplicationName = _appName, ApplicationUser = applicationUser, EmulatingUser = emulatingUser },
             ct: ct);
     }
 
     public async Task<IReadOnlyList<GLTransactionRecord>> GetGLTransactionListingsAsync(
-        IEnumerable<string> projectNumbers, string? applicationUser = null, CancellationToken ct = default)
+        IEnumerable<string> projectNumbers, string? applicationUser = null, string? emulatingUser = null, CancellationToken ct = default)
     {
         var projectNumbersParam = string.Join(",", projectNumbers);
         return await ExecuteSprocAsync<GLTransactionRecord>(
             "dbo.usp_GetGLTransactionListings",
-            new { ProjectIds = projectNumbersParam, ApplicationName = _appName, ApplicationUser = applicationUser },
+            new { ProjectIds = projectNumbersParam, ApplicationName = _appName, ApplicationUser = applicationUser, EmulatingUser = emulatingUser },
             ct: ct);
     }
 


### PR DESCRIPTION
When a System user emulates another user, the actual user's identity is now preserved in an "emulating_user" claim and logged throughout:
- AuditLog table: new EmulatingUser column
- All sprocs pass EmulatingUser through to usp_LogProcedureExecution
- Request logging middleware includes user.emulating in scope
- Chained emulation is blocked (must end current first)