### PR TITLE
Remove ProjectManager from CanViewFinancials policy

### DIFF
--- a/web/client/src/components/search/searchAccess.ts
+++ b/web/client/src/components/search/searchAccess.ts
@@ -1,9 +1,10 @@
-const FINANCIAL_SEARCH_ROLES = new Set([
-  'admin',
-  'financialviewer',
-  'projectmanager',
+import { ROLE_NAMES, type AppRole, hasRole } from '@/shared/auth/roleAccess.ts';
+
+const FINANCIAL_SEARCH_ROLES = new Set<AppRole>([
+  ROLE_NAMES.admin,
+  ROLE_NAMES.financialViewer,
 ]);
 
 export const canViewFinancials = (roles: readonly string[]) => {
-  return roles.some((role) => FINANCIAL_SEARCH_ROLES.has(role.toLowerCase()));
+  return hasRole(roles, FINANCIAL_SEARCH_ROLES);
 };

--- a/web/client/src/shared/auth/roleAccess.ts
+++ b/web/client/src/shared/auth/roleAccess.ts
@@ -16,7 +16,6 @@ const ELEVATED_ROLES = new Set<AppRole>([
 
 const PI_NAV_ROLES = new Set<AppRole>([
   ROLE_NAMES.financialViewer,
-  ROLE_NAMES.projectManager,
 ]);
 
 export const hasRole = (

--- a/web/server/Helpers/AuthorizationHelper.cs
+++ b/web/server/Helpers/AuthorizationHelper.cs
@@ -25,7 +25,7 @@ public static class AuthorizationHelper
                 policy.RequireRole(Role.Names.AccrualViewer));
 
             options.AddPolicy(Policies.CanViewFinancials, policy =>
-                policy.RequireRole(Role.Names.FinancialViewer, Role.Names.ProjectManager));
+                policy.RequireRole(Role.Names.FinancialViewer));
 
             options.AddPolicy(Policies.IsManager, policy =>
                 policy.RequireRole(Role.Names.Manager));


### PR DESCRIPTION
## Summary
- Remove `ProjectManager` from the `CanViewFinancials` authorization policy so PMs no longer automatically get broad financial access
- Update frontend role checks (`searchAccess.ts`, `roleAccess.ts`) to match — PMs won't see "All Projects" search or PI nav links
- Admins can still manually assign `FinancialViewer` to PMs who have verified Oracle/UCPath access

## Context
Per Shannon's request: we cannot grant all PMs broad access until we verify their roles in Oracle and UCPath. For now, PMs should only see their own information. Shannon will manually assign `FinancialViewer` through the admin console to PMs with appropriate access.

## Testing notes
- PM-only users should no longer see the PI navigation or "All Projects" search
- PM-only users should still see their own projects via the team search endpoint
- PMs manually granted `FinancialViewer` should have full access as before
- Verify no broken links/403s for PM-only users navigating the app

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Simplified access requirements for financial viewing—now requires only the FinancialViewer role.
  * Updated role-based access controls for the Principal Investigators navigation feature.

* **Refactor**
  * Improved role-checking implementation with enhanced consistency across authorization logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->