### PR TITLE
Lookup Kerberos ID via IAM instead of Entra

### DIFF
--- a/web/server.core/Domain/User.cs
+++ b/web/server.core/Domain/User.cs
@@ -14,7 +14,7 @@ public class User
     public Guid Id { get; set; }
 
     /// <summary>
-    /// Kerberos ID - will be looked up via Entra.
+    /// Kerberos ID - will be looked up via IAM.
     /// </summary>
     [Required]
     [MaxLength(20)]

--- a/web/server.core/Services/IdentityService.cs
+++ b/web/server.core/Services/IdentityService.cs
@@ -8,6 +8,8 @@ namespace server.core.Services;
 public interface IIdentityService
 {
     Task<IamIdentity?> GetByIamId(string iamId);
+
+    Task<string?> GetKerberosByIamId(string iamId);
 }
 
 public sealed class IdentityService : IIdentityService
@@ -47,6 +49,24 @@ public sealed class IdentityService : IIdentityService
         // should only be one result for a given IAM ID, so just take the first
         var person = results.First();
         return new IamIdentity(person.IamId, person.EmployeeId, person.FullName);
+    }
+
+    public async Task<string?> GetKerberosByIamId(string iamId)
+    {
+        if (string.IsNullOrWhiteSpace(iamId))
+        {
+            throw new ArgumentException("IAM ID is required.", nameof(iamId));
+        }
+
+        var kerberosResponse = await _ietClient.Kerberos.Get(iamId);
+        var results = kerberosResponse.ResponseData?.Results;
+
+        if (results is null || results.Length == 0)
+        {
+            return null;
+        }
+
+        return results.First().UserId;
     }
 
 }

--- a/web/server/Controllers/AdminUsersController.cs
+++ b/web/server/Controllers/AdminUsersController.cs
@@ -139,11 +139,6 @@ public sealed class AdminUsersController : ApiControllerBase
             return NotFound();
         }
 
-        if (string.IsNullOrWhiteSpace(profile.Kerberos))
-        {
-            return BadRequest("Kerberos extension attribute is missing for the selected user.");
-        }
-
         if (string.IsNullOrWhiteSpace(profile.IamId))
         {
             return BadRequest("IAMID extension attribute is missing for the selected user.");
@@ -170,10 +165,26 @@ public sealed class AdminUsersController : ApiControllerBase
             return BadRequest($"Employee ID is missing for IAM ID '{profile.IamId}'.");
         }
 
+        string? kerberos;
+        try
+        {
+            kerberos = await _identityService.GetKerberosByIamId(profile.IamId);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to retrieve Kerberos for IAM ID '{IamId}'.", profile.IamId);
+            return StatusCode(StatusCodes.Status502BadGateway);
+        }
+
+        if (string.IsNullOrWhiteSpace(kerberos))
+        {
+            return BadRequest($"Kerberos is missing for IAM ID '{profile.IamId}'.");
+        }
+
         var userProfile = new UserProfileData
         {
             UserId = entraUserId,
-            Kerberos = profile.Kerberos,
+            Kerberos = kerberos,
             IamId = profile.IamId,
             EmployeeId = iamIdentity.EmployeeId,
             DisplayName = iamIdentity.FullName ?? profile.DisplayName,

--- a/web/server/Services/EntraUserAttributeService.cs
+++ b/web/server/Services/EntraUserAttributeService.cs
@@ -13,7 +13,7 @@ public interface IEntraUserAttributeService
     Task<EntraUserAttributes?> GetAttributesAsync(string userId, ClaimsPrincipal principal, CancellationToken cancellationToken = default);
 }
 
-public record EntraUserAttributes(string? Kerberos, string? IamId);
+public record EntraUserAttributes(string? IamId);
 
 public class EntraUserAttributeService : IEntraUserAttributeService
 {
@@ -73,9 +73,7 @@ public class EntraUserAttributeService : IEntraUserAttributeService
                 return null;
             }
 
-            return new EntraUserAttributes(
-                Kerberos: extensions.ExtensionAttribute13,
-                IamId: extensions.ExtensionAttribute7);
+            return new EntraUserAttributes(IamId: extensions.ExtensionAttribute7);
         }
         catch (Exception ex)
         {

--- a/web/server/Services/GraphService.cs
+++ b/web/server/Services/GraphService.cs
@@ -38,7 +38,6 @@ public sealed record GraphUserProfile(
     string Id,
     string? DisplayName,
     string? Email,
-    string? Kerberos,
     string? IamId);
 
 public sealed class GraphService : IGraphService
@@ -457,7 +456,6 @@ public sealed class GraphService : IGraphService
                 Id: user.Id,
                 DisplayName: user.DisplayName,
                 Email: user.Mail ?? user.UserPrincipalName,
-                Kerberos: extensions?.ExtensionAttribute13,
                 IamId: extensions?.ExtensionAttribute7);
         }
         catch (ApiException ex) when (ex.ResponseStatusCode == 404)

--- a/web/server/Services/UserProfileOrchestrator.cs
+++ b/web/server/Services/UserProfileOrchestrator.cs
@@ -46,17 +46,6 @@ public sealed class UserProfileOrchestrator : IUserProfileOrchestrator
 
         var attributes = await _attributeService.GetAttributesAsync(userObjectId, principal, cancellationToken);
 
-        var kerberos = !string.IsNullOrWhiteSpace(attributes?.Kerberos)
-            ? attributes!.Kerberos
-            : existingUser?.Kerberos;
-
-        if (string.IsNullOrWhiteSpace(kerberos))
-        {
-            throw new InvalidOperationException(existingUser == null
-                ? $"Kerberos extension attribute is missing for new user {userId}."
-                : $"Kerberos extension attribute missing for {userId} and no stored value was found.");
-        }
-
         if (attributes == null && existingUser != null)
         {
             _logger.LogWarning("Falling back to stored profile for user {UserId} because Entra attributes could not be loaded.", userId);
@@ -90,6 +79,21 @@ public sealed class UserProfileOrchestrator : IUserProfileOrchestrator
         else if (iamIdentity == null)
         {
             throw new InvalidOperationException($"IAM identity lookup failed for IAM ID '{iamId}'.");
+        }
+
+        string? kerberos = null;
+        try
+        {
+            kerberos = await _identityService.GetKerberosByIamId(iamId);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to retrieve Kerberos for IAM ID '{IamId}'.", iamId);
+        }
+
+        if (string.IsNullOrWhiteSpace(kerberos))
+        {
+            throw new InvalidOperationException($"Kerberos lookup failed for IAM ID '{iamId}'.");
         }
 
         var employeeId = iamIdentity?.EmployeeId ?? existingUser?.EmployeeId;

--- a/web/tests/server.tests/Controllers/AdminUsersControllerTests.cs
+++ b/web/tests/server.tests/Controllers/AdminUsersControllerTests.cs
@@ -42,7 +42,6 @@ public sealed class AdminUsersControllerTests
             Id: entraUserId.ToString(),
             DisplayName: "Graph User",
             Email: "graph.user@example.com",
-            Kerberos: "guser",
             IamId: "IAM-123");
 
         var controller = CreateController(ctx, grantingUser.Id, graphProfile);
@@ -58,7 +57,7 @@ public sealed class AdminUsersControllerTests
         firstPayload.Added.Should().BeTrue();
         firstPayload.User.Id.Should().Be(entraUserId);
         firstPayload.User.Roles.Should().Contain(Role.Names.AccrualViewer);
-        firstPayload.User.Kerberos.Should().Be(graphProfile.Kerberos);
+        firstPayload.User.Kerberos.Should().Be("guser");
         firstPayload.User.IamId.Should().Be(graphProfile.IamId);
         firstPayload.User.EmployeeId.Should().Be("E12345");
         firstPayload.User.Name.Should().Be("Iam FullName");
@@ -105,7 +104,6 @@ public sealed class AdminUsersControllerTests
             Id: entraUserId.ToString(),
             DisplayName: "Graph User",
             Email: "graph.user@example.com",
-            Kerberos: "guser",
             IamId: "IAM-123");
 
         var controller = CreateController(ctx, grantingUser.Id, graphProfile);
@@ -118,11 +116,55 @@ public sealed class AdminUsersControllerTests
         result.Result.Should().BeOfType<BadRequestObjectResult>();
     }
 
-    private static AdminUsersController CreateController(AppDbContext ctx, Guid grantingUserId, GraphUserProfile graphProfile)
+    [Fact]
+    public async Task AssignRole_rejects_when_iam_kerberos_is_missing()
+    {
+        using AppDbContext ctx = TestDbContextFactory.CreateInMemory();
+
+        var grantingUser = new User
+        {
+            Id = Guid.NewGuid(),
+            Kerberos = "manager",
+            IamId = "IAM-MANAGER",
+            EmployeeId = "E-MANAGER",
+        };
+
+        ctx.Users.Add(grantingUser);
+        ctx.Roles.Add(new Role { Name = Role.Names.AccrualViewer });
+        await ctx.SaveChangesAsync();
+
+        var entraUserId = Guid.NewGuid();
+
+        var graphProfile = new GraphUserProfile(
+            Id: entraUserId.ToString(),
+            DisplayName: "Graph User",
+            Email: "graph.user@example.com",
+            IamId: "IAM-NO-KERB");
+
+        var controller = CreateController(
+            ctx,
+            grantingUser.Id,
+            graphProfile,
+            kerberosByIamId: new Dictionary<string, string?>());
+
+        var result = await controller.AssignRole(
+            entraUserId,
+            new AdminUsersController.AssignRoleRequest(Role.Names.AccrualViewer),
+            CancellationToken.None);
+
+        result.Result.Should().BeOfType<BadRequestObjectResult>()
+            .Which.Value.Should().Be("Kerberos is missing for IAM ID 'IAM-NO-KERB'.");
+    }
+
+    private static AdminUsersController CreateController(
+        AppDbContext ctx,
+        Guid grantingUserId,
+        GraphUserProfile graphProfile,
+        IReadOnlyDictionary<string, string?>? kerberosByIamId = null)
     {
         var graphService = new FakeGraphService(graphProfile);
         var userService = new UserService(NullLogger<UserService>.Instance, ctx);
-        var identityService = new FakeIdentityService();
+        var identityService = new FakeIdentityService(kerberosByIamId: kerberosByIamId);
 
         var controller = new AdminUsersController(
             graphService,
@@ -191,6 +233,16 @@ public sealed class AdminUsersControllerTests
 
     private sealed class FakeIdentityService : IIdentityService
     {
+        private readonly IReadOnlyDictionary<string, string?> _kerberosByIamId;
+
+        public FakeIdentityService(IReadOnlyDictionary<string, string?>? kerberosByIamId = null)
+        {
+            _kerberosByIamId = kerberosByIamId ?? new Dictionary<string, string?>
+            {
+                ["IAM-123"] = "guser",
+            };
+        }
+
         public Task<IamIdentity?> GetByIamId(string iamId)
         {
             if (iamId == "IAM-123")
@@ -198,7 +250,19 @@ public sealed class AdminUsersControllerTests
                 return Task.FromResult<IamIdentity?>(new IamIdentity(iamId, "E12345", "Iam FullName"));
             }
 
+            if (iamId == "IAM-NO-KERB")
+            {
+                return Task.FromResult<IamIdentity?>(new IamIdentity(iamId, "E12345", "Iam FullName"));
+            }
+
             return Task.FromResult<IamIdentity?>(null);
+        }
+
+        public Task<string?> GetKerberosByIamId(string iamId)
+        {
+            return Task.FromResult(_kerberosByIamId.TryGetValue(iamId, out var kerberos)
+                ? kerberos
+                : null);
         }
     }
 }

--- a/web/tests/server.tests/Controllers/SearchControllerTests.cs
+++ b/web/tests/server.tests/Controllers/SearchControllerTests.cs
@@ -120,7 +120,7 @@ public sealed class SearchControllerTests
             authorizationService,
             graphService,
             new FakeIdentityService(),
-            roles: [Role.Names.ProjectManager]);
+            roles: [Role.Names.FinancialViewer]);
 
         var result = await controller.SearchPeople("spang", CancellationToken.None);
         var payload = result.Should().BeOfType<OkObjectResult>().Which.Value
@@ -149,7 +149,7 @@ public sealed class SearchControllerTests
             authorizationService,
             graphService,
             new FakeIdentityService(),
-            roles: [Role.Names.ProjectManager]);
+            roles: [Role.Names.FinancialViewer]);
 
         var result = await controller.SearchPeople("person", CancellationToken.None);
         var payload = result.Should().BeOfType<OkObjectResult>().Which.Value
@@ -171,7 +171,6 @@ public sealed class SearchControllerTests
                     Id: "id-esspang",
                     DisplayName: "Edward Spang",
                     Email: "esspang@ucdavis.edu",
-                    Kerberos: "esspang",
                     IamId: "IAM-ESSPANG"),
             });
         var identityService = new FakeIdentityService(
@@ -185,7 +184,7 @@ public sealed class SearchControllerTests
             authorizationService,
             graphService,
             identityService,
-            roles: [Role.Names.ProjectManager]);
+            roles: [Role.Names.FinancialViewer]);
 
         var result = await controller.ResolvePersonByDirectoryId("id-esspang", CancellationToken.None);
         var payload = result.Should().BeOfType<OkObjectResult>().Which.Value
@@ -324,6 +323,11 @@ public sealed class SearchControllerTests
             return Task.FromResult(_identities.TryGetValue(iamId, out var identity)
                 ? identity
                 : null);
+        }
+
+        public Task<string?> GetKerberosByIamId(string iamId)
+        {
+            return Task.FromResult<string?>(null);
         }
     }
 }

--- a/web/tests/server.tests/Services/IdentityServiceTests.cs
+++ b/web/tests/server.tests/Services/IdentityServiceTests.cs
@@ -1,0 +1,73 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using FluentAssertions;
+using Ietws;
+using Microsoft.Extensions.Options;
+using server.core.Services;
+
+namespace server.tests.Services;
+
+public sealed class IdentityServiceTests
+{
+    [Fact]
+    public async Task GetKerberosByIamId_returns_user_id_from_kerberos_response()
+    {
+        var responsePayload = new KerberosResults
+        {
+            ResponseStatus = 200,
+            ResponseData = new ResponseData<KerberosResult>
+            {
+                Results =
+                [
+                    new KerberosResult
+                    {
+                        IamId = "IAM-123",
+                        UserId = "guser",
+                    },
+                ],
+            },
+        };
+
+        using var httpClient = new HttpClient(new StubHttpMessageHandler(_ => CreateJsonResponse(responsePayload)))
+        {
+            BaseAddress = new Uri("https://iam.example"),
+        };
+
+        var service = new IdentityService(
+            httpClient,
+            Options.Create(new IamSettings { ApiKey = "test-api-key" }));
+
+        var kerberos = await service.GetKerberosByIamId("IAM-123");
+
+        kerberos.Should().Be("guser");
+    }
+
+    private static HttpResponseMessage CreateJsonResponse<T>(T payload)
+    {
+        return new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(
+                JsonSerializer.Serialize(payload),
+                Encoding.UTF8,
+                "application/json"),
+        };
+    }
+
+    private sealed class StubHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, HttpResponseMessage> _responseFactory;
+
+        public StubHttpMessageHandler(Func<HttpRequestMessage, HttpResponseMessage> responseFactory)
+        {
+            _responseFactory = responseFactory;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            return Task.FromResult(_responseFactory(request));
+        }
+    }
+}

--- a/web/tests/server.tests/Services/UserProfileOrchestratorTests.cs
+++ b/web/tests/server.tests/Services/UserProfileOrchestratorTests.cs
@@ -1,0 +1,254 @@
+using System.Reflection;
+using System.Security.Claims;
+using AggieEnterpriseApi;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Identity.Web;
+using Server.Services;
+using Server.Tests;
+using server.core.Data;
+using server.core.Domain;
+using server.core.Services;
+using server.Services;
+using StrawberryShake;
+
+namespace server.tests.Services;
+
+public sealed class UserProfileOrchestratorTests
+{
+    [Fact]
+    public async Task EnsureUserProfileAsync_uses_iam_kerberos_and_persists_user()
+    {
+        using AppDbContext ctx = TestDbContextFactory.CreateInMemory();
+        ctx.Roles.Add(new Role { Name = Role.Names.ProjectManager });
+        await ctx.SaveChangesAsync();
+
+        var userId = Guid.NewGuid();
+        var principal = CreatePrincipal(userId, "person@ucdavis.edu");
+
+        var orchestrator = new UserProfileOrchestrator(
+            new FakeEntraUserAttributeService(new EntraUserAttributes("IAM-123")),
+            new FakeIdentityService(
+                iamIdentity: new IamIdentity("IAM-123", "E12345", "Iam FullName"),
+                kerberosByIamId: new Dictionary<string, string?> { ["IAM-123"] = "guser" }),
+            new UserService(NullLogger<UserService>.Instance, ctx),
+            new FakeFinancialApiService(),
+            NullLogger<UserProfileOrchestrator>.Instance);
+
+        var profile = await orchestrator.EnsureUserProfileAsync(
+            userId,
+            userId.ToString(),
+            principal,
+            CancellationToken.None);
+
+        profile.Kerberos.Should().Be("guser");
+        profile.IamId.Should().Be("IAM-123");
+        profile.EmployeeId.Should().Be("E12345");
+        profile.DisplayName.Should().Be("Iam FullName");
+        profile.Email.Should().Be("person@ucdavis.edu");
+
+        var user = await ctx.Users.SingleAsync(u => u.Id == userId);
+        user.Kerberos.Should().Be("guser");
+        user.IamId.Should().Be("IAM-123");
+        user.EmployeeId.Should().Be("E12345");
+    }
+
+    [Fact]
+    public async Task EnsureUserProfileAsync_fails_when_iam_kerberos_is_missing_even_if_user_exists()
+    {
+        using AppDbContext ctx = TestDbContextFactory.CreateInMemory();
+
+        var existingUser = new User
+        {
+            Id = Guid.NewGuid(),
+            Kerberos = "storedkerb",
+            IamId = "IAM-123",
+            EmployeeId = "E12345",
+            DisplayName = "Existing User",
+            Email = "existing@ucdavis.edu",
+        };
+
+        ctx.Users.Add(existingUser);
+        await ctx.SaveChangesAsync();
+
+        var orchestrator = new UserProfileOrchestrator(
+            new FakeEntraUserAttributeService(new EntraUserAttributes("IAM-123")),
+            new FakeIdentityService(
+                iamIdentity: new IamIdentity("IAM-123", "E12345", "Iam FullName"),
+                kerberosByIamId: new Dictionary<string, string?>()),
+            new UserService(NullLogger<UserService>.Instance, ctx),
+            new FakeFinancialApiService(),
+            NullLogger<UserProfileOrchestrator>.Instance);
+
+        var act = () => orchestrator.EnsureUserProfileAsync(
+            existingUser.Id,
+            existingUser.Id.ToString(),
+            CreatePrincipal(existingUser.Id, existingUser.Email!),
+            CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("Kerberos lookup failed for IAM ID 'IAM-123'.");
+    }
+
+    private static ClaimsPrincipal CreatePrincipal(Guid userId, string email)
+    {
+        var identity = new ClaimsIdentity(
+        [
+            new Claim(ClaimConstants.ObjectId, userId.ToString()),
+            new Claim("preferred_username", email),
+        ],
+            authenticationType: "Test");
+
+        return new ClaimsPrincipal(identity);
+    }
+
+    private sealed class FakeEntraUserAttributeService : IEntraUserAttributeService
+    {
+        private readonly EntraUserAttributes? _attributes;
+
+        public FakeEntraUserAttributeService(EntraUserAttributes? attributes)
+        {
+            _attributes = attributes;
+        }
+
+        public Task<EntraUserAttributes?> GetAttributesAsync(
+            string userId,
+            ClaimsPrincipal principal,
+            CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(_attributes);
+        }
+    }
+
+    private sealed class FakeIdentityService : IIdentityService
+    {
+        private readonly IamIdentity? _iamIdentity;
+        private readonly IReadOnlyDictionary<string, string?> _kerberosByIamId;
+
+        public FakeIdentityService(
+            IamIdentity? iamIdentity,
+            IReadOnlyDictionary<string, string?> kerberosByIamId)
+        {
+            _iamIdentity = iamIdentity;
+            _kerberosByIamId = kerberosByIamId;
+        }
+
+        public Task<IamIdentity?> GetByIamId(string iamId)
+        {
+            return Task.FromResult(_iamIdentity?.IamId == iamId ? _iamIdentity : null);
+        }
+
+        public Task<string?> GetKerberosByIamId(string iamId)
+        {
+            return Task.FromResult(_kerberosByIamId.TryGetValue(iamId, out var kerberos)
+                ? kerberos
+                : null);
+        }
+    }
+
+    private sealed class FakeFinancialApiService : IFinancialApiService
+    {
+        private readonly IAggieEnterpriseClient _client = CreateProxy<IAggieEnterpriseClient>((method, _) =>
+        {
+            if (method.Name == "get_PpmProjectByProjectTeamMemberEmployeeId")
+            {
+                return new FakePpmProjectByProjectTeamMemberEmployeeIdQuery();
+            }
+
+            throw new NotImplementedException($"{method.Name} is not implemented for this test.");
+        });
+
+        public IAggieEnterpriseClient GetClient()
+        {
+            return _client;
+        }
+    }
+
+    private sealed class FakePpmProjectByProjectTeamMemberEmployeeIdQuery : IPpmProjectByProjectTeamMemberEmployeeIdQuery
+    {
+        public Type ResultType => typeof(IPpmProjectByProjectTeamMemberEmployeeIdResult);
+
+        public OperationRequest Create(IReadOnlyDictionary<string, object?>? variables)
+        {
+            return new OperationRequest(
+                "FakePpmProjectByProjectTeamMemberEmployeeId",
+                CreateProxy<IDocument>((_, _) => throw new NotImplementedException()),
+                variables ?? new Dictionary<string, object?>(),
+                new Dictionary<string, Upload?>(),
+                default);
+        }
+
+        public Task<IOperationResult<IPpmProjectByProjectTeamMemberEmployeeIdResult>> ExecuteAsync(
+            string employeeId,
+            string? roleName,
+            CancellationToken cancellationToken)
+        {
+            var result = new PpmProjectByProjectTeamMemberEmployeeIdResult([]);
+            return Task.FromResult<IOperationResult<IPpmProjectByProjectTeamMemberEmployeeIdResult>>(
+                new FakeOperationResult<IPpmProjectByProjectTeamMemberEmployeeIdResult>(result));
+        }
+
+        public IObservable<IOperationResult<IPpmProjectByProjectTeamMemberEmployeeIdResult>> Watch(
+            string employeeId,
+            string? roleName,
+            ExecutionStrategy? strategy = null)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    private sealed class FakeOperationResult<TResultData> : IOperationResult<TResultData>
+        where TResultData : class
+    {
+        public FakeOperationResult(TResultData data)
+        {
+            Data = data;
+        }
+
+        public TResultData Data { get; }
+
+        public IOperationResultDataFactory<TResultData> DataFactory => null!;
+
+        object IOperationResult.Data => Data!;
+
+        object IOperationResult.DataFactory => DataFactory;
+
+        public IOperationResultDataInfo DataInfo => null!;
+
+        public Type DataType => typeof(TResultData);
+
+        public IReadOnlyList<IClientError> Errors => Array.Empty<IClientError>();
+
+        public IReadOnlyDictionary<string, object?> Extensions => new Dictionary<string, object?>();
+
+        public IReadOnlyDictionary<string, object?> ContextData => new Dictionary<string, object?>();
+
+        public IOperationResult<TResultData> WithData(TResultData data, IOperationResultDataInfo dataInfo)
+        {
+            return new FakeOperationResult<TResultData>(data);
+        }
+    }
+
+    private class InterfaceProxy<T> : DispatchProxy where T : class
+    {
+        public Func<MethodInfo, object?[]?, object?>? Handler { get; set; }
+
+        protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
+        {
+            if (targetMethod == null || Handler == null)
+            {
+                throw new NotImplementedException();
+            }
+
+            return Handler(targetMethod, args);
+        }
+    }
+
+    private static T CreateProxy<T>(Func<MethodInfo, object?[]?, object?> handler) where T : class
+    {
+        var proxy = DispatchProxy.Create<T, InterfaceProxy<T>>();
+        ((InterfaceProxy<T>)(object)proxy).Handler = handler;
+        return proxy;
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to reflect that Kerberos identifiers are now resolved via IAM instead of Entra.

* **Bug Fixes**
  * Enhanced error handling and validation for Kerberos identifier lookups during user profile operations. System now provides clearer error messages when identifiers cannot be found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->