### PR TITLE
Restrict FP monitor trigger to 7am-7pm Pacific

### DIFF
--- a/pipelines/trigger/MonitorFPProjectsTrigger.json
+++ b/pipelines/trigger/MonitorFPProjectsTrigger.json
@@ -14,10 +14,13 @@
 		"type": "ScheduleTrigger",
 		"typeProperties": {
 			"recurrence": {
-				"frequency": "Hour",
-				"interval": 3,
-				"startTime": "2026-04-10T08:00:00",
-				"timeZone": "Eastern Standard Time"
+				"frequency": "Day",
+				"interval": 1,
+				"startTime": "2026-04-10T10:00:00",
+				"timeZone": "Eastern Standard Time",
+				"schedule": {
+					"hours": [10, 13, 16, 19]
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
- Follow-up to #201 — restricts the `MonitorFPProjectsTrigger` to only run during business hours
- Runs at 7am, 10am, 1pm, 4pm Pacific (every 3 hours within 7am–7pm window)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal monitoring schedule configuration to optimize system operations and execution timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->