### PR TITLE
Add disclaimer text for internal projects

### DIFF
--- a/web/client/src/routes/(authenticated)/index.tsx
+++ b/web/client/src/routes/(authenticated)/index.tsx
@@ -206,6 +206,11 @@ function RouteComponent() {
           {internalProjects.length > 0 && (
             <div className="mt-4">
               <h2 className="h2">Internal Projects</h2>
+              <p className="text-sm text-base-content/70 mt-1">
+                Totals for internal projects do not reflect transactions that
+                have occurred since the latest data refresh or manual updates
+                that are needed. Contact your fiscal officer with any questions.
+              </p>
               <InternalProjectsTable
                 discrepancies={discrepancies}
                 employeeId={user.employeeId}

--- a/web/client/src/routes/(authenticated)/projects/$employeeId/$projectNumber/index.tsx
+++ b/web/client/src/routes/(authenticated)/projects/$employeeId/$projectNumber/index.tsx
@@ -70,6 +70,13 @@ function ProjectContent({
         <h3 className="subtitle">
           Data source: Faculty Department Portfolio Report (PPM)
         </h3>
+        {summary.isInternal && (
+          <p className="text-sm text-base-content/70 mt-2">
+            Totals for internal projects do not reflect transactions that have
+            occurred since the latest data refresh or manual updates that are
+            needed. Contact your fiscal officer with any questions.
+          </p>
+        )}
         <div className="mt-6">
           <ProjectAlerts
             employeeId={employeeId}

--- a/web/client/src/routes/(authenticated)/projects/$employeeId/index.tsx
+++ b/web/client/src/routes/(authenticated)/projects/$employeeId/index.tsx
@@ -136,6 +136,11 @@ function RouteComponent() {
       {internalProjects.length > 0 && (
         <section className="section-margin">
           <h2 className="h2">Internal Projects</h2>
+          <p className="text-sm text-base-content/70 mt-1">
+            Totals for internal projects do not reflect transactions that have
+            occurred since the latest data refresh or manual updates that are
+            needed. Contact your fiscal officer with any questions.
+          </p>
           <InternalProjectsTable
             discrepancies={discrepancies}
             employeeId={employeeId}


### PR DESCRIPTION
## Summary
- Adds disclaimer text to internal project sections: "Totals for internal projects do not reflect transactions that have occurred since the latest data refresh or manual updates that are needed. Contact your fiscal officer with any questions."
- Displayed on the home page, the employee projects page, and each internal project's detail page

Closes #212

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added informational disclaimers across multiple Internal Projects pages indicating that project totals may be outdated and may not reflect transactions processed since the latest data refresh or manual updates.
  * Users are directed to contact their fiscal officer with questions regarding project data accuracy or discrepancies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->