### PR TITLE
Tweak admin user management UI

### DIFF
--- a/web/client/src/queries/adminUsers.ts
+++ b/web/client/src/queries/adminUsers.ts
@@ -84,6 +84,11 @@ export async function assignRole({
 
 export type UserRolesResponse = {
   roles: string[];
+  name?: string | null;
+  email?: string | null;
+  employeeId?: string | null;
+  kerberos?: string | null;
+  iamId?: string | null;
 };
 
 export type RemoveRoleResponse = {

--- a/web/client/src/queries/adminUsers.ts
+++ b/web/client/src/queries/adminUsers.ts
@@ -81,3 +81,53 @@ export async function assignRole({
     signal
   );
 }
+
+export type UserRolesResponse = {
+  roles: string[];
+};
+
+export type RemoveRoleResponse = {
+  roles: string[];
+  removed: boolean;
+};
+
+export const userRolesQueryOptions = (entraUserId: string | null) => ({
+  enabled: !!entraUserId,
+  gcTime: 0,
+  queryFn: async ({
+    signal,
+  }: {
+    signal: AbortSignal;
+  }): Promise<UserRolesResponse> => {
+    return await fetchJson<UserRolesResponse>(
+      `/api/admin/users/${encodeURIComponent(entraUserId!)}/roles`,
+      {},
+      signal
+    );
+  },
+  queryKey: ['admin', 'users', entraUserId, 'roles'] as const,
+  staleTime: 0,
+});
+
+export const useUserRolesQuery = (entraUserId: string | null) => {
+  return useQuery(userRolesQueryOptions(entraUserId));
+};
+
+export async function removeRole({
+  entraUserId,
+  roleName,
+  signal,
+}: {
+  entraUserId: string;
+  roleName: string;
+  signal?: AbortSignal;
+}): Promise<RemoveRoleResponse> {
+  return await fetchJson<RemoveRoleResponse>(
+    `/api/admin/users/${encodeURIComponent(entraUserId)}/roles`,
+    {
+      method: 'DELETE',
+      body: JSON.stringify({ roleName }),
+    },
+    signal
+  );
+}

--- a/web/client/src/routes/(authenticated)/admin/users.tsx
+++ b/web/client/src/routes/(authenticated)/admin/users.tsx
@@ -203,13 +203,37 @@ function RouteComponent() {
               <div className="rounded-box bg-primary/10 p-4">
                 <div className="text-sm font-semibold">Selected user</div>
                 <div className="mt-1 truncate">
-                  {selectedUser.displayName ||
+                  {userRolesQuery.data?.name ||
+                    selectedUser.displayName ||
                     selectedUser.email ||
                     selectedUser.id}
                 </div>
-                {selectedUser.email ? (
+                {(userRolesQuery.data?.email ?? selectedUser.email) ? (
                   <div className="truncate text-sm text-base-content/80">
-                    {selectedUser.email}
+                    {userRolesQuery.data?.email ?? selectedUser.email}
+                  </div>
+                ) : null}
+
+                {userRolesQuery.data?.employeeId ? (
+                  <div className="mt-3 grid gap-2 text-sm md:grid-cols-3">
+                    <div>
+                      <div className="font-semibold">Employee ID</div>
+                      <div className="truncate">
+                        {userRolesQuery.data.employeeId}
+                      </div>
+                    </div>
+                    <div>
+                      <div className="font-semibold">Kerberos</div>
+                      <div className="truncate">
+                        {userRolesQuery.data.kerberos}
+                      </div>
+                    </div>
+                    <div>
+                      <div className="font-semibold">IAMID</div>
+                      <div className="truncate">
+                        {userRolesQuery.data.iamId}
+                      </div>
+                    </div>
                   </div>
                 ) : null}
               </div>
@@ -340,62 +364,17 @@ function RouteComponent() {
               ) : null}
 
               {assignSuccess ? (
-                <>
-                  <div
-                    className={`alert ${
-                      assignSuccess.added ? 'alert-success' : 'alert-info'
-                    }`}
-                  >
-                    <span>
-                      {assignSuccess.added
-                        ? 'Role added.'
-                        : 'User already has that role.'}
-                    </span>
-                  </div>
-
-                  <div className="rounded-box bg-base-200 p-4">
-                    <div className="text-sm font-semibold">User</div>
-                    <div className="mt-1">{assignSuccess.user.name}</div>
-                    <div className="text-sm text-base-content/70">
-                      {assignSuccess.user.email}
-                    </div>
-
-                    <div className="mt-4 grid gap-2 text-sm md:grid-cols-2">
-                      <div>
-                        <div className="font-semibold">Employee ID</div>
-                        <div className="truncate">
-                          {assignSuccess.user.employeeId}
-                        </div>
-                      </div>
-                      <div>
-                        <div className="font-semibold">Kerberos</div>
-                        <div className="truncate">
-                          {assignSuccess.user.kerberos}
-                        </div>
-                      </div>
-                      <div>
-                        <div className="font-semibold">IAMID</div>
-                        <div className="truncate">
-                          {assignSuccess.user.iamId}
-                        </div>
-                      </div>
-                      <div>
-                        <div className="font-semibold">Roles</div>
-                        <div className="mt-1 flex flex-wrap gap-2">
-                          {assignSuccess.user.roles.length ? (
-                            assignSuccess.user.roles.map((r) => (
-                              <span className="badge badge-neutral" key={r}>
-                                {r}
-                              </span>
-                            ))
-                          ) : (
-                            <span className="text-base-content/60">None</span>
-                          )}
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </>
+                <div
+                  className={`alert ${
+                    assignSuccess.added ? 'alert-success' : 'alert-info'
+                  }`}
+                >
+                  <span>
+                    {assignSuccess.added
+                      ? 'Role added.'
+                      : 'User already has that role.'}
+                  </span>
+                </div>
               ) : null}
             </div>
           ) : null}

--- a/web/client/src/routes/(authenticated)/admin/users.tsx
+++ b/web/client/src/routes/(authenticated)/admin/users.tsx
@@ -61,6 +61,11 @@ function RouteComponent() {
           ['admin', 'users', selectedUserId, 'roles'],
           (old: UserRolesResponse | undefined) => ({
             ...old,
+            name: data.user.name,
+            email: data.user.email,
+            employeeId: data.user.employeeId,
+            kerberos: data.user.kerberos,
+            iamId: data.user.iamId,
             roles: data.user.roles,
           })
         );

--- a/web/client/src/routes/(authenticated)/admin/users.tsx
+++ b/web/client/src/routes/(authenticated)/admin/users.tsx
@@ -4,14 +4,20 @@ import { canAccessAdminUsers } from '@/shared/auth/roleAccess.ts';
 import {
   assignRole,
   AssignableRole,
+  removeRole,
   useAdminUserSearchQuery,
+  useUserRolesQuery,
 } from '@/queries/adminUsers.ts';
 import { useDebouncedValue } from '@/lib/useDebouncedValue.ts';
 import { createFileRoute, Link, redirect } from '@tanstack/react-router';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useMemo, useState } from 'react';
 import { HttpError } from '@/lib/api.ts';
-import { ArrowLeftIcon, UsersIcon } from '@heroicons/react/24/outline';
+import {
+  ArrowLeftIcon,
+  UsersIcon,
+  XMarkIcon,
+} from '@heroicons/react/24/outline';
 
 export const Route = createFileRoute('/(authenticated)/admin/users')({
   beforeLoad: async ({ context }: { context: RouterContext }) => {
@@ -42,12 +48,38 @@ function RouteComponent() {
     [searchResults, selectedUserId]
   );
 
+  const queryClient = useQueryClient();
+
+  const userRolesQuery = useUserRolesQuery(selectedUserId);
+
   const assignRoleMutation = useMutation({
     mutationFn: assignRole,
+    onSuccess: (data) => {
+      if (selectedUserId) {
+        queryClient.setQueryData(
+          ['admin', 'users', selectedUserId, 'roles'],
+          { roles: data.user.roles }
+        );
+      }
+    },
+  });
+
+  const removeRoleMutation = useMutation({
+    mutationFn: removeRole,
+    onSuccess: (data) => {
+      if (selectedUserId) {
+        queryClient.setQueryData(
+          ['admin', 'users', selectedUserId, 'roles'],
+          { roles: data.roles }
+        );
+      }
+    },
   });
 
   const assignError = assignRoleMutation.error;
   const assignSuccess = assignRoleMutation.data;
+  const removeError = removeRoleMutation.error;
+  const currentRoles = userRolesQuery.data?.roles ?? [];
 
   const searchError = searchQuery.error;
   const showQueryHint = query.trim().length > 0 && query.trim().length < 3;
@@ -87,6 +119,7 @@ function RouteComponent() {
                   setQuery(e.target.value);
                   setSelectedUserId(null);
                   assignRoleMutation.reset();
+                  removeRoleMutation.reset();
                 }}
                 placeholder="Type at least 3 characters…"
                 type="text"
@@ -142,6 +175,7 @@ function RouteComponent() {
                           onClick={() => {
                             setSelectedUserId(u.id);
                             assignRoleMutation.reset();
+                            removeRoleMutation.reset();
                           }}
                           type="button"
                         >
@@ -176,6 +210,79 @@ function RouteComponent() {
                 {selectedUser.email ? (
                   <div className="truncate text-sm text-base-content/80">
                     {selectedUser.email}
+                  </div>
+                ) : null}
+              </div>
+
+              <div>
+                <div className="label">
+                  <span className="label-text">Current roles</span>
+                </div>
+                {userRolesQuery.isLoading ? (
+                  <div className="flex items-center gap-3 text-sm text-base-content/70">
+                    <div className="loading loading-spinner loading-sm" />
+                    <span>Loading roles…</span>
+                  </div>
+                ) : userRolesQuery.error ? (
+                  <div className="alert alert-error">
+                    <span>
+                      Failed to load roles{' '}
+                      {userRolesQuery.error instanceof HttpError
+                        ? `(HTTP ${userRolesQuery.error.status})`
+                        : ''}
+                      .
+                    </span>
+                  </div>
+                ) : currentRoles.length === 0 ? (
+                  <div className="text-sm text-base-content/60">
+                    No roles assigned.
+                  </div>
+                ) : (
+                  <div className="flex flex-wrap gap-2">
+                    {currentRoles.map((r) => {
+                      const isRemoving =
+                        removeRoleMutation.isPending &&
+                        removeRoleMutation.variables?.roleName === r;
+                      return (
+                        <span
+                          className="badge badge-neutral gap-1 pr-1"
+                          key={r}
+                        >
+                          {r}
+                          <button
+                            aria-label={`Remove role ${r}`}
+                            className="btn btn-circle btn-ghost btn-xs"
+                            disabled={removeRoleMutation.isPending}
+                            onClick={() => {
+                              removeRoleMutation.reset();
+                              removeRoleMutation.mutate({
+                                entraUserId: selectedUser.id,
+                                roleName: r,
+                              });
+                            }}
+                            type="button"
+                          >
+                            {isRemoving ? (
+                              <span className="loading loading-spinner loading-xs" />
+                            ) : (
+                              <XMarkIcon className="w-3 h-3" />
+                            )}
+                          </button>
+                        </span>
+                      );
+                    })}
+                  </div>
+                )}
+
+                {removeError ? (
+                  <div className="alert alert-error mt-2">
+                    <span>
+                      Failed to remove role{' '}
+                      {removeError instanceof HttpError
+                        ? `(HTTP ${removeError.status})`
+                        : ''}
+                      .
+                    </span>
                   </div>
                 ) : null}
               </div>

--- a/web/client/src/routes/(authenticated)/admin/users.tsx
+++ b/web/client/src/routes/(authenticated)/admin/users.tsx
@@ -7,6 +7,7 @@ import {
   removeRole,
   useAdminUserSearchQuery,
   useUserRolesQuery,
+  UserRolesResponse,
 } from '@/queries/adminUsers.ts';
 import { useDebouncedValue } from '@/lib/useDebouncedValue.ts';
 import { createFileRoute, Link, redirect } from '@tanstack/react-router';
@@ -58,7 +59,10 @@ function RouteComponent() {
       if (selectedUserId) {
         queryClient.setQueryData(
           ['admin', 'users', selectedUserId, 'roles'],
-          { roles: data.user.roles }
+          (old: UserRolesResponse | undefined) => ({
+            ...old,
+            roles: data.user.roles,
+          })
         );
       }
     },
@@ -70,7 +74,10 @@ function RouteComponent() {
       if (selectedUserId) {
         queryClient.setQueryData(
           ['admin', 'users', selectedUserId, 'roles'],
-          { roles: data.roles }
+          (old: UserRolesResponse | undefined) => ({
+            ...old,
+            roles: data.roles,
+          })
         );
       }
     },

--- a/web/server/Controllers/AdminUsersController.cs
+++ b/web/server/Controllers/AdminUsersController.cs
@@ -197,4 +197,60 @@ public sealed class AdminUsersController : ApiControllerBase
 
         return Ok(new AssignRoleResponse(responseUser, added));
     }
+
+    public sealed record UserRolesResponse(IReadOnlyList<string> Roles);
+
+    [HttpGet("{entraUserId:guid}/roles")]
+    public async Task<ActionResult<UserRolesResponse>> GetRoles(
+        Guid entraUserId,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (entraUserId == Guid.Empty)
+        {
+            return BadRequest("Entra user ID is required.");
+        }
+
+        var roles = await _userService.GetRolesForUser(entraUserId);
+        return Ok(new UserRolesResponse(roles));
+    }
+
+    public sealed record RemoveRoleRequest(string RoleName);
+
+    public sealed record RemoveRoleResponse(IReadOnlyList<string> Roles, bool Removed);
+
+    [HttpDelete("{entraUserId:guid}/roles")]
+    public async Task<ActionResult<RemoveRoleResponse>> RemoveRole(
+        Guid entraUserId,
+        [FromBody] RemoveRoleRequest request,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (entraUserId == Guid.Empty)
+        {
+            return BadRequest("Entra user ID is required.");
+        }
+
+        var roleName = request?.RoleName?.Trim();
+        if (string.IsNullOrWhiteSpace(roleName))
+        {
+            return BadRequest("Role name is required.");
+        }
+
+        bool removed;
+        try
+        {
+            removed = await _userService.RemoveRoleFromUserAsync(entraUserId, roleName, cancellationToken);
+        }
+        catch (InvalidOperationException ex)
+        {
+            _logger.LogWarning(ex, "Failed to remove role '{RoleName}' from user '{UserId}'.", roleName, entraUserId);
+            return NotFound(ex.Message);
+        }
+
+        var roles = await _userService.GetRolesForUser(entraUserId);
+        return Ok(new RemoveRoleResponse(roles, removed));
+    }
 }

--- a/web/server/Controllers/AdminUsersController.cs
+++ b/web/server/Controllers/AdminUsersController.cs
@@ -198,7 +198,13 @@ public sealed class AdminUsersController : ApiControllerBase
         return Ok(new AssignRoleResponse(responseUser, added));
     }
 
-    public sealed record UserRolesResponse(IReadOnlyList<string> Roles);
+    public sealed record UserRolesResponse(
+        IReadOnlyList<string> Roles,
+        string? Name,
+        string? Email,
+        string? EmployeeId,
+        string? Kerberos,
+        string? IamId);
 
     [HttpGet("{entraUserId:guid}/roles")]
     public async Task<ActionResult<UserRolesResponse>> GetRoles(
@@ -213,7 +219,14 @@ public sealed class AdminUsersController : ApiControllerBase
         }
 
         var roles = await _userService.GetRolesForUser(entraUserId);
-        return Ok(new UserRolesResponse(roles));
+        var user = await _userService.GetByIdAsync(entraUserId, cancellationToken);
+        return Ok(new UserRolesResponse(
+            roles,
+            Name: user?.DisplayName,
+            Email: user?.Email,
+            EmployeeId: user?.EmployeeId,
+            Kerberos: user?.Kerberos,
+            IamId: user?.IamId));
     }
 
     public sealed record RemoveRoleRequest(string RoleName);


### PR DESCRIPTION
## Summary
- Add ability to view and remove existing roles for a selected user in admin user management (closes #217)
- Show user profile details (employee ID, kerberos, IAMID) in the selected user card when available
- Simplify post-assign feedback to a single alert instead of a redundant detail card


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin users can view a selected user’s current roles with loading, error, and empty states.
  * One-click removal of individual roles with immediate UI updates.
  * Assigned role changes are reflected instantly in the interface.
  * Selected-user panel now shows additional identity fields (name, email, employee ID, Kerberos, IAM ID) when available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->