### PR TITLE
Reconciliation detail: expand GL export, add revenue/expense filter and date sorting

### DIFF
--- a/datamart/StoredProcedures/usp_GetGLTransactionListings.sql
+++ b/datamart/StoredProcedures/usp_GetGLTransactionListings.sql
@@ -62,32 +62,34 @@ BEGIN
 
     -- Build filter clause based on which parameter was provided
     IF @FinancialDept IS NOT NULL
-        SET @FilterClause = ' WHERE financial_department = ''' + @FinancialDept + '''';
+        SET @FilterClause = ' WHERE tlr.financial_department = ''' + @FinancialDept + '''';
     ELSE
-        SET @FilterClause = ' WHERE PROJECT IN (' + @ProjectIdFilter + ')';
+        SET @FilterClause = ' WHERE tlr.PROJECT IN (' + @ProjectIdFilter + ')';
 
     -- Add date filters
     IF @StartDate IS NOT NULL
-        SET @FilterClause = @FilterClause + ' AND journal_acct_date >= ''' + CONVERT(VARCHAR(10), @StartDate, 120) + '''';
+        SET @FilterClause = @FilterClause + ' AND tlr.journal_acct_date >= ''' + CONVERT(VARCHAR(10), @StartDate, 120) + '''';
 
     IF @EndDate IS NOT NULL
-        SET @FilterClause = @FilterClause + ' AND journal_acct_date <= ''' + CONVERT(VARCHAR(10), @EndDate, 120) + '''';
+        SET @FilterClause = @FilterClause + ' AND tlr.journal_acct_date <= ''' + CONVERT(VARCHAR(10), @EndDate, 120) + '''';
 
     -- Build Redshift query with explicit column list
     SET @RedshiftQuery = '
         SELECT
-            ENTITY, ENTITY_DESCRIPTION, FUND, FUND_DESCRIPTION,
-            FINANCIAL_DEPARTMENT, FINANCIAL_DEPARTMENT_DESCRIPTION,
-            ACCOUNT, ACCOUNT_DESCRIPTION, PURPOSE, PURPOSE_DESCRIPTION,
-            PROGRAM, PROGRAM_DESCRIPTION, PROJECT, PROJECT_DESCRIPTION,
-            ACTIVITY, ACTIVITY_DESCRIPTION, DOCUMENT_TYPE,
-            ACCOUNTING_SEQUENCE_NUMBER, TRACKING_NO, REFERENCE,
-            JOURNAL_LINE_DESCRIPTION, JOURNAL_ACCT_DATE, JOURNAL_NAME,
-            JOURNAL_REFERENCE, PERIOD_NAME, JOURNAL_BATCH_NAME,
-            JOURNAL_SOURCE, JOURNAL_CATEGORY, BATCH_STATUS, ACTUAL_FLAG,
-            ENCUMBRANCE_TYPE_CODE, ACTUAL_AMOUNT, COMMITMENT_AMOUNT,
-            OBLIGATION_AMOUNT
-        FROM ae_dwh.transactional_listing_report
+            tlr.ENTITY, tlr.ENTITY_DESCRIPTION, tlr.FUND, tlr.FUND_DESCRIPTION,
+            tlr.FINANCIAL_DEPARTMENT, tlr.FINANCIAL_DEPARTMENT_DESCRIPTION,
+            tlr.ACCOUNT, tlr.ACCOUNT_DESCRIPTION, tlr.PURPOSE, tlr.PURPOSE_DESCRIPTION,
+            tlr.PROGRAM, tlr.PROGRAM_DESCRIPTION, tlr.PROJECT, tlr.PROJECT_DESCRIPTION,
+            tlr.ACTIVITY, tlr.ACTIVITY_DESCRIPTION, tlr.DOCUMENT_TYPE,
+            tlr.ACCOUNTING_SEQUENCE_NUMBER, tlr.TRACKING_NO, tlr.REFERENCE,
+            tlr.JOURNAL_LINE_DESCRIPTION, tlr.JOURNAL_ACCT_DATE, tlr.JOURNAL_NAME,
+            tlr.JOURNAL_REFERENCE, tlr.PERIOD_NAME, tlr.JOURNAL_BATCH_NAME,
+            tlr.JOURNAL_SOURCE, tlr.JOURNAL_CATEGORY, tlr.BATCH_STATUS, tlr.ACTUAL_FLAG,
+            tlr.ENCUMBRANCE_TYPE_CODE, tlr.ACTUAL_AMOUNT, tlr.COMMITMENT_AMOUNT,
+            tlr.OBLIGATION_AMOUNT,
+            acc.parent_level_0_code AS NATURAL_ACCOUNT_TYPE
+        FROM ae_dwh.transactional_listing_report tlr
+        LEFT JOIN ae_dwh.erp_account acc ON tlr.ACCOUNT = acc.code
         ' + @FilterClause;
 
     -- Build parameters JSON for logging

--- a/web/client/src/queries/project.ts
+++ b/web/client/src/queries/project.ts
@@ -87,6 +87,7 @@ export interface GLTransactionRecord {
   actualAmount: number;
   commitmentAmount: number;
   obligationAmount: number;
+  naturalAccountType: string | null;
 }
 
 export interface GLPPMReconciliationRecord {

--- a/web/client/src/routes/(authenticated)/reports/reconciliation/$projectNumber/detail.tsx
+++ b/web/client/src/routes/(authenticated)/reports/reconciliation/$projectNumber/detail.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { createFileRoute, Link } from '@tanstack/react-router';
 import { useQuery } from '@tanstack/react-query';
 import { createColumnHelper } from '@tanstack/react-table';
@@ -226,17 +227,43 @@ const ppmTaskCsvColumns = [
 ];
 
 const glCsvColumns = [
-  { format: 'date' as const, header: 'Date', key: 'journalAcctDate' as const },
-  { header: 'Chart String', key: 'chartString' as const },
-  { header: 'Journal', key: 'journalName' as const },
-  { header: 'Batch', key: 'journalBatchName' as const },
-  { header: 'Category', key: 'journalCategory' as const },
-  { header: 'Description', key: 'journalLineDescription' as const },
+  { header: 'Fund', key: 'fund' as const },
+  { header: 'Fund Description', key: 'fundDescription' as const },
+  { header: 'Financial Dept', key: 'financialDepartment' as const },
+  {
+    header: 'Financial Dept Description',
+    key: 'financialDepartmentDescription' as const,
+  },
+  { header: 'Account', key: 'account' as const },
+  { header: 'Account Description', key: 'accountDescription' as const },
+  { header: 'Purpose', key: 'purpose' as const },
+  { header: 'Purpose Description', key: 'purposeDescription' as const },
+  { header: 'Program', key: 'program' as const },
+  { header: 'Program Description', key: 'programDescription' as const },
+  { header: 'Project', key: 'project' as const },
+  { header: 'Project Description', key: 'projectDescription' as const },
+  { header: 'Activity', key: 'activity' as const },
+  { header: 'Activity Description', key: 'activityDescription' as const },
+  { header: 'Document Type', key: 'documentType' as const },
+  { header: 'Document Number', key: 'accountingSequenceNumber' as const },
+  { header: 'Tracking Number', key: 'trackingNo' as const },
+  { header: 'Reference', key: 'reference' as const },
+  { header: 'JE Source', key: 'journalSource' as const },
+  { header: 'JE Category', key: 'journalCategory' as const },
+  { header: 'JE Batch Name', key: 'journalBatchName' as const },
+  { header: 'JE Name', key: 'journalName' as const },
+  { header: 'JE Accounting Period', key: 'periodName' as const },
+  {
+    format: 'date' as const,
+    header: 'JE Accounting Date',
+    key: 'journalAcctDate' as const,
+  },
   {
     format: 'currency' as const,
     header: 'Amount',
     key: 'actualAmount' as const,
   },
+  { header: 'JE Line Description', key: 'journalLineDescription' as const },
 ];
 
 function buildChartString(t: GLTransactionRecord): string {
@@ -315,23 +342,21 @@ function RouteComponent() {
       }, {})
   );
 
-  const glTransactions = (transactions ?? [])
-    .filter((t) => matchesGL(t, search))
-    .sort((a, b) => {
-      if (!a.journalAcctDate && !b.journalAcctDate) {
-        return 0;
-      }
-      if (!a.journalAcctDate) {
-        return 1;
-      }
-      if (!b.journalAcctDate) {
-        return -1;
-      }
-      return (
-        new Date(b.journalAcctDate).getTime() -
-        new Date(a.journalAcctDate).getTime()
-      );
-    });
+  const [accountFilter, setAccountFilter] = useState<
+    'all' | 'revenue' | 'expense'
+  >('all');
+
+  const glTransactions = (transactions ?? []).filter(
+    (t) => matchesGL(t, search)
+  );
+
+  const filteredGlTransactions = glTransactions.filter((t) => {
+    if (accountFilter === 'revenue')
+      return t.naturalAccountType?.startsWith('4');
+    if (accountFilter === 'expense')
+      return t.naturalAccountType?.startsWith('5');
+    return true;
+  });
 
   const keyLabel = [search.dept, search.fund, search.program, search.activity]
     .filter(Boolean)
@@ -418,24 +443,49 @@ function RouteComponent() {
 
           {/* GL Transaction Listings */}
           <section className="mb-8">
-            <h2 className="h2 mb-4">
-              GL Transactions ({glTransactions.length})
-            </h2>
-            {glTransactions.length === 0 ? (
+            <div className="flex items-center justify-between mb-4">
+              <h2 className="h2">
+                GL Transactions ({filteredGlTransactions.length})
+              </h2>
+              <div className="join">
+                <button
+                  className={`btn btn-sm join-item${accountFilter === 'all' ? ' btn-active' : ''}`}
+                  onClick={() => setAccountFilter('all')}
+                  type="button"
+                >
+                  All
+                </button>
+                <button
+                  className={`btn btn-sm join-item${accountFilter === 'revenue' ? ' btn-active' : ''}`}
+                  onClick={() => setAccountFilter('revenue')}
+                  type="button"
+                >
+                  Revenue
+                </button>
+                <button
+                  className={`btn btn-sm join-item${accountFilter === 'expense' ? ' btn-active' : ''}`}
+                  onClick={() => setAccountFilter('expense')}
+                  type="button"
+                >
+                  Expenses
+                </button>
+              </div>
+            </div>
+            {filteredGlTransactions.length === 0 ? (
               <p className="text-base-content/80">No GL transactions found.</p>
             ) : (
               <DataTable
                 columns={glColumns}
-                data={glTransactions}
+                data={filteredGlTransactions}
                 expandable={true}
+                initialState={{
+                  sorting: [{ id: 'journalAcctDate', desc: true }],
+                }}
                 pagination="auto"
                 tableActions={
                   <ExportDataButton
                     columns={glCsvColumns}
-                    data={glTransactions.map((t) => ({
-                      ...t,
-                      chartString: buildChartString(t),
-                    }))}
+                    data={filteredGlTransactions}
                     filename="gl-transactions.csv"
                   />
                 }

--- a/web/client/src/test/routes/(authenticated)/reconciliation-detail.test.tsx
+++ b/web/client/src/test/routes/(authenticated)/reconciliation-detail.test.tsx
@@ -1,7 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import { screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
-import type { GLPPMReconciliationRecord } from '@/queries/project.ts';
+import type {
+  GLPPMReconciliationRecord,
+  GLTransactionRecord,
+} from '@/queries/project.ts';
 import { server } from '@/test/mswUtils.ts';
 import { renderRoute } from '@/test/routerUtils.tsx';
 
@@ -28,8 +32,50 @@ const createReconciliationRecord = (
   ...overrides,
 });
 
+const createTransaction = (
+  overrides: Partial<GLTransactionRecord> = {}
+): GLTransactionRecord => ({
+  account: '500001',
+  accountDescription: 'Supplies',
+  accountingSequenceNumber: null,
+  activity: '000000',
+  activityDescription: 'Default Activity',
+  actualAmount: 100,
+  actualFlag: 'A',
+  batchStatus: 'P',
+  commitmentAmount: 0,
+  documentType: null,
+  encumbranceTypeCode: null,
+  entity: 'ENTITY',
+  entityDescription: null,
+  financialDepartment: 'DEPT001',
+  financialDepartmentDescription: null,
+  fund: '13U02',
+  fundDescription: null,
+  journalAcctDate: '2026-01-15',
+  journalBatchName: null,
+  journalCategory: null,
+  journalLineDescription: 'Test transaction',
+  journalName: 'JE001',
+  journalReference: null,
+  journalSource: null,
+  naturalAccountType: null,
+  obligationAmount: 0,
+  periodName: null,
+  program: '000',
+  programDescription: null,
+  project: 'PROJ001',
+  projectDescription: null,
+  purpose: null,
+  purposeDescription: null,
+  reference: null,
+  trackingNo: null,
+  ...overrides,
+});
+
 const setupHandlers = (
-  reconciliation: GLPPMReconciliationRecord[] = []
+  reconciliation: GLPPMReconciliationRecord[] = [],
+  transactions: GLTransactionRecord[] = []
 ) => {
   server.use(
     http.get('/api/user/me', () =>
@@ -46,7 +92,9 @@ const setupHandlers = (
     http.get('/api/project/gl-ppm-reconciliation', () =>
       HttpResponse.json(reconciliation)
     ),
-    http.get('/api/project/transactions', () => HttpResponse.json([]))
+    http.get('/api/project/transactions', () =>
+      HttpResponse.json(transactions)
+    )
   );
 };
 
@@ -82,6 +130,55 @@ describe('reconciliation detail page', () => {
 
     try {
       expect(await screen.findByText('No record found.')).toBeInTheDocument();
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('renders filter buttons and filters transactions by account type', async () => {
+    const user = userEvent.setup();
+    const record = createReconciliationRecord();
+    const txns = [
+      createTransaction({
+        actualAmount: -1000,
+        journalLineDescription: 'Grant revenue',
+        naturalAccountType: '40000',
+      }),
+      createTransaction({
+        actualAmount: 250,
+        journalLineDescription: 'Lab supplies',
+        naturalAccountType: '50000',
+      }),
+      createTransaction({
+        actualAmount: 150,
+        journalLineDescription: 'Travel expense',
+        naturalAccountType: '54000',
+      }),
+    ];
+    setupHandlers([record], txns);
+
+    const { cleanup } = renderRoute({ initialPath: detailPath });
+
+    try {
+      // Wait for data to load — all 3 transactions visible
+      expect(
+        await screen.findByText('GL Transactions (3)')
+      ).toBeInTheDocument();
+
+      // Filter to revenue
+      await user.click(screen.getByRole('button', { name: 'Revenue' }));
+      expect(screen.getByText('GL Transactions (1)')).toBeInTheDocument();
+      expect(screen.getByText('Grant revenue')).toBeInTheDocument();
+
+      // Filter to expenses
+      await user.click(screen.getByRole('button', { name: 'Expenses' }));
+      expect(screen.getByText('GL Transactions (2)')).toBeInTheDocument();
+      expect(screen.getByText('Lab supplies')).toBeInTheDocument();
+      expect(screen.getByText('Travel expense')).toBeInTheDocument();
+
+      // Back to all
+      await user.click(screen.getByRole('button', { name: 'All' }));
+      expect(screen.getByText('GL Transactions (3)')).toBeInTheDocument();
     } finally {
       cleanup();
     }

--- a/web/server/Models/GLTransactionRecord.cs
+++ b/web/server/Models/GLTransactionRecord.cs
@@ -108,4 +108,7 @@ public sealed class GLTransactionRecord
 
     [JsonPropertyName("obligationAmount")]
     public decimal ObligationAmount { get; set; }
+
+    [JsonPropertyName("naturalAccountType")]
+    public string? NaturalAccountType { get; set; }
 }


### PR DESCRIPTION
Based on conversations with Melissa Estes

- Expand GL transaction CSV export from 7 to 26 columns matching the 8419 report (fund, dept, account, purpose, program, project, activity with descriptions, document type/number, tracking, JE metadata, amount)
- Add revenue/expense/all filter buttons on GL transactions using naturalAccountType from erp_account join (4xxx=revenue, 5xxx=expense)
- Default date sort descending via DataTable initialState
- Join erp_account in usp_GetGLTransactionListings sproc for account type
- Add NaturalAccountType to server model and client interface
- Add test for filter button behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GL transactions can now be filtered by account type: All, Revenue, or Expenses
  * GL transaction CSV export now includes expanded columns: fund, account, purpose, program, project, activity, document identifiers, JE source, category, batch, period, and formatted accounting date

* **Improvements**
  * GL transactions display sorted by accounting date in descending order

<!-- end of auto-generated comment: release notes by coderabbit.ai -->