### PR TITLE
Extended beta feedback batch (#224)

### DIFF
--- a/web/client/src/components/alerts/PiProjectAlerts.tsx
+++ b/web/client/src/components/alerts/PiProjectAlerts.tsx
@@ -19,7 +19,8 @@ export interface PiProjectAlertsState {
 }
 
 export function usePiProjectAlerts(
-  managedPis: ManagedPiRecord[]
+  managedPis: ManagedPiRecord[],
+  pmEmployeeId: string
 ): PiProjectAlertsState {
   const projectsQueries = useQueries({
     queries: managedPis.map((pi) => projectsDetailQueryOptions(pi.employeeId)),
@@ -37,7 +38,9 @@ export function usePiProjectAlerts(
     const pisWithProjects: PiWithProjects[] = managedPis.map((pi, index) => {
       const allProjects = projectsQueries[index]?.data ?? [];
       const projects = allProjects.filter(
-        (p) => !p.awardEndDate || new Date(p.awardEndDate) >= now
+        (p) =>
+          p.pmEmployeeId === pmEmployeeId &&
+          (!p.awardEndDate || new Date(p.awardEndDate) >= now)
       );
       const totalBudget = projects.reduce((sum, p) => sum + p.budget, 0);
       const totalBalance = projects.reduce((sum, p) => sum + p.balance, 0);
@@ -54,7 +57,7 @@ export function usePiProjectAlerts(
 
     return getPiProjectAlerts(pisWithProjects);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [allLoaded, managedPis]);
+  }, [allLoaded, managedPis, pmEmployeeId]);
 
   return {
     alerts,
@@ -66,11 +69,17 @@ export function usePiProjectAlerts(
 
 interface PiProjectAlertsProps {
   managedPis: ManagedPiRecord[];
+  pmEmployeeId: string;
 }
 
-export function PiProjectAlerts({ managedPis }: PiProjectAlertsProps) {
-  const { alerts, isLoading, isError, error } =
-    usePiProjectAlerts(managedPis);
+export function PiProjectAlerts({
+  managedPis,
+  pmEmployeeId,
+}: PiProjectAlertsProps) {
+  const { alerts, isLoading, isError, error } = usePiProjectAlerts(
+    managedPis,
+    pmEmployeeId
+  );
 
   if (managedPis.length === 0) {
     return null;

--- a/web/client/src/components/project/InternalProjectsTable.tsx
+++ b/web/client/src/components/project/InternalProjectsTable.tsx
@@ -254,7 +254,7 @@ export function InternalProjectsTable({
                 onClick={() => setShowInactive(!showInactive)}
                 type="button"
               >
-                {showInactive ? 'Hide' : 'Show'} inactive ({inactiveCount})
+                {showInactive ? 'Hide' : 'Show'} inactive tasks ({inactiveCount})
               </button>
             )}
             <ExportDataButton columns={csvColumns} data={projects} filename="internal-projects.csv" />

--- a/web/client/src/components/project/PersonnelTable.tsx
+++ b/web/client/src/components/project/PersonnelTable.tsx
@@ -43,6 +43,7 @@ export interface AggregatedPosition {
   distributions: AggregatedDistribution[];
   employeeId: string;
   fte: number;
+  jobCode: string;
   jobEffectiveDate: string | null;
   jobEndDate: string | null;
   jobEndingSoon: boolean;
@@ -88,6 +89,7 @@ export function aggregateByPosition(
         distributions: [aggregateDistribution(record)],
         employeeId: record.employeeId,
         fte: record.fte,
+        jobCode: safeText(record.jobCode),
         jobEffectiveDate: record.jobEffectiveDate,
         jobEndDate: record.jobEndDate,
         jobEndingSoon: isEndingSoon(record.jobEndDate),
@@ -227,6 +229,7 @@ function getExportData(positions: AggregatedPosition[]) {
       fte: pos.fte,
       fundingEffectiveDate: dist.record.fundingEffectiveDate ?? '',
       fundingEndDate: dist.record.fundingEndDate ?? '',
+      jobCode: pos.jobCode,
       monthlyFringe: dist.monthlyFringe,
       monthlyRate: dist.monthlyRate,
       monthlyTotal: dist.monthlyTotal,
@@ -242,6 +245,7 @@ const personnelCsvColumns = [
   { header: 'Name', key: 'name' as const },
   { header: 'Position Number', key: 'positionNumber' as const },
   { header: 'Position', key: 'positionDescription' as const },
+  { header: 'Job Code', key: 'jobCode' as const },
   { header: 'FTE', key: 'fte' as const },
   { header: 'Project', key: 'projectDescription' as const },
   { header: 'Dist %', key: 'distributionPercent' as const },
@@ -322,6 +326,10 @@ export function PersonnelTable({
         size: 300,
         sortingFn: (a, b) =>
           safeText(a.original.name).localeCompare(safeText(b.original.name)),
+      }),
+      columnHelper.accessor('jobCode', {
+        cell: (info) => info.getValue(),
+        header: 'Job Code',
       }),
       columnHelper.accessor('fte', {
         cell: (info) => (

--- a/web/client/src/components/project/PersonnelTable.tsx
+++ b/web/client/src/components/project/PersonnelTable.tsx
@@ -322,17 +322,14 @@ export function PersonnelTable({
         footer: showTotals ? () => 'Totals' : undefined,
         header: 'Position',
         id: 'positionProject',
-        minSize: 300,
-        size: 300,
+        minSize: 400,
+        size: 400,
         sortingFn: (a, b) =>
           safeText(a.original.name).localeCompare(safeText(b.original.name)),
       }),
       columnHelper.accessor('jobCode', {
         cell: (info) => info.getValue(),
         header: 'Job Code',
-        maxSize: 80,
-        minSize: 80,
-        size: 80,
       }),
       columnHelper.accessor('fte', {
         cell: (info) => (
@@ -378,6 +375,8 @@ export function PersonnelTable({
           );
         },
         header: () => <span className="flex justify-end w-full">End Date</span>,
+        minSize: 130,
+        size: 130,
       }),
       columnHelper.accessor('monthlyRate', {
         cell: (info) => (

--- a/web/client/src/components/project/PersonnelTable.tsx
+++ b/web/client/src/components/project/PersonnelTable.tsx
@@ -330,6 +330,9 @@ export function PersonnelTable({
       columnHelper.accessor('jobCode', {
         cell: (info) => info.getValue(),
         header: 'Job Code',
+        maxSize: 80,
+        minSize: 80,
+        size: 80,
       }),
       columnHelper.accessor('fte', {
         cell: (info) => (

--- a/web/client/src/components/project/ProjectAdditionalInfo.tsx
+++ b/web/client/src/components/project/ProjectAdditionalInfo.tsx
@@ -82,12 +82,10 @@ function buildSecondaryFields(summary: ProjectSummary): Field[] {
 }
 
 interface ProjectAdditionalInfoProps {
-  isProjectManager: boolean;
   summary: ProjectSummary;
 }
 
 export function ProjectAdditionalInfo({
-  isProjectManager,
   summary,
 }: ProjectAdditionalInfoProps) {
   const [expanded, setExpanded] = React.useState(false);
@@ -131,7 +129,7 @@ export function ProjectAdditionalInfo({
             </div>
           ))}
 
-        {isProjectManager && secondaryFields.length > 0 && (
+        {secondaryFields.length > 0 && (
           <div className="md:col-span-2 mt-2">
             <button
               className="btn"

--- a/web/client/src/components/project/ProjectAdditionalInfo.tsx
+++ b/web/client/src/components/project/ProjectAdditionalInfo.tsx
@@ -32,11 +32,6 @@ function buildPrimaryFields(summary: ProjectSummary): Field[] {
         ? `${Number.parseFloat((Number.parseFloat(summary.projectBurdenCostRate) * 100).toFixed(4))}%`
         : '—',
     },
-    {
-      label: 'Contract Administrator',
-      tooltip: tooltipDefinitions.contractAdministrator,
-      value: summary.contractAdministrator ?? '—',
-    },
   ];
 }
 
@@ -58,6 +53,11 @@ function buildSecondaryFields(summary: ProjectSummary): Field[] {
       label: 'Burden Structure',
       tooltip: tooltipDefinitions.burdenStructure,
       value: summary.projectBurdenScheduleBase?.split('-')[0].trim() || '—',
+    },
+    {
+      label: 'Contract Administrator',
+      tooltip: tooltipDefinitions.contractAdministrator,
+      value: summary.contractAdministrator ?? '—',
     },
     {
       label: 'Cost Share Required by Sponsor',

--- a/web/client/src/components/project/ProjectAdditionalInfo.tsx
+++ b/web/client/src/components/project/ProjectAdditionalInfo.tsx
@@ -14,6 +14,7 @@ function buildPrimaryFields(summary: ProjectSummary): Field[] {
   return [
     { label: 'Award Number', value: summary.awardNumber ?? '—' },
     { label: 'Award Name', value: summary.awardName ?? '—' },
+    { label: 'Award PI', value: summary.awardPi ?? '—' },
     { label: 'Award Start Date', value: formatDate(summary.awardStartDate) },
     { label: 'Award End Date', value: formatDate(summary.awardEndDate) },
     {
@@ -46,7 +47,6 @@ function buildSecondaryFields(summary: ProjectSummary): Field[] {
       tooltip: tooltipDefinitions.awardCloseDate,
       value: formatDate(summary.awardCloseDate),
     },
-    { label: 'Award PI', value: summary.awardPi ?? '—' },
     { label: 'Award Status', value: summary.awardStatus ?? '—' },
     { label: 'Award Type', value: summary.awardType ?? '—' },
     {

--- a/web/client/src/components/project/ProjectAdditionalInfo.tsx
+++ b/web/client/src/components/project/ProjectAdditionalInfo.tsx
@@ -78,7 +78,6 @@ function buildSecondaryFields(summary: ProjectSummary): Field[] {
       tooltip: tooltipDefinitions.postReportingPeriod,
       value: summary.postReportingPeriod ?? '—',
     },
-    { label: 'Project Fund', value: summary.projectFund ?? '—' },
   ];
 }
 

--- a/web/client/src/queries/personnel.ts
+++ b/web/client/src/queries/personnel.ts
@@ -8,6 +8,7 @@ export interface PersonnelRecord {
   fte: number;
   fundingEffectiveDate: string | null;
   fundingEndDate: string | null;
+  jobCode: string | null;
   jobEffectiveDate: string | null;
   jobEndDate: string | null;
   monthlyRate: number;

--- a/web/client/src/routes/(authenticated)/index.tsx
+++ b/web/client/src/routes/(authenticated)/index.tsx
@@ -45,8 +45,10 @@ function RouteComponent() {
   const isPrincipalInvestigator =
     !isProjectManager && (userProjectsQuery.data?.length ?? 0) > 0;
 
-  const { alerts: pmAlerts, isLoading: alertsLoading } =
-    usePiProjectAlerts(managedPis);
+  const { alerts: pmAlerts, isLoading: alertsLoading } = usePiProjectAlerts(
+    managedPis,
+    user.employeeId
+  );
 
   const sponsoredProjects = useMemo(
     () =>
@@ -71,13 +73,13 @@ function RouteComponent() {
 
   const discrepancies = useProjectDiscrepancies(internalProjectNumbers);
 
-  const piAlerts = useMemo(
-    () =>
-      isPrincipalInvestigator && userProjectsQuery.data
-        ? getProjectListAlerts(userProjectsQuery.data, user.employeeId)
-        : [],
-    [isPrincipalInvestigator, userProjectsQuery.data, user.employeeId]
-  );
+  const piAlerts = useMemo(() => {
+    if (!isPrincipalInvestigator || !userProjectsQuery.data) return [];
+    const piOnlyProjects = userProjectsQuery.data.filter(
+      (p) => p.pmEmployeeId !== user.employeeId
+    );
+    return getProjectListAlerts(piOnlyProjects, user.employeeId);
+  }, [isPrincipalInvestigator, userProjectsQuery.data, user.employeeId]);
 
   const allAlerts = isProjectManager ? pmAlerts : piAlerts;
 
@@ -224,7 +226,10 @@ function RouteComponent() {
       {selectedTab === 'alerts' && (
         <div aria-labelledby="tab-alerts" id="panel-alerts" role="tabpanel">
           {isProjectManager && (
-            <PiProjectAlerts managedPis={managedPis} />
+            <PiProjectAlerts
+              managedPis={managedPis}
+              pmEmployeeId={user.employeeId}
+            />
           )}
           {isPrincipalInvestigator && piAlerts.length > 0 && (
             <div className="mt-4 flex flex-col gap-4">

--- a/web/client/src/routes/(authenticated)/projects/$employeeId/$projectNumber/index.tsx
+++ b/web/client/src/routes/(authenticated)/projects/$employeeId/$projectNumber/index.tsx
@@ -89,8 +89,8 @@ function ProjectContent({
       </section>
 
       <ProjectDetails summary={summary} />
-      <ProjectAdditionalInfo isProjectManager={isProjectManager} summary={summary} />
       <FinancialDetails summary={summary} />
+      <ProjectAdditionalInfo isProjectManager={isProjectManager} summary={summary} />
 
       <section className="section-margin">
         <h2 className="h2">

--- a/web/client/src/routes/(authenticated)/projects/$employeeId/$projectNumber/index.tsx
+++ b/web/client/src/routes/(authenticated)/projects/$employeeId/$projectNumber/index.tsx
@@ -14,7 +14,6 @@ import {
   useProjectDiscrepancies,
 } from '@/queries/project.ts';
 
-import { useUser } from '@/shared/auth/UserContext.tsx';
 import { TooltipLabel } from '@/shared/TooltipLabel.tsx';
 import { tooltipDefinitions } from '@/shared/tooltips.ts';
 import { useSuspenseQuery } from '@tanstack/react-query';
@@ -49,8 +48,6 @@ function ProjectContent({
   projectRecords: ProjectRecord[];
   summary: ProjectSummary;
 }) {
-  const user = useUser();
-  const isProjectManager = user.employeeId === summary.pmEmployeeId;
   const personnelQuery = usePersonnelQuery(employeeId, [summary.projectNumber]);
   const discrepancies = useProjectDiscrepancies(
     summary.isInternal ? [summary.projectNumber] : []
@@ -90,7 +87,7 @@ function ProjectContent({
 
       <ProjectDetails summary={summary} />
       <FinancialDetails summary={summary} />
-      <ProjectAdditionalInfo isProjectManager={isProjectManager} summary={summary} />
+      <ProjectAdditionalInfo summary={summary} />
 
       <section className="section-margin">
         <h2 className="h2">

--- a/web/client/src/routes/(authenticated)/reports/reconciliation/$projectNumber/detail.tsx
+++ b/web/client/src/routes/(authenticated)/reports/reconciliation/$projectNumber/detail.tsx
@@ -383,19 +383,19 @@ function RouteComponent() {
             {ppmRecord ? (
               <div className="stats shadow stats-vertical bg-base-200 lg:stats-horizontal w-full">
                 <div className="stat">
-                  <div className="uppercase font-proxima-bold text-primary">
-                    PPM
-                  </div>
-                  <div className="text-2xl">
-                    {formatCurrency(ppmRecord.ppmBudBal)}
-                  </div>
-                </div>
-                <div className="stat">
                   <div className="uppercase font-proxima-bold text-accent">
                     GL
                   </div>
                   <div className="text-2xl">
                     {formatCurrency(ppmRecord.glActualAmount)}
+                  </div>
+                </div>
+                <div className="stat">
+                  <div className="uppercase font-proxima-bold text-primary">
+                    PPM
+                  </div>
+                  <div className="text-2xl">
+                    {formatCurrency(ppmRecord.ppmBudBal)}
                   </div>
                 </div>
                 <div

--- a/web/client/src/routes/(authenticated)/reports/reconciliation/$projectNumber/detail.tsx
+++ b/web/client/src/routes/(authenticated)/reports/reconciliation/$projectNumber/detail.tsx
@@ -398,9 +398,7 @@ function RouteComponent() {
                     {formatCurrency(ppmRecord.ppmBudBal)}
                   </div>
                 </div>
-                <div
-                  className={`stat${Math.abs(ppmRecord.glActualAmount + ppmRecord.ppmBudBal) > 0.005 ? ' bg-error/10' : ''}`}
-                >
+                <div className="stat">
                   <div className="uppercase font-proxima-bold text-dark-font/70">
                     Difference
                   </div>

--- a/web/client/src/routes/(authenticated)/reports/reconciliation/$projectNumber/index.tsx
+++ b/web/client/src/routes/(authenticated)/reports/reconciliation/$projectNumber/index.tsx
@@ -136,7 +136,7 @@ function RouteComponent() {
           return (
             <span
               className={`flex font-proxima-bold justify-end ${
-                isDisc ? (diff < 0 ? 'text-error' : 'text-warning') : ''
+                isDisc ? 'text-info' : ''
               }`}
             >
               {formatCurrency(diff)}
@@ -211,17 +211,10 @@ function RouteComponent() {
               />
             }
             getRowProps={(row) => {
-              const r = row.original;
-              const diff = r.glActualAmount + r.ppmBudBal;
-              const isDisc = hasDiscrepancy(r);
-
-              if (!isDisc) {
+              if (!hasDiscrepancy(row.original)) {
                 return {};
               }
-
-              return {
-                className: diff < 0 ? 'bg-error/10' : 'bg-warning/10',
-              };
+              return { className: 'bg-info/10' };
             }}
             globalFilter="none"
             pagination="off"

--- a/web/client/src/test/components/PersonnelTable.test.tsx
+++ b/web/client/src/test/components/PersonnelTable.test.tsx
@@ -23,6 +23,7 @@ const createRecord = (
   fte: 1.0,
   fundingEffectiveDate: '2025-07-01T00:00:00.000Z',
   fundingEndDate: '2026-12-31T00:00:00.000Z',
+  jobCode: '001234',
   jobEffectiveDate: '2020-01-01T00:00:00.000Z',
   jobEndDate: null,
   monthlyRate: 5000,

--- a/web/client/src/test/components/project/ProjectAdditionalInfo.test.tsx
+++ b/web/client/src/test/components/project/ProjectAdditionalInfo.test.tsx
@@ -44,13 +44,13 @@ const createSummary = (
 
 describe('ProjectAdditionalInfo', () => {
   it('renders the section heading', () => {
-    render(<ProjectAdditionalInfo isProjectManager={false} summary={createSummary()} />);
+    render(<ProjectAdditionalInfo summary={createSummary()} />);
 
     expect(screen.getByText('Award Information')).toBeInTheDocument();
   });
 
   it('shows primary award fields for all users', () => {
-    render(<ProjectAdditionalInfo isProjectManager={false} summary={createSummary()} />);
+    render(<ProjectAdditionalInfo summary={createSummary()} />);
 
     expect(screen.getByText('Award Number')).toBeInTheDocument();
     expect(screen.getByText('AWD-100')).toBeInTheDocument();
@@ -67,23 +67,22 @@ describe('ProjectAdditionalInfo', () => {
     expect(screen.getByText('Admin, Carol')).toBeInTheDocument();
   });
 
-  it('hides secondary fields and show more button for non-PMs', () => {
-    render(<ProjectAdditionalInfo isProjectManager={false} summary={createSummary()} />);
+  it('hides secondary fields by default', () => {
+    render(<ProjectAdditionalInfo summary={createSummary()} />);
 
     expect(screen.queryByText('Award Close Date')).not.toBeInTheDocument();
     expect(screen.queryByText('Billing Cycle')).not.toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: /show more/i })).not.toBeInTheDocument();
   });
 
-  it('shows Show more button for PMs', () => {
-    render(<ProjectAdditionalInfo isProjectManager={true} summary={createSummary()} />);
+  it('shows Show more button for all users', () => {
+    render(<ProjectAdditionalInfo summary={createSummary()} />);
 
     expect(screen.getByRole('button', { name: 'Show more' })).toBeInTheDocument();
   });
 
-  it('reveals hidden fields when PM clicks Show more', async () => {
+  it('reveals hidden fields when Show more is clicked', async () => {
     const user = userEvent.setup();
-    render(<ProjectAdditionalInfo isProjectManager={true} summary={createSummary()} />);
+    render(<ProjectAdditionalInfo summary={createSummary()} />);
 
     await user.click(screen.getByRole('button', { name: 'Show more' }));
 
@@ -98,7 +97,7 @@ describe('ProjectAdditionalInfo', () => {
 
   it('collapses fields when Show less is clicked', async () => {
     const user = userEvent.setup();
-    render(<ProjectAdditionalInfo isProjectManager={true} summary={createSummary()} />);
+    render(<ProjectAdditionalInfo summary={createSummary()} />);
 
     await user.click(screen.getByRole('button', { name: 'Show more' }));
     expect(screen.getByText('Billing Cycle')).toBeInTheDocument();
@@ -110,7 +109,6 @@ describe('ProjectAdditionalInfo', () => {
   it('displays em-dash for null values', () => {
     render(
       <ProjectAdditionalInfo
-        isProjectManager={false}
         summary={createSummary({
           awardName: null,
           contractAdministrator: null,
@@ -125,7 +123,6 @@ describe('ProjectAdditionalInfo', () => {
   it('formats dates as MM.dd.yyyy', () => {
     render(
       <ProjectAdditionalInfo
-        isProjectManager={false}
         summary={createSummary({
           awardEndDate: '2026-12-31',
           awardStartDate: '2024-01-01',
@@ -139,7 +136,7 @@ describe('ProjectAdditionalInfo', () => {
 
   it('shows a tooltip for Indirect/Burden Rate', async () => {
     const user = userEvent.setup();
-    render(<ProjectAdditionalInfo isProjectManager={false} summary={createSummary()} />);
+    render(<ProjectAdditionalInfo summary={createSummary()} />);
 
     const label = screen.getByText('Indirect/Burden Rate');
     await user.hover(label.parentElement as HTMLElement);
@@ -151,7 +148,7 @@ describe('ProjectAdditionalInfo', () => {
 
   it('shows tooltips for secondary award fields after expansion', async () => {
     const user = userEvent.setup();
-    render(<ProjectAdditionalInfo isProjectManager={true} summary={createSummary()} />);
+    render(<ProjectAdditionalInfo summary={createSummary()} />);
 
     await user.click(screen.getByRole('button', { name: 'Show more' }));
 
@@ -165,7 +162,7 @@ describe('ProjectAdditionalInfo', () => {
 
   it('renders nothing when awardNumber is null (internal project)', () => {
     const { container } = render(
-      <ProjectAdditionalInfo isProjectManager={false} summary={createSummary({ awardNumber: null })} />
+      <ProjectAdditionalInfo summary={createSummary({ awardNumber: null })} />
     );
 
     expect(container.innerHTML).toBe('');

--- a/web/client/src/test/components/project/ProjectAdditionalInfo.test.tsx
+++ b/web/client/src/test/components/project/ProjectAdditionalInfo.test.tsx
@@ -65,8 +65,6 @@ describe('ProjectAdditionalInfo', () => {
     expect(screen.getByText('NSF-2024-001')).toBeInTheDocument();
     expect(screen.getByText('Indirect/Burden Rate')).toBeInTheDocument();
     expect(screen.getByText('26.5%')).toBeInTheDocument();
-    expect(screen.getByText('Contract Administrator')).toBeInTheDocument();
-    expect(screen.getByText('Admin, Carol')).toBeInTheDocument();
   });
 
   it('hides secondary fields by default', () => {
@@ -89,6 +87,8 @@ describe('ProjectAdditionalInfo', () => {
     await user.click(screen.getByRole('button', { name: 'Show more' }));
 
     expect(screen.getByText('Award Close Date')).toBeInTheDocument();
+    expect(screen.getByText('Contract Administrator')).toBeInTheDocument();
+    expect(screen.getByText('Admin, Carol')).toBeInTheDocument();
     expect(screen.getByText('Billing Cycle')).toBeInTheDocument();
     expect(screen.getByText('Monthly')).toBeInTheDocument();
     expect(screen.getByText('Burden Structure')).toBeInTheDocument();
@@ -111,7 +111,7 @@ describe('ProjectAdditionalInfo', () => {
       <ProjectAdditionalInfo
         summary={createSummary({
           awardName: null,
-          contractAdministrator: null,
+          awardPi: null,
         })}
       />
     );

--- a/web/client/src/test/components/project/ProjectAdditionalInfo.test.tsx
+++ b/web/client/src/test/components/project/ProjectAdditionalInfo.test.tsx
@@ -56,6 +56,8 @@ describe('ProjectAdditionalInfo', () => {
     expect(screen.getByText('AWD-100')).toBeInTheDocument();
     expect(screen.getByText('Award Name')).toBeInTheDocument();
     expect(screen.getByText('Test Award')).toBeInTheDocument();
+    expect(screen.getByText('Award PI')).toBeInTheDocument();
+    expect(screen.getByText('Smith, Jane')).toBeInTheDocument();
     expect(screen.getByText('Award End Date')).toBeInTheDocument();
     expect(screen.getByText('Primary Sponsor Name')).toBeInTheDocument();
     expect(screen.getByText('National Science Foundation')).toBeInTheDocument();
@@ -87,8 +89,6 @@ describe('ProjectAdditionalInfo', () => {
     await user.click(screen.getByRole('button', { name: 'Show more' }));
 
     expect(screen.getByText('Award Close Date')).toBeInTheDocument();
-    expect(screen.getByText('Award PI')).toBeInTheDocument();
-    expect(screen.getByText('Smith, Jane')).toBeInTheDocument();
     expect(screen.getByText('Billing Cycle')).toBeInTheDocument();
     expect(screen.getByText('Monthly')).toBeInTheDocument();
     expect(screen.getByText('Burden Structure')).toBeInTheDocument();

--- a/web/client/src/test/routes/(authenticated)/project-detail.test.tsx
+++ b/web/client/src/test/routes/(authenticated)/project-detail.test.tsx
@@ -102,42 +102,6 @@ describe('project detail page', () => {
     }
   });
 
-  it('shows Show more button only for project managers', async () => {
-    const projects = [createProject({ pmEmployeeId: '1000' })];
-    setupHandlers({ employeeId: '1000', name: 'PM User' }, projects);
-
-    const { cleanup } = renderRoute({
-      initialPath: '/projects/1000/P1',
-    });
-
-    try {
-      await screen.findByText('Award Information');
-      expect(
-        screen.getByRole('button', { name: 'Show more' })
-      ).toBeInTheDocument();
-    } finally {
-      cleanup();
-    }
-  });
-
-  it('hides Show more button for non-project managers', async () => {
-    const projects = [createProject({ pmEmployeeId: '2000' })];
-    setupHandlers({ employeeId: '1000', name: 'PI User' }, projects);
-
-    const { cleanup } = renderRoute({
-      initialPath: '/projects/1000/P1',
-    });
-
-    try {
-      await screen.findByText('Award Information');
-      expect(
-        screen.queryByRole('button', { name: 'Show more' })
-      ).not.toBeInTheDocument();
-    } finally {
-      cleanup();
-    }
-  });
-
   it('hides Award Information and date fields for internal projects', async () => {
     const projects = [
       createProject({

--- a/web/server/Models/FacultyPortfolioRecord.cs
+++ b/web/server/Models/FacultyPortfolioRecord.cs
@@ -34,13 +34,9 @@ public sealed class FacultyPortfolioRecord
         get
         {
             var projectName = ProjectName ?? "";
-            var cleanedName = string.IsNullOrEmpty(ProjectNumber)
+            return string.IsNullOrEmpty(ProjectNumber)
                 ? projectName.Trim()
                 : projectName.Replace(ProjectNumber, "").Trim();
-            var name = cleanedName;
-            if (ProjectType == "Internal" && !string.IsNullOrEmpty(TaskName))
-                name += $" - {TaskName}";
-            return name;
         }
     }
 

--- a/web/server/Models/FacultyPortfolioRecord.cs
+++ b/web/server/Models/FacultyPortfolioRecord.cs
@@ -116,7 +116,7 @@ public sealed class FacultyPortfolioRecord
     public string? AwardType { get; set; }
 
     [JsonPropertyName("awardCloseDate")]
-    public string? AwardCloseDate { get; set; }
+    public DateTime? AwardCloseDate { get; set; }
 
     [JsonPropertyName("awardPi")]
     public string? AwardPi { get; set; }

--- a/web/server/Models/PositionBudgetRecord.cs
+++ b/web/server/Models/PositionBudgetRecord.cs
@@ -25,6 +25,9 @@ public sealed class PositionBudgetRecord
     [JsonPropertyName("positionDescription")]
     public string? PositionDescription { get; set; }
 
+    [JsonPropertyName("jobCode")]
+    public string? JobCode { get; set; }
+
     [JsonPropertyName("monthlyRate")]
     public decimal? MonthlyRate { get; set; }
 


### PR DESCRIPTION
## Summary

Addresses several items from #224 (extended beta feedback from Orbelina walkthrough, Shannon, and design channel). One commit per item for easy review.

**Alerts**
- `64e20b3a` Filter home-page alerts to projects the current user actually manages (PMs) or is PI on (PIs) — previously surfaced alerts for every project across every PI the PM touched.

**Personnel table**
- `4b717d12` Add Job Code column (surfaced from `usp_GetPositionBudgets` → `PositionBudgetRecord.JobCode`).
- `51b61ba7` Constrain Job Code column to 80px so Position doesn't wrap.

**Project detail page**
- `beb78d7b` Drop ` - {TaskName}` suffix from Internal (FP) project `displayName` — task was already shown as its own column in the internal table.
- `bcf256de` Put Financial Details above Award Information on sponsored projects.
- `7ab2e1dc` Remove "Project Fund" field — source column was hardcoded to `''` in all 4 stored procs and a single fund value per project doesn't work anyway.
- `34ec7b5c` Open the Show more / Show less toggle to all users (previously PM-only).
- `c965d29a` Fix Award Close Date: was typed `string?` in `FacultyPortfolioRecord`, so Dapper coerced the Redshift DATE to a culture-dependent string that `parseISO` couldn't read. Retype to `DateTime?` so it serializes as ISO like other award dates.
- `c300314b` Move Award PI into primary award fields.
- `9c406145` Move Contract Administrator to secondary award fields (next to Grant Administrator).

**Internal projects table**
- `1fda03a2` Toggle label now says "Show/Hide inactive tasks" instead of the ambiguous "inactive".

**Reconciliation drill-down**
- `9a6ba044` Swap the top Summary stats so GL shows before PPM (AD-419 convention). Sections below unchanged.

## Not in this PR
From the #224 checklist, deferred after triage:
- Funding distribution column alignment (needs broader layout refactor).
- Hourly rate for hourly employees (needs stored-proc + model + UI plumbing).
- Never show closed tasks to PIs in task breakdown.
- Link from expenditure categories to Glide report in Cognos.
- Feedback mechanism (caeshelp link).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Job Code column to the Personnel table for better position tracking.
  * Principal Investigator alerts now respect project manager filtering (PM-specific alerts update when PM changes).

* **Bug Fixes**
  * Corrected PPM/GL label bindings in reconciliation summary and unified discrepancy styling.
  * Updated inactive toggle label to “Show/Hide inactive tasks (...)” for clarity.

* **Refactor**
  * Reorganized project info: "Award PI" moved to primary fields and role-gated visibility removed so all users see the same layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->