### PR TITLE
Exclude carryforward docs from GL transaction listings

### DIFF
--- a/datamart/StoredProcedures/usp_GetGLTransactionListings.sql
+++ b/datamart/StoredProcedures/usp_GetGLTransactionListings.sql
@@ -43,6 +43,7 @@ BEGIN
     DECLARE @Duration_MS INT;
     DECLARE @ErrorMsg NVARCHAR(MAX);
     DECLARE @ParametersJSON NVARCHAR(MAX);
+    DECLARE @ExcludedDocNumbers NVARCHAR(MAX);
 
     -- Sanitize ApplicationName for injection protection (whitelist: alphanumeric + spaces only)
     EXEC dbo.usp_SanitizeInputString @ApplicationName OUTPUT;
@@ -72,6 +73,13 @@ BEGIN
 
     IF @EndDate IS NOT NULL
         SET @FilterClause = @FilterClause + ' AND tlr.journal_acct_date <= ''' + CONVERT(VARCHAR(10), @EndDate, 120) + '''';
+
+    -- Exclude carryforward document numbers (same exclusion as usp_GetGLPPMReconciliation)
+    SELECT @ExcludedDocNumbers = STRING_AGG('''' + CAST(DocumentNumber AS VARCHAR(10)) + '''', ', ')
+    FROM dbo.CarryforwardDocumentNumbers;
+
+    IF @ExcludedDocNumbers IS NOT NULL
+        SET @FilterClause = @FilterClause + ' AND tlr.ACCOUNTING_SEQUENCE_NUMBER NOT IN (' + @ExcludedDocNumbers + ')';
 
     -- Build Redshift query with explicit column list
     SET @RedshiftQuery = '


### PR DESCRIPTION
## Summary
- `usp_GetGLTransactionListings` now applies the same `dbo.CarryforwardDocumentNumbers` exclusion that `usp_GetGLPPMReconciliation` already uses.
- Transaction listing totals will match the GL side of the reconciliation screen for a given project (when no date range is applied).

## Why
Reconciliation filters out rows whose `ACCOUNTING_SEQUENCE_NUMBER` appears in `CarryforwardDocumentNumbers`, but the transaction detail view did not. Users comparing the two screens saw unexplained deltas driven by carryforward docs.

## Test plan
- [ ] Run `EXEC dbo.usp_GetGLTransactionListings @ProjectIds = '<project with carryforward docs>'` and confirm excluded `ACCOUNTING_SEQUENCE_NUMBER`s do not appear.
- [ ] Sum `ACTUAL_AMOUNT` from the listing for a project and confirm it matches `GL_ACTUAL_AMOUNT` for that project from `usp_GetGLPPMReconciliation` (no date range).
- [ ] Spot-check a project with no carryforward docs to confirm results are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * GL transaction listings now correctly exclude carryforward document entries from results

<!-- end of auto-generated comment: release notes by coderabbit.ai -->