### PR TITLE
Redesign Award Information section, add Award Name field

### DIFF
--- a/datamart/StoredProcedures/usp_GetPPMProjectSummaryElzar.sql
+++ b/datamart/StoredProcedures/usp_GetPPMProjectSummaryElzar.sql
@@ -73,6 +73,7 @@ BEGIN
         -- PPM financials at task+chart string level from Elzar, joined with pgm metadata
         SET @TSQLCommand = @TSQLCommand +
             N'SELECT CAST(f.Award_Number AS NVARCHAR(MAX)) AS AWARD_NUMBER,
+                CAST(f.Award_Name AS NVARCHAR(MAX)) AS AWARD_NAME,
                 f.Award_Start_Date AS AWARD_START_DATE, f.Award_End_Date AS AWARD_END_DATE,
                 CAST(f.Award_Status AS NVARCHAR(MAX)) AS AWARD_STATUS,
                 CAST(f.Award_Entity AS NVARCHAR(MAX)) AS AWARD_TYPE,
@@ -138,7 +139,8 @@ BEGIN
                 ON f.Project_Number = p.project_number AND f.Award_Number = p.award_number
             WHERE f.Project_Number IN (' + @ProjectIdFilter + N')
               AND f.Task_Status <> ''Inactive''
-            GROUP BY CAST(f.Award_Number AS NVARCHAR(MAX)), f.Award_Start_Date, f.Award_End_Date,
+            GROUP BY CAST(f.Award_Number AS NVARCHAR(MAX)), CAST(f.Award_Name AS NVARCHAR(MAX)),
+                f.Award_Start_Date, f.Award_End_Date,
                 CAST(f.Award_Status AS NVARCHAR(MAX)), CAST(f.Award_Entity AS NVARCHAR(MAX)),
                 CAST(f.Project_Number AS NVARCHAR(MAX)), CAST(f.Project_Name AS NVARCHAR(MAX)),
                 CAST(f.Project_Owning_Organization AS NVARCHAR(MAX)),

--- a/web/client/src/components/project/ProjectAdditionalInfo.tsx
+++ b/web/client/src/components/project/ProjectAdditionalInfo.tsx
@@ -7,16 +7,20 @@ interface Field {
   value: string;
 }
 
-function buildFields(summary: ProjectSummary): Field[] {
+function buildPrimaryFields(summary: ProjectSummary): Field[] {
   return [
-    { label: 'Award Close Date', value: formatDate(summary.awardCloseDate) },
-    { label: 'Award End Date', value: formatDate(summary.awardEndDate) },
     { label: 'Award Number', value: summary.awardNumber ?? '—' },
-    { label: 'Award PI', value: summary.awardPi ?? '—' },
+    { label: 'Award Name', value: summary.awardName ?? '—' },
     { label: 'Award Start Date', value: formatDate(summary.awardStartDate) },
-    { label: 'Award Status', value: summary.awardStatus ?? '—' },
-    { label: 'Award Type', value: summary.awardType ?? '—' },
-    { label: 'Billing Cycle', value: summary.billingCycle ?? '—' },
+    { label: 'Award End Date', value: formatDate(summary.awardEndDate) },
+    {
+      label: 'Primary Sponsor Name',
+      value: summary.primarySponsorName ?? '—',
+    },
+    {
+      label: 'Sponsor Award Number',
+      value: summary.sponsorAwardNumber ?? '—',
+    },
     {
       label: 'Burden Schedule Rate',
       value: summary.projectBurdenCostRate
@@ -24,12 +28,22 @@ function buildFields(summary: ProjectSummary): Field[] {
         : '—',
     },
     {
-      label: 'Burden Structure',
-      value: summary.projectBurdenScheduleBase?.split('-')[0].trim() || '—',
-    },
-    {
       label: 'Contract Administrator',
       value: summary.contractAdministrator ?? '—',
+    },
+  ];
+}
+
+function buildSecondaryFields(summary: ProjectSummary): Field[] {
+  return [
+    { label: 'Award Close Date', value: formatDate(summary.awardCloseDate) },
+    { label: 'Award PI', value: summary.awardPi ?? '—' },
+    { label: 'Award Status', value: summary.awardStatus ?? '—' },
+    { label: 'Award Type', value: summary.awardType ?? '—' },
+    { label: 'Billing Cycle', value: summary.billingCycle ?? '—' },
+    {
+      label: 'Burden Structure',
+      value: summary.projectBurdenScheduleBase?.split('-')[0].trim() || '—',
     },
     {
       label: 'Cost Share Required by Sponsor',
@@ -44,44 +58,30 @@ function buildFields(summary: ProjectSummary): Field[] {
       label: 'Post Reporting Period',
       value: summary.postReportingPeriod ?? '—',
     },
-    {
-      label: 'Primary Sponsor Name',
-      value: summary.primarySponsorName ?? '—',
-    },
     { label: 'Project Fund', value: summary.projectFund ?? '—' },
-    {
-      label: 'Sponsor Award Number',
-      value: summary.sponsorAwardNumber ?? '—',
-    },
   ];
 }
 
-const COLLAPSE_AFTER_LABEL = 'Billing Cycle';
-
 interface ProjectAdditionalInfoProps {
+  isProjectManager: boolean;
   summary: ProjectSummary;
 }
 
 export function ProjectAdditionalInfo({
+  isProjectManager,
   summary,
 }: ProjectAdditionalInfoProps) {
   const [expanded, setExpanded] = React.useState(false);
 
-  const fields = buildFields(summary);
-
-  const splitIndex =
-    fields.findIndex((f) => f.label === COLLAPSE_AFTER_LABEL) + 1;
-
-  const visibleFields = splitIndex > 0 ? fields.slice(0, splitIndex) : fields;
-  const hiddenFields = splitIndex > 0 ? fields.slice(splitIndex) : [];
+  const primaryFields = buildPrimaryFields(summary);
+  const secondaryFields = buildSecondaryFields(summary);
 
   return (
     <section className="section-margin">
-      <h2 className="h2 mb-4">Additional Information</h2>
+      <h2 className="h2 mb-4">Award Information</h2>
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-x-4 gap-y-2">
-        {/* Always visible */}
-        {visibleFields.map((field) => (
+        {primaryFields.map((field) => (
           <div
             className="grid grid-cols-[max-content_1fr] gap-x-4"
             key={field.label}
@@ -91,9 +91,8 @@ export function ProjectAdditionalInfo({
           </div>
         ))}
 
-        {/* Conditionally visible */}
         {expanded &&
-          hiddenFields.map((field) => (
+          secondaryFields.map((field) => (
             <div
               className="grid grid-cols-[max-content_1fr] gap-x-4"
               key={field.label}
@@ -103,8 +102,7 @@ export function ProjectAdditionalInfo({
             </div>
           ))}
 
-        {/* ALWAYS last row */}
-        {hiddenFields.length > 0 && (
+        {isProjectManager && secondaryFields.length > 0 && (
           <div className="md:col-span-2 mt-2">
             <button
               className="btn"

--- a/web/client/src/lib/projectSummary.ts
+++ b/web/client/src/lib/projectSummary.ts
@@ -10,6 +10,7 @@ export interface ProjectTotals {
 export interface ProjectSummary {
   awardCloseDate: string | null;
   awardEndDate: string | null;
+  awardName: string | null;
   awardNumber: string | null;
   awardPi: string | null;
   awardStartDate: string | null;
@@ -99,6 +100,7 @@ export const summarizeAllProjects = (
   return {
     awardCloseDate: null,
     awardEndDate: findLatestDate(records, 'awardEndDate'),
+    awardName: null,
     awardNumber: null,
     awardPi: null,
     awardStartDate: findEarliestDate(records, 'awardStartDate'),
@@ -146,6 +148,7 @@ export const summarizeProjectByNumber = (
   return {
     awardCloseDate: first.awardCloseDate,
     awardEndDate: findLatestDate(filtered, 'awardEndDate'),
+    awardName: first.awardName,
     awardNumber: first.awardNumber,
     awardPi: first.awardPi,
     awardStartDate: findEarliestDate(filtered, 'awardStartDate'),

--- a/web/client/src/queries/project.ts
+++ b/web/client/src/queries/project.ts
@@ -7,6 +7,7 @@ export interface ProjectRecord {
   activityDesc: string;
   awardCloseDate: string | null;
   awardEndDate: string | null;
+  awardName: string | null;
   awardNumber: string | null;
   awardPi: string | null;
   awardStartDate: string | null;

--- a/web/client/src/routes/(authenticated)/projects/$employeeId/$projectNumber/index.tsx
+++ b/web/client/src/routes/(authenticated)/projects/$employeeId/$projectNumber/index.tsx
@@ -80,7 +80,7 @@ function ProjectContent({
       </section>
 
       <ProjectDetails summary={summary} />
-      {isProjectManager && <ProjectAdditionalInfo summary={summary} />}
+      <ProjectAdditionalInfo isProjectManager={isProjectManager} summary={summary} />
       <FinancialDetails summary={summary} />
 
       <section className="section-margin">

--- a/web/client/src/test/components/project/ProjectAdditionalInfo.test.tsx
+++ b/web/client/src/test/components/project/ProjectAdditionalInfo.test.tsx
@@ -11,13 +11,14 @@ const createSummary = (
 ): ProjectSummary => ({
   awardCloseDate: '2026-06-30',
   awardEndDate: '2026-12-31',
+  awardName: 'Test Award',
   awardNumber: 'AWD-100',
   awardPi: 'Smith, Jane',
   awardStartDate: '2024-01-01',
   awardStatus: 'Active',
   awardType: 'Federal Grant',
   billingCycle: 'Monthly',
-  contractAdministrator: null,
+  contractAdministrator: 'Admin, Carol',
   copi: null,
   costShareRequiredBySponsor: null,
   displayName: 'Test Project',
@@ -42,117 +43,97 @@ const createSummary = (
 
 describe('ProjectAdditionalInfo', () => {
   it('renders the section heading', () => {
-    render(<ProjectAdditionalInfo summary={createSummary()} />);
+    render(<ProjectAdditionalInfo isProjectManager={false} summary={createSummary()} />);
 
-    expect(screen.getByText('Additional Information')).toBeInTheDocument();
+    expect(screen.getByText('Award Information')).toBeInTheDocument();
   });
 
-  it('shows visible fields up through Billing Cycle', () => {
-    render(<ProjectAdditionalInfo summary={createSummary()} />);
+  it('shows primary award fields for all users', () => {
+    render(<ProjectAdditionalInfo isProjectManager={false} summary={createSummary()} />);
 
-    // These should be visible without expanding
-    expect(screen.getByText('Award Close Date')).toBeInTheDocument();
     expect(screen.getByText('Award Number')).toBeInTheDocument();
     expect(screen.getByText('AWD-100')).toBeInTheDocument();
-    expect(screen.getByText('Award PI')).toBeInTheDocument();
-    expect(screen.getByText('Smith, Jane')).toBeInTheDocument();
-    expect(screen.getByText('Award Status')).toBeInTheDocument();
-    expect(screen.getByText('Active')).toBeInTheDocument();
-    expect(screen.getByText('Award Type')).toBeInTheDocument();
-    expect(screen.getByText('Federal Grant')).toBeInTheDocument();
-    expect(screen.getByText('Billing Cycle')).toBeInTheDocument();
-    expect(screen.getByText('Monthly')).toBeInTheDocument();
-  });
-
-  it('hides fields after Billing Cycle until expanded', () => {
-    render(<ProjectAdditionalInfo summary={createSummary()} />);
-
-    // These should be hidden initially
-    expect(screen.queryByText('Primary Sponsor Name')).not.toBeInTheDocument();
-    expect(
-      screen.queryByText('National Science Foundation')
-    ).not.toBeInTheDocument();
-    expect(screen.queryByText('Sponsor Award Number')).not.toBeInTheDocument();
-    expect(screen.queryByText('Burden Schedule Rate')).not.toBeInTheDocument();
-  });
-
-  it('reveals hidden fields when Show more is clicked', async () => {
-    const user = userEvent.setup();
-    render(<ProjectAdditionalInfo summary={createSummary()} />);
-
-    await user.click(screen.getByRole('button', { name: 'Show more' }));
-
+    expect(screen.getByText('Award Name')).toBeInTheDocument();
+    expect(screen.getByText('Test Award')).toBeInTheDocument();
+    expect(screen.getByText('Award End Date')).toBeInTheDocument();
     expect(screen.getByText('Primary Sponsor Name')).toBeInTheDocument();
-    expect(
-      screen.getByText('National Science Foundation')
-    ).toBeInTheDocument();
+    expect(screen.getByText('National Science Foundation')).toBeInTheDocument();
     expect(screen.getByText('Sponsor Award Number')).toBeInTheDocument();
     expect(screen.getByText('NSF-2024-001')).toBeInTheDocument();
     expect(screen.getByText('Burden Schedule Rate')).toBeInTheDocument();
     expect(screen.getByText('26.5%')).toBeInTheDocument();
+    expect(screen.getByText('Contract Administrator')).toBeInTheDocument();
+    expect(screen.getByText('Admin, Carol')).toBeInTheDocument();
+  });
+
+  it('hides secondary fields and show more button for non-PMs', () => {
+    render(<ProjectAdditionalInfo isProjectManager={false} summary={createSummary()} />);
+
+    expect(screen.queryByText('Award Close Date')).not.toBeInTheDocument();
+    expect(screen.queryByText('Billing Cycle')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /show more/i })).not.toBeInTheDocument();
+  });
+
+  it('shows Show more button for PMs', () => {
+    render(<ProjectAdditionalInfo isProjectManager={true} summary={createSummary()} />);
+
+    expect(screen.getByRole('button', { name: 'Show more' })).toBeInTheDocument();
+  });
+
+  it('reveals hidden fields when PM clicks Show more', async () => {
+    const user = userEvent.setup();
+    render(<ProjectAdditionalInfo isProjectManager={true} summary={createSummary()} />);
+
+    await user.click(screen.getByRole('button', { name: 'Show more' }));
+
+    expect(screen.getByText('Award Close Date')).toBeInTheDocument();
+    expect(screen.getByText('Award PI')).toBeInTheDocument();
+    expect(screen.getByText('Smith, Jane')).toBeInTheDocument();
+    expect(screen.getByText('Billing Cycle')).toBeInTheDocument();
+    expect(screen.getByText('Monthly')).toBeInTheDocument();
     expect(screen.getByText('Burden Structure')).toBeInTheDocument();
     expect(screen.getByText('MTDC')).toBeInTheDocument();
-    // Verify "-Rev 001" suffix was stripped
-    expect(screen.queryByText('MTDC-Rev 001')).not.toBeInTheDocument();
   });
 
   it('collapses fields when Show less is clicked', async () => {
     const user = userEvent.setup();
-    render(<ProjectAdditionalInfo summary={createSummary()} />);
+    render(<ProjectAdditionalInfo isProjectManager={true} summary={createSummary()} />);
 
     await user.click(screen.getByRole('button', { name: 'Show more' }));
-    expect(screen.getByText('Sponsor Award Number')).toBeInTheDocument();
+    expect(screen.getByText('Billing Cycle')).toBeInTheDocument();
 
     await user.click(screen.getByRole('button', { name: 'Show less' }));
-    expect(screen.queryByText('Sponsor Award Number')).not.toBeInTheDocument();
+    expect(screen.queryByText('Billing Cycle')).not.toBeInTheDocument();
   });
 
   it('displays em-dash for null values', () => {
     render(
       <ProjectAdditionalInfo
+        isProjectManager={false}
         summary={createSummary({
+          awardName: null,
           awardNumber: null,
-          awardPi: null,
-          awardStatus: null,
-          billingCycle: null,
+          contractAdministrator: null,
         })}
       />
     );
 
-    // All null fields should show the em-dash fallback
     const dashes = screen.getAllByText('—');
-    expect(dashes.length).toBeGreaterThanOrEqual(4);
+    expect(dashes.length).toBeGreaterThanOrEqual(3);
   });
 
   it('formats dates as MM.dd.yyyy', () => {
     render(
       <ProjectAdditionalInfo
+        isProjectManager={false}
         summary={createSummary({
-          awardCloseDate: '2026-06-30',
           awardEndDate: '2026-12-31',
           awardStartDate: '2024-01-01',
         })}
       />
     );
 
-    expect(screen.getByText('06.30.2026')).toBeInTheDocument();
     expect(screen.getByText('12.31.2026')).toBeInTheDocument();
     expect(screen.getByText('01.01.2024')).toBeInTheDocument();
-  });
-
-  it('shows em-dash for null dates', () => {
-    render(
-      <ProjectAdditionalInfo
-        summary={createSummary({
-          awardCloseDate: null,
-          awardEndDate: null,
-          awardStartDate: null,
-        })}
-      />
-    );
-
-    // The three date fields plus any other null fields should all show dashes
-    const dashes = screen.getAllByText('—');
-    expect(dashes.length).toBeGreaterThanOrEqual(3);
   });
 });

--- a/web/client/src/test/components/project/ProjectsTable.test.tsx
+++ b/web/client/src/test/components/project/ProjectsTable.test.tsx
@@ -18,6 +18,7 @@ const createProject = (
   activityDesc: 'Activity',
   awardCloseDate: null,
   awardEndDate: '2099-12-31',
+  awardName: null,
   awardNumber: 'AWD001',
   awardPi: null,
   awardStartDate: '2024-01-01',

--- a/web/client/src/test/lib/projectAlerts.test.ts
+++ b/web/client/src/test/lib/projectAlerts.test.ts
@@ -7,6 +7,7 @@ const createSummary = (
 ): ProjectSummary => ({
   awardCloseDate: null,
   awardEndDate: '2030-12-31',
+  awardName: null,
   awardNumber: null,
   awardPi: null,
   awardStartDate: '2020-01-01',

--- a/web/client/src/test/routes/(authenticated)/project-detail.test.tsx
+++ b/web/client/src/test/routes/(authenticated)/project-detail.test.tsx
@@ -12,6 +12,7 @@ const createProject = (
   activityDesc: 'Activity',
   awardCloseDate: null,
   awardEndDate: '2099-12-31',
+  awardName: null,
   awardNumber: 'AWD001',
   awardPi: null,
   awardStartDate: '2024-01-01',
@@ -81,24 +82,7 @@ const setupHandlers = (
 };
 
 describe('project detail page', () => {
-  it('shows Additional Information when user is the project manager', async () => {
-    const projects = [createProject({ pmEmployeeId: '1000' })];
-    setupHandlers({ employeeId: '1000', name: 'PM User' }, projects);
-
-    const { cleanup } = renderRoute({
-      initialPath: '/projects/1000/P1',
-    });
-
-    try {
-      expect(
-        await screen.findByText('Additional Information')
-      ).toBeInTheDocument();
-    } finally {
-      cleanup();
-    }
-  });
-
-  it('hides Additional Information when user is not the project manager', async () => {
+  it('shows Award Information for all users', async () => {
     const projects = [createProject({ pmEmployeeId: '2000' })];
     setupHandlers({ employeeId: '1000', name: 'PI User' }, projects);
 
@@ -107,11 +91,44 @@ describe('project detail page', () => {
     });
 
     try {
-      // Wait for the page to render by finding the project heading
-      await screen.findByRole('heading', { name: 'Test Project' });
-
       expect(
-        screen.queryByText('Additional Information')
+        await screen.findByText('Award Information')
+      ).toBeInTheDocument();
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('shows Show more button only for project managers', async () => {
+    const projects = [createProject({ pmEmployeeId: '1000' })];
+    setupHandlers({ employeeId: '1000', name: 'PM User' }, projects);
+
+    const { cleanup } = renderRoute({
+      initialPath: '/projects/1000/P1',
+    });
+
+    try {
+      await screen.findByText('Award Information');
+      expect(
+        screen.getByRole('button', { name: 'Show more' })
+      ).toBeInTheDocument();
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('hides Show more button for non-project managers', async () => {
+    const projects = [createProject({ pmEmployeeId: '2000' })];
+    setupHandlers({ employeeId: '1000', name: 'PI User' }, projects);
+
+    const { cleanup } = renderRoute({
+      initialPath: '/projects/1000/P1',
+    });
+
+    try {
+      await screen.findByText('Award Information');
+      expect(
+        screen.queryByRole('button', { name: 'Show more' })
       ).not.toBeInTheDocument();
     } finally {
       cleanup();

--- a/web/server/Models/FacultyPortfolioRecord.cs
+++ b/web/server/Models/FacultyPortfolioRecord.cs
@@ -10,6 +10,9 @@ public sealed class FacultyPortfolioRecord
     [JsonPropertyName("awardNumber")]
     public string? AwardNumber { get; set; }
 
+    [JsonPropertyName("awardName")]
+    public string? AwardName { get; set; }
+
     [JsonPropertyName("awardStartDate")]
     public DateTime? AwardStartDate { get; set; }
 


### PR DESCRIPTION
- Rename "Additional Information" to "Award Information", visible to all users
- Primary fields always shown: Award Number, Award Name, Award Start/End Date, Primary Sponsor Name, Sponsor Award Number, Burden Schedule Rate, Contract Admin
- Secondary fields behind "Show more" button, only available to Project Managers
- Add Award Name to sproc, server model, client query, and project summary
- Update tests for new section layout and awardName field

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Award Information section displaying Award Name and award-related details to project pages.
  * Implemented expandable secondary fields for project managers via a "Show more/Show less" toggle to access additional award information.

* **Updates**
  * Reorganized award fields into primary fields (always visible) and secondary fields (collapsible for managers).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->