### PR TITLE
Fix task breakdown showing no rows

### DIFF
--- a/web/client/src/components/project/TaskBreakdown.tsx
+++ b/web/client/src/components/project/TaskBreakdown.tsx
@@ -92,7 +92,7 @@ interface TaskBreakdownProps {
 }
 
 function isClosedTask(row: TaskBreakdownRow): boolean {
-  return row.taskStatus !== 'OPEN';
+  return row.taskStatus === 'Inactive';
 }
 
 export function TaskBreakdown({ employeeId, projectNumber, records }: TaskBreakdownProps) {

--- a/web/client/src/test/components/project/ProjectFundingChart.test.tsx
+++ b/web/client/src/test/components/project/ProjectFundingChart.test.tsx
@@ -66,7 +66,7 @@ const createProject = (
   sponsorAwardNumber: null,
   taskName: 'Task 1',
   taskNum: 'T001',
-  taskStatus: 'OPEN',
+  taskStatus: 'Active',
   ...overrides,
 });
 

--- a/web/client/src/test/components/project/ProjectsTable.test.tsx
+++ b/web/client/src/test/components/project/ProjectsTable.test.tsx
@@ -60,7 +60,7 @@ const createProject = (
   sponsorAwardNumber: null,
   taskName: 'Task 1',
   taskNum: 'T001',
-  taskStatus: 'OPEN',
+  taskStatus: 'Active',
   ...overrides,
 });
 

--- a/web/client/src/test/components/project/TaskBreakdown.test.tsx
+++ b/web/client/src/test/components/project/TaskBreakdown.test.tsx
@@ -62,7 +62,7 @@ const createProject = (
   sponsorAwardNumber: null,
   taskName: 'Task 1',
   taskNum: 'T001',
-  taskStatus: 'OPEN',
+  taskStatus: 'Active',
   ...overrides,
 });
 

--- a/web/client/src/test/routes/(authenticated)/project-detail.test.tsx
+++ b/web/client/src/test/routes/(authenticated)/project-detail.test.tsx
@@ -58,7 +58,7 @@ const createProject = (
   sponsorAwardNumber: null,
   taskName: 'Task 1',
   taskNum: 'T001',
-  taskStatus: 'OPEN',
+  taskStatus: 'Active',
   ...overrides,
 });
 


### PR DESCRIPTION
## Summary
- The closed-task filter was checking `taskStatus !== 'OPEN'`, but `FacultyDeptPortfolio.TaskStatus` uses `Active`/`Inactive`
- Every row was treated as closed and hidden by default
- Changed to `taskStatus === 'Inactive'` and updated test fixtures to use realistic values

## Test plan
- [x] All 135 existing tests pass
- [ ] Verify task breakdown rows appear on a project detail page
- [ ] Verify "Show closed" toggle still works for inactive tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed task closure classification to correctly identify closed tasks by status. The "Show/Hide closed" table action now filters based on proper task status values.

* **Tests**
  * Updated test fixtures to align with revised task status definitions and ensure test coverage reflects the corrected behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->