### PR TITLE
Preserve manually granted roles during login sync

### DIFF
--- a/web/server/Services/UserService.cs
+++ b/web/server/Services/UserService.cs
@@ -215,8 +215,10 @@ public class UserService : IUserService
             throw new InvalidOperationException($"Role '{roleName}' not found.");
         }
 
+        // Only remove auto-synced permissions (self-granted).
+        // Manually granted permissions (GrantedByUserId != userId) are preserved.
         var permissions = await _dbContext.Permissions
-            .Where(p => p.UserId == userId && p.RoleId == role.Id)
+            .Where(p => p.UserId == userId && p.RoleId == role.Id && p.GrantedByUserId == userId)
             .ToListAsync(cancellationToken);
 
         if (permissions.Count == 0)

--- a/web/tests/server.tests/Services/UserServiceTests.cs
+++ b/web/tests/server.tests/Services/UserServiceTests.cs
@@ -158,18 +158,31 @@ public class UserServiceTests
         ctx.Roles.AddRange(projectManagerRole, accrualViewerRole);
         await ctx.SaveChangesAsync();
 
+        var adminUser = new User
+        {
+            Id = Guid.NewGuid(),
+            Kerberos = "adminuser",
+            IamId = "IAM-ADMIN",
+            EmployeeId = "E-ADMIN",
+            DisplayName = "Admin User",
+            Email = "admin@example.com",
+        };
+        ctx.Users.Add(adminUser);
+
         ctx.Permissions.AddRange(
             new Permission
             {
                 UserId = targetUser.Id,
                 RoleId = projectManagerRole.Id,
                 DeptCode = null,
+                GrantedByUserId = targetUser.Id, // auto-synced (self-granted)
             },
             new Permission
             {
                 UserId = targetUser.Id,
                 RoleId = projectManagerRole.Id,
                 DeptCode = "AA100",
+                GrantedByUserId = adminUser.Id, // manually granted by admin
             },
             new Permission
             {
@@ -185,7 +198,9 @@ public class UserServiceTests
         var removed = await service.RemoveRoleFromUserAsync(targetUser.Id, Role.Names.ProjectManager);
 
         removed.Should().BeTrue();
-        ctx.Permissions.Should().NotContain(p => p.UserId == targetUser.Id && p.RoleId == projectManagerRole.Id);
+        // Only the self-granted permission should be removed; admin-granted one is preserved
+        ctx.Permissions.Should().ContainSingle(p => p.UserId == targetUser.Id && p.RoleId == projectManagerRole.Id);
+        ctx.Permissions.Should().Contain(p => p.UserId == targetUser.Id && p.RoleId == projectManagerRole.Id && p.GrantedByUserId == adminUser.Id);
         ctx.Permissions.Should().ContainSingle(p => p.UserId == targetUser.Id && p.RoleId == accrualViewerRole.Id);
     }
 
@@ -215,6 +230,7 @@ public class UserServiceTests
             UserId = targetUser.Id,
             RoleId = projectManagerRole.Id,
             DeptCode = null,
+            GrantedByUserId = targetUser.Id, // auto-synced (self-granted)
         });
         await ctx.SaveChangesAsync();
 


### PR DESCRIPTION
We ran into an issue where when a user is assigned PM permissions without being a PM, those permissions are removed when the user logs in. This PR fixes that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Role removal now correctly preserves permissions granted by other users. When removing a role from a user, only self-granted permissions are removed while administrator-assigned or team-granted permissions remain intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->