### PR TITLE
Analyst feedback omnibus (#165)

### DIFF
--- a/web/client/src/components/project/ProjectAdditionalInfo.tsx
+++ b/web/client/src/components/project/ProjectAdditionalInfo.tsx
@@ -25,7 +25,7 @@ function buildPrimaryFields(summary: ProjectSummary): Field[] {
       value: summary.sponsorAwardNumber ?? '—',
     },
     {
-      label: 'Burden Schedule Rate',
+      label: 'Indirect/Burden Rate',
       tooltip: tooltipDefinitions.burdenScheduleRate,
       value: summary.projectBurdenCostRate
         ? `${Number.parseFloat((Number.parseFloat(summary.projectBurdenCostRate) * 100).toFixed(4))}%`

--- a/web/client/src/components/project/TaskBreakdown.tsx
+++ b/web/client/src/components/project/TaskBreakdown.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { Link } from '@tanstack/react-router';
 import { createColumnHelper } from '@tanstack/react-table';
 import { ExportDataButton } from '@/components/ExportDataButton.tsx';
@@ -23,6 +23,7 @@ interface TaskBreakdownRow {
   programDesc: string;
   taskName: string;
   taskNum: string;
+  taskStatus: string;
 }
 
 const columnHelper = createColumnHelper<TaskBreakdownRow>();
@@ -59,6 +60,7 @@ function buildRows(records: ProjectRecord[]): TaskBreakdownRow[] {
         programDesc: r.programDesc,
         taskName: r.taskName ?? '',
         taskNum: task,
+        taskStatus: r.taskStatus,
       });
     }
   }
@@ -89,8 +91,18 @@ interface TaskBreakdownProps {
   records: ProjectRecord[];
 }
 
+function isClosedTask(row: TaskBreakdownRow): boolean {
+  return row.taskStatus !== 'OPEN';
+}
+
 export function TaskBreakdown({ employeeId, projectNumber, records }: TaskBreakdownProps) {
-  const rows = useMemo(() => buildRows(records), [records]);
+  const [showClosed, setShowClosed] = useState(false);
+  const allRows = useMemo(() => buildRows(records), [records]);
+  const closedCount = useMemo(() => allRows.filter(isClosedTask).length, [allRows]);
+  const rows = useMemo(
+    () => (showClosed ? allRows : allRows.filter((r) => !isClosedTask(r))),
+    [allRows, showClosed]
+  );
 
   const totals = useMemo(
     () =>
@@ -245,7 +257,7 @@ export function TaskBreakdown({ employeeId, projectNumber, records }: TaskBreakd
     [employeeId, projectNumber, totals.balance, totals.budget, totals.commitments, totals.expenses]
   );
 
-  if (rows.length === 0) {
+  if (allRows.length === 0) {
     return null;
   }
 
@@ -256,11 +268,22 @@ export function TaskBreakdown({ employeeId, projectNumber, records }: TaskBreakd
       footerRowClassName="totaltr"
       pagination="off"
       tableActions={
-        <ExportDataButton
-          columns={csvColumns}
-          data={rows}
-          filename={`task-breakdown-${projectNumber}.csv`}
-        />
+        <>
+          {closedCount > 0 && (
+            <button
+              className={`btn btn-sm ${showClosed ? 'btn-active' : 'btn-default'}`}
+              onClick={() => setShowClosed(!showClosed)}
+              type="button"
+            >
+              {showClosed ? 'Hide' : 'Show'} closed ({closedCount})
+            </button>
+          )}
+          <ExportDataButton
+            columns={csvColumns}
+            data={rows}
+            filename={`task-breakdown-${projectNumber}.csv`}
+          />
+        </>
       }
     />
   );

--- a/web/client/src/components/project/TaskBreakdown.tsx
+++ b/web/client/src/components/project/TaskBreakdown.tsx
@@ -124,7 +124,9 @@ export function TaskBreakdown({ employeeId, projectNumber, records }: TaskBreakd
         minSize: 200,
       }),
       columnHelper.accessor('financialDepartmentCode', {
-        cell: (info) => <span>{info.getValue()}</span>,
+        cell: (info) => (
+          <span title={info.row.original.financialDepartment}>{info.getValue()}</span>
+        ),
         header: 'Dept',
       }),
       columnHelper.accessor('fundCode', {

--- a/web/client/src/components/project/TaskBreakdown.tsx
+++ b/web/client/src/components/project/TaskBreakdown.tsx
@@ -254,6 +254,7 @@ export function TaskBreakdown({ employeeId, projectNumber, records }: TaskBreakd
       columns={columns}
       data={rows}
       footerRowClassName="totaltr"
+      pagination="off"
       tableActions={
         <ExportDataButton
           columns={csvColumns}

--- a/web/client/src/components/search/SearchButton.tsx
+++ b/web/client/src/components/search/SearchButton.tsx
@@ -5,7 +5,7 @@ import { MagnifyingGlassIcon } from '@heroicons/react/24/outline';
 
 const getDefaultPlaceholder = (roles: readonly string[]) => {
   return canViewFinancials(roles)
-    ? 'Search PIs, Projects, Personnel...'
+    ? 'Search projects, people, reports...'
     : 'Search projects and reports...';
 };
 

--- a/web/client/src/routes/(authenticated)/reports/reconciliation/$projectNumber/index.tsx
+++ b/web/client/src/routes/(authenticated)/reports/reconciliation/$projectNumber/index.tsx
@@ -48,18 +48,15 @@ function RouteComponent() {
     isPending: isReconciliationPending,
   } = useQuery(glPpmReconciliationQueryOptions([projectNumber]));
 
-  // Sort by discrepancy first (discrepancies at top), then by absolute difference
+  // Sort by fund, then program, then activity
   const sorted = useMemo(
     () =>
       [...(records ?? [])].sort((a, b) => {
-        const aDisc = hasDiscrepancy(a);
-        const bDisc = hasDiscrepancy(b);
-        if (aDisc !== bDisc) {
-          return aDisc ? -1 : 1;
-        }
-        const aDiff = Math.abs(a.glActualAmount + a.ppmItdExp);
-        const bDiff = Math.abs(b.glActualAmount + b.ppmItdExp);
-        return bDiff - aDiff;
+        const fundCmp = (a.fundCode ?? '').localeCompare(b.fundCode ?? '');
+        if (fundCmp !== 0) return fundCmp;
+        const progCmp = (a.programCode ?? '').localeCompare(b.programCode ?? '');
+        if (progCmp !== 0) return progCmp;
+        return (a.activityCode ?? '').localeCompare(b.activityCode ?? '');
       }),
     [records]
   );

--- a/web/client/src/shared/auth/roleAccess.ts
+++ b/web/client/src/shared/auth/roleAccess.ts
@@ -64,4 +64,4 @@ export const canAccessPrincipalInvestigatorsNav = (roles: readonly string[]) =>
   hasRole(roles, PI_NAV_ROLES);
 
 export const canAccessReportsNav = (roles: readonly string[]) =>
-  hasNonSystemSpecialRole(roles);
+  roles.includes(ROLE_NAMES.accrualViewer) || hasRole(roles, ELEVATED_ROLES);

--- a/web/client/src/test/components/project/ProjectAdditionalInfo.test.tsx
+++ b/web/client/src/test/components/project/ProjectAdditionalInfo.test.tsx
@@ -61,7 +61,7 @@ describe('ProjectAdditionalInfo', () => {
     expect(screen.getByText('National Science Foundation')).toBeInTheDocument();
     expect(screen.getByText('Sponsor Award Number')).toBeInTheDocument();
     expect(screen.getByText('NSF-2024-001')).toBeInTheDocument();
-    expect(screen.getByText('Burden Schedule Rate')).toBeInTheDocument();
+    expect(screen.getByText('Indirect/Burden Rate')).toBeInTheDocument();
     expect(screen.getByText('26.5%')).toBeInTheDocument();
     expect(screen.getByText('Contract Administrator')).toBeInTheDocument();
     expect(screen.getByText('Admin, Carol')).toBeInTheDocument();
@@ -137,11 +137,11 @@ describe('ProjectAdditionalInfo', () => {
     expect(screen.getByText('01.01.2024')).toBeInTheDocument();
   });
 
-  it('shows a tooltip for Burden Schedule Rate', async () => {
+  it('shows a tooltip for Indirect/Burden Rate', async () => {
     const user = userEvent.setup();
     render(<ProjectAdditionalInfo isProjectManager={false} summary={createSummary()} />);
 
-    const label = screen.getByText('Burden Schedule Rate');
+    const label = screen.getByText('Indirect/Burden Rate');
     await user.hover(label.parentElement as HTMLElement);
 
     expect(await screen.findByRole('tooltip')).toHaveTextContent(

--- a/web/client/src/test/components/search/SearchButton.test.tsx
+++ b/web/client/src/test/components/search/SearchButton.test.tsx
@@ -36,7 +36,7 @@ describe('SearchButton', () => {
 
     expect(
       screen.getByRole('button', {
-        name: /Search PIs, Projects, Personnel\.\.\./i,
+        name: /Search projects, people, reports\.\.\./i,
       })
     ).toBeInTheDocument();
   });

--- a/web/client/src/test/routes/(authenticated)/nav-access.test.tsx
+++ b/web/client/src/test/routes/(authenticated)/nav-access.test.tsx
@@ -95,14 +95,14 @@ describe('header navigation access control', () => {
     }
   });
 
-  it('shows Principal Investigators and Reports for FinancialViewer users', async () => {
+  it('shows Principal Investigators for FinancialViewer users (no Reports)', async () => {
     const { cleanup } = await renderHomeForRoles(['FinancialViewer']);
 
     try {
       expect(
         screen.getByRole('link', { name: 'Principal Investigators' })
       ).toBeInTheDocument();
-      expect(screen.getByRole('link', { name: 'Reports' })).toBeInTheDocument();
+      expect(screen.queryByRole('link', { name: 'Reports' })).not.toBeInTheDocument();
       expect(screen.queryByRole('link', { name: 'Projects' })).not.toBeInTheDocument();
       expect(screen.queryByRole('link', { name: 'Personnel' })).not.toBeInTheDocument();
       expect(screen.queryByRole('link', { name: 'Admin' })).not.toBeInTheDocument();
@@ -111,14 +111,14 @@ describe('header navigation access control', () => {
     }
   });
 
-  it('shows Principal Investigators and Reports for ProjectManager users', async () => {
+  it('shows Principal Investigators for ProjectManager users (no Reports)', async () => {
     const { cleanup } = await renderHomeForRoles(['ProjectManager']);
 
     try {
       expect(
         screen.getByRole('link', { name: 'Principal Investigators' })
       ).toBeInTheDocument();
-      expect(screen.getByRole('link', { name: 'Reports' })).toBeInTheDocument();
+      expect(screen.queryByRole('link', { name: 'Reports' })).not.toBeInTheDocument();
       expect(screen.queryByRole('link', { name: 'Projects' })).not.toBeInTheDocument();
       expect(screen.queryByRole('link', { name: 'Personnel' })).not.toBeInTheDocument();
       expect(screen.queryByRole('link', { name: 'Admin' })).not.toBeInTheDocument();


### PR DESCRIPTION
## Summary
Implements 6 items from the analyst feedback omnibus (#165):

- **Dept hover tooltip** — Task breakdown dept column now shows full department name on hover
- **Remove task breakdown pagination** — All rows visible without paging so analysts don't miss data
- **Search text consistency** — Splash page search button and command palette now both say "Search projects, people, reports..."
- **Reconciliation sort** — GL/PPM reconciliation sorts by fund/program/activity instead of by discrepancy
- **Hide Reports nav** — Reports link only shows for roles that have actual reports (AccrualViewer, Admin, Manager)
- **Active/inactive task toggle** — Task breakdown defaults to active tasks with a "Show closed (N)" toggle button

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Toggle to show/hide closed tasks in task breakdown; export uses currently displayed rows.

* **Updates**
  * Department column shows extra info on hover.
  * Search placeholder refined for clearer guidance.
  * Reconciliation table now sorts by fund → program → activity codes.
  * Table pagination disabled for the task breakdown view.

* **Access**
  * Reports navigation access updated to include accrual viewers and elevated roles.

* **Tests**
  * Updated tests to reflect changed search text and Reports visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->