### PR TITLE
Fix project routing and vacate transferred positions

### DIFF
--- a/datamart/StoredProcedures/usp_GetPositionBudgets.sql
+++ b/datamart/StoredProcedures/usp_GetPositionBudgets.sql
@@ -116,11 +116,22 @@ BEGIN
                     PARTITION BY POSITION_NBR
                     ORDER BY EFFDT DESC, EFFSEQ DESC
                 ) AS rnk
-            FROM caes_hcmods.PS_JOB_V
+            FROM caes_hcmods.PS_JOB_V j
             WHERE DML_IND != ''D''
               AND EFFDT <= TRUNC(SYSDATE)
               AND NOT (AUTO_END_FLG = ''Y'' AND EXPECTED_END_DATE < TRUNC(SYSDATE))
               AND POSITION_NBR IN (SELECT DISTINCT POSITION_NBR FROM LatestBudget)
+              /*Vacate positions where person has moved to a different position. PeopleSoft does NOT back-fill the old position-side history when an
+               employee transfers, so without this check a position may appear to be filled forever. */
+              AND NOT EXISTS (
+                  SELECT 1 FROM caes_hcmods.PS_JOB_V j2
+                  WHERE j2.EMPLID = j.EMPLID
+                    AND j2.EMPL_RCD = j.EMPL_RCD
+                    AND j2.DML_IND != ''D''
+                    AND j2.EFFDT <= TRUNC(SYSDATE)
+                    AND (j2.EFFDT > j.EFFDT
+                         OR (j2.EFFDT = j.EFFDT AND j2.EFFSEQ > j.EFFSEQ))
+              )
         ),
         LatestEmployee AS (
             SELECT


### PR DESCRIPTION
## Summary
- Fall back to Project Manager when resolving projects without a PI
- Mirror PI loop structure for the PM fallback path
- Vacate positions in `usp_GetPositionBudgets` where the employee has transferred — PeopleSoft doesn't back-fill old position history, so positions appeared filled forever

## Test plan
- [ ] Verify projects without a PI now resolve via PM fallback
- [ ] Verify position budgets correctly show vacant positions after employee transfers
- [ ] Confirm no regression for projects that have a PI assigned

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected position tracking to ensure positions no longer appear as indefinitely filled following employee transfers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->