### PR TITLE
Deduplicate pgm_master_data in project summary

### DIFF
--- a/datamart/StoredProcedures/usp_GetProjectSummary.sql
+++ b/datamart/StoredProcedures/usp_GetProjectSummary.sql
@@ -57,25 +57,40 @@ BEGIN
 
     -- Build Redshift query for award metadata (pgm_master_data is still remote)
     SET @RedshiftQuery = '
+        WITH ranked AS (
+            SELECT *,
+                ROW_NUMBER() OVER (
+                    PARTITION BY project_number, award_number
+                    ORDER BY project_burden_cost_rate DESC NULLS LAST, contract_line_number ASC NULLS LAST
+                ) AS rn
+            FROM ae_dwh.pgm_master_data
+            WHERE project_number IN (' + @ProjectIdFilter + ')
+        ),
+        best AS (
+            SELECT * FROM ranked WHERE rn = 1
+        )
         SELECT
-            project_number, award_number,
-            close_date AS award_close_date,
-            LISTAGG(DISTINCT principal_investigator_person_name, ''; '') WITHIN GROUP (ORDER BY 1) AS award_pi,
-            billing_cycle, project_burden_schedule_base, project_burden_cost_rate,
-            cost_share_required_by_sponsor,
-            LISTAGG(DISTINCT grant_administrator, ''; '') WITHIN GROUP (ORDER BY 1) AS grant_administrator,
-            postrepperiod AS post_reporting_period,
-            primary_sponsor_name,
+            b.project_number, b.award_number,
+            b.close_date AS award_close_date,
+            LISTAGG(DISTINCT a.principal_investigator_person_name, ''; '') WITHIN GROUP (ORDER BY 1) AS award_pi,
+            b.billing_cycle,
+            b.project_burden_schedule_base,
+            b.project_burden_cost_rate,
+            b.cost_share_required_by_sponsor,
+            LISTAGG(DISTINCT a.grant_administrator, ''; '') WITHIN GROUP (ORDER BY 1) AS grant_administrator,
+            b.postrepperiod AS post_reporting_period,
+            b.primary_sponsor_name,
             '''' AS project_fund,
-            LISTAGG(DISTINCT contractadmin, ''; '') WITHIN GROUP (ORDER BY 1) AS contract_administrator,
-            sponsor_award_number
-        FROM ae_dwh.pgm_master_data
-        WHERE project_number IN (' + @ProjectIdFilter + ')
+            LISTAGG(DISTINCT a.contractadmin, ''; '') WITHIN GROUP (ORDER BY 1) AS contract_administrator,
+            b.sponsor_award_number
+        FROM best b
+        JOIN ae_dwh.pgm_master_data a
+            ON a.project_number = b.project_number AND a.award_number = b.award_number
         GROUP BY
-            project_number, award_number, close_date, billing_cycle,
-            project_burden_schedule_base, project_burden_cost_rate,
-            cost_share_required_by_sponsor, postrepperiod, primary_sponsor_name,
-            sponsor_award_number';
+            b.project_number, b.award_number, b.close_date, b.billing_cycle,
+            b.project_burden_schedule_base, b.project_burden_cost_rate,
+            b.cost_share_required_by_sponsor, b.postrepperiod, b.primary_sponsor_name,
+            b.sponsor_award_number';
 
     -- Build parameters JSON for logging
     SET @ParametersJSON = (

--- a/web/client/src/routes/(authenticated)/projects/$employeeId/index.tsx
+++ b/web/client/src/routes/(authenticated)/projects/$employeeId/index.tsx
@@ -19,6 +19,8 @@ import {
   UsersIcon,
 } from '@heroicons/react/24/outline';
 import { ProjectFundingChart } from '@/components/project/ProjectFundingChart.tsx';
+import { TooltipLabel } from '@/shared/TooltipLabel.tsx';
+import { tooltipDefinitions } from '@/shared/tooltips.ts';
 
 export const Route = createFileRoute('/(authenticated)/projects/$employeeId/')({
   component: RouteComponent,
@@ -103,14 +105,24 @@ function RouteComponent() {
             </div>
             <div className="flex flex-col">
               <ClipboardDocumentCheckIcon className="w-4 h-4" />
-              <dt className="stat-label-lg">Total Budget</dt>
+              <dt className="stat-label-lg">
+                <TooltipLabel
+                  label="Total Budget"
+                  tooltip={tooltipDefinitions.totalBudget}
+                />
+              </dt>
               <dd className="stat-value-lg">
                 {summary ? <Currency value={summary.totals.budget} /> : '...'}
               </dd>
             </div>
             <div className="flex flex-col">
               <BanknotesIcon className="w-4 h-4" />
-              <dt className="stat-label-lg">Balance</dt>
+              <dt className="stat-label-lg">
+                <TooltipLabel
+                  label="Balance"
+                  tooltip={tooltipDefinitions.totalBalance}
+                />
+              </dt>
               <dd className="stat-value-lg">
                 {summary ? <Currency value={summary.totals.balance} /> : '...'}
               </dd>

--- a/web/client/src/shared/tooltips.ts
+++ b/web/client/src/shared/tooltips.ts
@@ -11,6 +11,10 @@ export const tooltipDefinitions = {
   cbr: 'Monthly composite benefit rate cost, including fringe/benefit burden.',
   taskBreakdown:
     'Summary of how project costs are organized by financial coding segments.',
+  totalBudget:
+    'Total PPM budget across all active and expired projects. Closed projects are excluded.',
+  totalBalance:
+    'Total remaining balance (budget minus expenses and commitments) across all active and expired projects. Closed projects are excluded.',
   commitment:
     'Commitment / Encumbrance are funds set aside when a requisition is fully approved; it is automatically released when the associated purchase order is created (or when an approved requisition is canceled before PO creation).',
   contractAdministrator:


### PR DESCRIPTION
## Summary
- Fixes duplicate rows in `usp_GetProjectSummary` caused by multiple `pgm_master_data` entries per project+award (differing by contract line / burden rate)
- Uses `ROW_NUMBER()` to pick one row per project+award, ordered by highest `project_burden_cost_rate` then lowest `contract_line_number`
- `LISTAGG(DISTINCT)` still aggregates PI, grant admin, and contract admin names across all rows for that project+award
- Adds tooltips to project summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Project summary data retrieval now consistently returns the single best result per project and award combination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->