### PR TITLE
QA findings: Extended Beta fixes

### DIFF
--- a/web/client/src/components/project/InternalProjectsTable.tsx
+++ b/web/client/src/components/project/InternalProjectsTable.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { Link } from '@tanstack/react-router';
 import { createColumnHelper } from '@tanstack/react-table';
 import { ExclamationTriangleIcon } from '@heroicons/react/24/outline';
@@ -19,10 +19,15 @@ interface AggregatedProject {
   projectStatusCode: string;
   taskName: string;
   taskNum: string;
+  taskStatus: string;
   totalBalance: number;
   totalBudget: number;
   totalEncumbrance: number;
   totalExpense: number;
+}
+
+function isInactiveTask(row: AggregatedProject): boolean {
+  return row.taskStatus === 'Inactive';
 }
 
 const columnHelper = createColumnHelper<AggregatedProject>();
@@ -50,6 +55,7 @@ function aggregateProjects(records: ProjectRecord[]): AggregatedProject[] {
         projectStatusCode: p.projectStatusCode,
         taskName: p.taskName,
         taskNum: p.taskNum,
+        taskStatus: p.taskStatus,
         totalBalance: p.balance,
         totalBudget: p.budget,
         totalEncumbrance: p.commitments,
@@ -87,7 +93,17 @@ export function InternalProjectsTable({
   employeeId,
   records,
 }: InternalProjectsTableProps) {
-  const projects = useMemo(() => aggregateProjects(records), [records]);
+  const [showInactive, setShowInactive] = useState(false);
+  const allProjects = useMemo(() => aggregateProjects(records), [records]);
+  const inactiveCount = useMemo(
+    () => allProjects.filter(isInactiveTask).length,
+    [allProjects]
+  );
+  const projects = useMemo(
+    () =>
+      showInactive ? allProjects : allProjects.filter((p) => !isInactiveTask(p)),
+    [allProjects, showInactive]
+  );
 
   const totals = useMemo(
     () =>
@@ -218,7 +234,7 @@ export function InternalProjectsTable({
     [discrepancies, employeeId, totals.totalBalance, totals.totalBudget, totals.totalEncumbrance, totals.totalExpense]
   );
 
-  if (projects.length === 0) {
+  if (allProjects.length === 0) {
     return <p className="text-base-content/70 mt-8">No projects found.</p>;
   }
 
@@ -231,7 +247,18 @@ export function InternalProjectsTable({
         globalFilter="left"
         initialState={{ pagination: { pageSize: 25 } }}
         tableActions={
-          <ExportDataButton columns={csvColumns} data={projects} filename="internal-projects.csv" />
+          <>
+            {inactiveCount > 0 && (
+              <button
+                className={`btn btn-sm ${showInactive ? 'btn-active' : 'btn-default'}`}
+                onClick={() => setShowInactive(!showInactive)}
+                type="button"
+              >
+                {showInactive ? 'Hide' : 'Show'} inactive ({inactiveCount})
+              </button>
+            )}
+            <ExportDataButton columns={csvColumns} data={projects} filename="internal-projects.csv" />
+          </>
         }
       />
     </div>

--- a/web/client/src/components/project/InternalProjectsTable.tsx
+++ b/web/client/src/components/project/InternalProjectsTable.tsx
@@ -6,6 +6,8 @@ import { ExportDataButton } from '@/components/ExportDataButton.tsx';
 import { formatCurrency } from '@/lib/currency.ts';
 import type { ProjectRecord } from '@/queries/project.ts';
 import { DataTable } from '@/shared/DataTable.tsx';
+import { TooltipLabel } from '@/shared/TooltipLabel.tsx';
+import { tooltipDefinitions } from '@/shared/tooltips.ts';
 
 interface AggregatedProject {
   displayName: string;
@@ -186,7 +188,15 @@ export function InternalProjectsTable({
             {formatCurrency(totals.totalEncumbrance)}
           </span>
         ),
-        header: () => <span className="flex justify-end">Commitment</span>,
+        header: () => (
+          <span className="flex justify-end w-full">
+            <TooltipLabel
+              label="Commitment"
+              placement="bottom"
+              tooltip={tooltipDefinitions.commitment}
+            />
+          </span>
+        ),
       }),
       columnHelper.accessor('totalBalance', {
         cell: (info) => {

--- a/web/client/src/components/project/SponsoredProjectsTable.tsx
+++ b/web/client/src/components/project/SponsoredProjectsTable.tsx
@@ -6,6 +6,8 @@ import { formatCurrency } from '@/lib/currency.ts';
 import { formatDate } from '@/lib/date.ts';
 import type { ProjectRecord } from '@/queries/project.ts';
 import { DataTable } from '@/shared/DataTable.tsx';
+import { TooltipLabel } from '@/shared/TooltipLabel.tsx';
+import { tooltipDefinitions } from '@/shared/tooltips.ts';
 
 interface AggregatedProject {
   awardEndDate: string | null;
@@ -252,7 +254,15 @@ export function SponsoredProjectsTable({
             {formatCurrency(totals.totalEncumbrance)}
           </span>
         ),
-        header: () => <span className="flex justify-end">Commitment</span>,
+        header: () => (
+          <span className="flex justify-end w-full">
+            <TooltipLabel
+              label="Commitment"
+              placement="bottom"
+              tooltip={tooltipDefinitions.commitment}
+            />
+          </span>
+        ),
       }),
       columnHelper.accessor('totalBalance', {
         cell: (info) => {

--- a/web/client/src/routes/(authenticated)/personnel.tsx
+++ b/web/client/src/routes/(authenticated)/personnel.tsx
@@ -8,10 +8,6 @@ import { PageLoading } from '@/components/states/PageLoading.tsx';
 import { PageEmpty } from '@/components/states/PageEmpty.tsx';
 import { PageError } from '@/components/states/PageError.tsx';
 import { getErrorPresentation } from '@/lib/errorPresentation.ts';
-import {
-  ClipboardDocumentListIcon,
-  UsersIcon,
-} from '@heroicons/react/24/outline';
 
 export const Route = createFileRoute('/(authenticated)/personnel')({
   component: RouteComponent,
@@ -78,22 +74,6 @@ function RouteComponent() {
       <h3 className="subtitle">
         {uniqueEmployees} employees across {uniqueProjects} projects
       </h3>
-
-      {/* Summary Cards */}
-      <div className="fancy-data">
-        <dl className="grid items-stretch gap-6 md:gap-8 grid-cols-1 md:grid-cols-2">
-          <div>
-            <UsersIcon className="w-4 h-4" />
-            <dt className="stat-label">Personnel</dt>
-            <dd className="stat-value">{uniqueEmployees}</dd>
-          </div>
-          <div>
-            <ClipboardDocumentListIcon className="w-4 h-4" />
-            <dt className="stat-label">Projects</dt>
-            <dd className="stat-value">{uniqueProjects}</dd>
-          </div>
-        </dl>
-      </div>
 
       {/* Personnel Table */}
       <PersonnelTable data={data} />

--- a/web/client/src/routes/(authenticated)/reports/reconciliation/$projectNumber/detail.tsx
+++ b/web/client/src/routes/(authenticated)/reports/reconciliation/$projectNumber/detail.tsx
@@ -160,6 +160,7 @@ const glColumns = [
       </span>
     ),
     header: 'Date',
+    size: 80,
   }),
   glColumnHelper.display({
     cell: (info) => (
@@ -169,6 +170,7 @@ const glColumns = [
     ),
     header: 'Chart String',
     id: 'chartString',
+    size: 220,
   }),
   glColumnHelper.accessor('journalName', {
     cell: (info) => <span className="text-sm">{info.getValue() ?? '-'}</span>,
@@ -197,6 +199,7 @@ const glColumns = [
       </span>
     ),
     header: () => <span className="flex justify-end">Amount</span>,
+    size: 90,
   }),
 ];
 

--- a/web/client/src/shared/DataTable.tsx
+++ b/web/client/src/shared/DataTable.tsx
@@ -271,6 +271,13 @@ export const DataTable = <TData extends object>({
           </div>
         ) : null}
 
+        {showPaginationControls ? (
+          <span className="text-sm text-base-content/70">
+            Showing {table.getRowModel().rows.length} of{' '}
+            {table.getFilteredRowModel().rows.length}
+          </span>
+        ) : null}
+
         <div
           className={
             isOverlayActive ? 'flex-1 min-h-0 overflow-auto' : 'overflow-x-auto'

--- a/web/client/src/shared/DataTable.tsx
+++ b/web/client/src/shared/DataTable.tsx
@@ -131,14 +131,15 @@ export const DataTable = <TData extends object>({
   const hasExpandableRows = expandableRows.length > 0;
   const areAllExpandableRowsExpanded =
     hasExpandableRows && expandableRows.every((row) => row.getIsExpanded());
+  const showFooter = hasAnyFooter(columns);
+  const showPaginationControls =
+    pagination === 'on' || (pagination === 'auto' && table.getPageCount() > 1);
   const shouldShowToolbar =
     globalFilter !== 'none' ||
     expandable ||
     tableActions ||
+    showPaginationControls ||
     (rowExpansionEnabled && hasExpandableRows);
-  const showFooter = hasAnyFooter(columns);
-  const showPaginationControls =
-    pagination === 'on' || (pagination === 'auto' && table.getPageCount() > 1);
   const filterValue = table.getState().globalFilter ?? '';
   const hasFilterValue = filterValue !== '';
 
@@ -179,51 +180,57 @@ export const DataTable = <TData extends object>({
       >
         {shouldShowToolbar ? (
           <div className="grid grid-cols-[1fr_auto] items-center gap-2">
-            {globalFilter !== 'none' ? (
-              <label className="input input-bordered flex items-center gap-2 max-w-sm">
-                <svg
-                  className="h-[1em] opacity-50"
-                  viewBox="0 0 24 24"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <g
-                    fill="none"
-                    stroke="currentColor"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth="2.5"
+            <div className="flex items-center gap-3 min-w-0">
+              {globalFilter !== 'none' ? (
+                <label className="input input-bordered flex items-center gap-2 max-w-sm flex-1">
+                  <svg
+                    className="h-[1em] opacity-50"
+                    viewBox="0 0 24 24"
+                    xmlns="http://www.w3.org/2000/svg"
                   >
-                    <circle cx="11" cy="11" r="8"></circle>
-                    <path d="m21 21-4.3-4.3"></path>
-                  </g>
-                </svg>
-                <input
-                  className="grow"
-                  onChange={(e) => table.setGlobalFilter(e.target.value)}
-                  placeholder={filterPlaceholder}
-                  type="text"
-                  value={filterValue}
-                />
-                {hasFilterValue ? (
-                  <button
-                    className="btn btn-ghost btn-sm btn-circle"
-                    onClick={() => table.setGlobalFilter('')}
-                    type="button"
-                  >
-                    <svg
-                      className="h-4 w-4"
-                      fill="currentColor"
-                      viewBox="0 0 16 16"
-                      xmlns="http://www.w3.org/2000/svg"
+                    <g
+                      fill="none"
+                      stroke="currentColor"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth="2.5"
                     >
-                      <path d="M5.28 4.22a.75.75 0 0 0-1.06 1.06L6.94 8l-2.72 2.72a.75.75 0 1 0 1.06 1.06L8 9.06l2.72 2.72a.75.75 0 1 0 1.06-1.06L9.06 8l2.72-2.72a.75.75 0 0 0-1.06-1.06L8 6.94 5.28 4.22Z" />
-                    </svg>
-                  </button>
-                ) : null}
-              </label>
-            ) : (
-              <div />
-            )}
+                      <circle cx="11" cy="11" r="8"></circle>
+                      <path d="m21 21-4.3-4.3"></path>
+                    </g>
+                  </svg>
+                  <input
+                    className="grow"
+                    onChange={(e) => table.setGlobalFilter(e.target.value)}
+                    placeholder={filterPlaceholder}
+                    type="text"
+                    value={filterValue}
+                  />
+                  {hasFilterValue ? (
+                    <button
+                      className="btn btn-ghost btn-sm btn-circle"
+                      onClick={() => table.setGlobalFilter('')}
+                      type="button"
+                    >
+                      <svg
+                        className="h-4 w-4"
+                        fill="currentColor"
+                        viewBox="0 0 16 16"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path d="M5.28 4.22a.75.75 0 0 0-1.06 1.06L6.94 8l-2.72 2.72a.75.75 0 1 0 1.06 1.06L8 9.06l2.72 2.72a.75.75 0 1 0 1.06-1.06L9.06 8l2.72-2.72a.75.75 0 0 0-1.06-1.06L8 6.94 5.28 4.22Z" />
+                      </svg>
+                    </button>
+                  ) : null}
+                </label>
+              ) : null}
+              {showPaginationControls ? (
+                <span className="text-sm text-base-content/70 whitespace-nowrap">
+                  Showing {table.getRowModel().rows.length} of{' '}
+                  {table.getFilteredRowModel().rows.length}
+                </span>
+              ) : null}
+            </div>
 
             <div className="flex items-center gap-2">
               {tableActions}
@@ -269,13 +276,6 @@ export const DataTable = <TData extends object>({
               ) : null}
             </div>
           </div>
-        ) : null}
-
-        {showPaginationControls ? (
-          <span className="text-sm text-base-content/70">
-            Showing {table.getRowModel().rows.length} of{' '}
-            {table.getFilteredRowModel().rows.length}
-          </span>
         ) : null}
 
         <div

--- a/web/client/src/test/routes/(authenticated)/personnel.test.tsx
+++ b/web/client/src/test/routes/(authenticated)/personnel.test.tsx
@@ -99,10 +99,6 @@ describe('personnel page', () => {
       expect(
         screen.getByText('2 employees across 2 projects')
       ).toBeInTheDocument();
-
-      // Summary cards should show correct counts
-      const employeeCards = screen.getAllByText('2');
-      expect(employeeCards.length).toBeGreaterThanOrEqual(2); // In card and subtitle
     } finally {
       cleanup();
     }


### PR DESCRIPTION
## Summary

Addresses the QA checklist items from #210:

- **Commitment tooltip** — adds the tooltip to the Sponsored and Internal project tables on the Projects Dashboard (previously only present in Task Breakdown / Financial Details)
- **"Showing X of Y" row count** — displays above paginated tables, placed in the toolbar on the same line as search and export, only when more than one page exists
- **Personnel page summary cards removed** — the cards duplicated the subtitle's "{X} employees across {Y} projects" line
- **Inactive task toggle on Internal Projects** — hides inactive tasks by default with a "Show/Hide inactive (N)" toggle, matching the existing Task Breakdown pattern; totals recalculate based on visible rows
- **GL Transactions column widths** — narrowed Date and Amount, widened Chart String

Fixes #210

## Test plan
- [ ] Projects Dashboard: hover the Commitment column header on both Sponsored and Internal tables — tooltip appears
- [ ] Any paginated table: confirm "Showing X of Y" appears next to the search box when there are multiple pages, and is hidden on single-page tables
- [ ] `/personnel`: confirm the summary cards are gone and the subtitle still shows counts
- [ ] Projects Dashboard → Internal Projects: confirm inactive tasks are hidden by default and the "Show inactive (N)" button appears when any exist; toggling reveals them and updates the totals row
- [ ] Reports → Reconciliation → Project → GL Transactions: confirm Date / Amount are tighter and Chart String has more room

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Toggle to show/hide inactive projects with a live count
  * Record count summary in table toolbar ("Showing X of Y")

* **UI Enhancements**
  * Tooltips added to "Commitment" column headers across project tables
  * Adjusted column widths in GL reports for improved readability

* **Bug Fixes**
  * Empty-state now appears only when no records exist

* **Removed**
  * Summary cards removed from personnel page
<!-- end of auto-generated comment: release notes by coderabbit.ai -->