### PR TITLE
Handle carry-forward accrual

### DIFF
--- a/web/server/Services/AccrualOverviewCalculator.cs
+++ b/web/server/Services/AccrualOverviewCalculator.cs
@@ -161,7 +161,7 @@ public static class AccrualOverviewCalculator
             return null;
         }
 
-        if (orderedMonths.Count > 1)
+        if (orderedMonths.Count > 1 && IsPartialMonthSnapshot(orderedMonths[^1].AsOfDate))
         {
             // Mid-month extracts can omit monthly-paid employees, so carry forward anyone who
             // existed last month but has not received a current-month row yet.
@@ -412,6 +412,12 @@ public static class AccrualOverviewCalculator
         }
 
         return mergedMonth;
+    }
+
+    // Detects whether the snapshot was taken before the month has fully closed.
+    private static bool IsPartialMonthSnapshot(DateTime asOfDate)
+    {
+        return asOfDate.Day < DateTime.DaysInMonth(asOfDate.Year, asOfDate.Month);
     }
 
     // Limits YTD calculations to months in the current fiscal year.

--- a/web/server/Services/AccrualOverviewCalculator.cs
+++ b/web/server/Services/AccrualOverviewCalculator.cs
@@ -21,6 +21,7 @@ public static class AccrualOverviewCalculator
         ["SMG"] = 72m,
     };
 
+    // Builds the top-level overview response from the available accrual history.
     public static AccrualOverviewResponse Build(IReadOnlyList<EmployeeAccrualBalanceRecord> records)
     {
         var context = PrepareContext(records);
@@ -76,6 +77,7 @@ public static class AccrualOverviewCalculator
         };
     }
 
+    // Builds the department drilldown using the same merged latest snapshot as the overview.
     public static AccrualDepartmentDetailResponse? BuildDepartmentDetail(
         IReadOnlyList<EmployeeAccrualBalanceRecord> records,
         string departmentCode)
@@ -130,6 +132,7 @@ public static class AccrualOverviewCalculator
         };
     }
 
+    // Normalizes raw records into monthly snapshots and selects the latest view we should display.
     private static CalculationContext? PrepareContext(IReadOnlyList<EmployeeAccrualBalanceRecord> records)
     {
         var usableRecords = records
@@ -160,6 +163,8 @@ public static class AccrualOverviewCalculator
 
         if (orderedMonths.Count > 1)
         {
+            // Mid-month extracts can omit monthly-paid employees, so carry forward anyone who
+            // existed last month but has not received a current-month row yet.
             orderedMonths[^1] = BuildCarryForwardMonth(
                 currentMonth: orderedMonths[^1],
                 previousMonth: orderedMonths[^2]);
@@ -172,6 +177,7 @@ public static class AccrualOverviewCalculator
             GetFiscalYearMonthCount(latestMonth.AsOfDate));
     }
 
+    // Creates one employee snapshot per month using that employee's latest row within the month.
     private static Dictionary<int, MonthlySnapshot> BuildMonthlySnapshots(
         IReadOnlyList<EmployeeAccrualBalanceRecord> records)
     {
@@ -223,6 +229,7 @@ public static class AccrualOverviewCalculator
         return monthlySnapshots;
     }
 
+    // Collapses one employee's current-month rows plus prior history into the values shown in the UI.
     private static EmployeeSnapshot BuildEmployeeSnapshot(
         IReadOnlyList<EmployeeAccrualBalanceRecord> currentRows,
         IReadOnlyList<EmployeeAccrualBalanceRecord> historyRows,
@@ -309,6 +316,7 @@ public static class AccrualOverviewCalculator
             status);
     }
 
+    // Aggregates the latest snapshot into per-department summary rows.
     private static IReadOnlyList<AccrualDepartmentBreakdownRow> BuildDepartmentBreakdown(
         IReadOnlyList<EmployeeSnapshot> latestEmployees,
         IReadOnlyList<MonthlySnapshot> fiscalYearMonths)
@@ -339,6 +347,7 @@ public static class AccrualOverviewCalculator
             .ToList();
     }
 
+    // Produces the department selector options from the latest snapshot.
     private static IReadOnlyList<AccrualDepartmentOption> BuildDepartmentOptions(
         IReadOnlyList<EmployeeSnapshot> latestEmployees)
     {
@@ -355,6 +364,7 @@ public static class AccrualOverviewCalculator
             .ToList();
     }
 
+    // Maps internal employee snapshots to the department detail table rows.
     private static IReadOnlyList<AccrualDepartmentEmployeeRow> BuildDepartmentEmployeeRows(
         IReadOnlyList<EmployeeSnapshot> employees)
     {
@@ -375,11 +385,13 @@ public static class AccrualOverviewCalculator
             .ToList();
     }
 
+    // Applies the rounding convention used throughout the accrual UI.
     private static decimal DecimalRound(decimal value, int decimals = 2)
     {
         return Math.Round(value, decimals, MidpointRounding.AwayFromZero);
     }
 
+    // Merges the newest month with the immediately prior month to fill gaps in partial extracts.
     private static MonthlySnapshot BuildCarryForwardMonth(
         MonthlySnapshot currentMonth,
         MonthlySnapshot previousMonth)
@@ -402,6 +414,7 @@ public static class AccrualOverviewCalculator
         return mergedMonth;
     }
 
+    // Limits YTD calculations to months in the current fiscal year.
     private static IReadOnlyList<MonthlySnapshot> GetFiscalYearMonths(
         IReadOnlyList<MonthlySnapshot> orderedMonths,
         DateTime latestAsOfDate)
@@ -412,6 +425,7 @@ public static class AccrualOverviewCalculator
             .ToList();
     }
 
+    // Converts a date into the 1-12 fiscal month count used by the UI summary cards.
     private static int GetFiscalYearMonthCount(DateTime asOfDate)
     {
         return asOfDate.Month >= 7
@@ -419,16 +433,19 @@ public static class AccrualOverviewCalculator
             : asOfDate.Month + 6;
     }
 
+    // Maps a calendar date to its UC fiscal year.
     private static int GetFiscalYear(DateTime date)
     {
         return date.Month >= 7 ? date.Year + 1 : date.Year;
     }
 
+    // Buckets dates by calendar month for snapshot grouping.
     private static int GetMonthKey(DateTime date)
     {
         return (date.Year * 100) + date.Month;
     }
 
+    // Sums fiscal-year lost cost for a single department across the monthly snapshots.
     private static decimal SumDepartmentLostCost(
         IReadOnlyList<MonthlySnapshot> fiscalYearMonths,
         string departmentCode)
@@ -441,6 +458,7 @@ public static class AccrualOverviewCalculator
             .Sum(employee => employee.LostCostMonth));
     }
 
+    // Estimates how many months remain before the employee reaches their cap.
     private static int? GetMonthsToCap(
         decimal balance,
         decimal accrualLimit,
@@ -470,6 +488,7 @@ public static class AccrualOverviewCalculator
                 MidpointRounding.AwayFromZero));
     }
 
+    // Chooses an hourly rate bucket for lost-cost estimation.
     private static decimal GetHourlyRate(string employeeClassDescription)
     {
         if (HourlyRates.TryGetValue(employeeClassDescription, out var rate))
@@ -482,6 +501,7 @@ public static class AccrualOverviewCalculator
             : DefaultStaffRate;
     }
 
+    // Classifies employees into the status groupings shown in the overview and detail screens.
     private static AccrualStatus GetStatus(decimal percentage)
     {
         return percentage switch
@@ -492,6 +512,7 @@ public static class AccrualOverviewCalculator
         };
     }
 
+    // Picks the most common non-empty string from duplicated source rows.
     private static string MostCommonValue(IEnumerable<string?> values, string fallback)
     {
         return values
@@ -503,6 +524,7 @@ public static class AccrualOverviewCalculator
             .FirstOrDefault() ?? fallback;
     }
 
+    // Normalizes source job-class descriptions into the smaller set of UI/reporting buckets.
     private static string NormalizeClassification(string employeeClassDescription)
     {
         var lower = employeeClassDescription.ToLowerInvariant();

--- a/web/server/Services/AccrualOverviewCalculator.cs
+++ b/web/server/Services/AccrualOverviewCalculator.cs
@@ -158,6 +158,13 @@ public static class AccrualOverviewCalculator
             return null;
         }
 
+        if (orderedMonths.Count > 1)
+        {
+            orderedMonths[^1] = BuildCarryForwardMonth(
+                currentMonth: orderedMonths[^1],
+                previousMonth: orderedMonths[^2]);
+        }
+
         var latestMonth = orderedMonths[^1];
         return new CalculationContext(
             latestMonth,
@@ -371,6 +378,28 @@ public static class AccrualOverviewCalculator
     private static decimal DecimalRound(decimal value, int decimals = 2)
     {
         return Math.Round(value, decimals, MidpointRounding.AwayFromZero);
+    }
+
+    private static MonthlySnapshot BuildCarryForwardMonth(
+        MonthlySnapshot currentMonth,
+        MonthlySnapshot previousMonth)
+    {
+        var mergedMonth = new MonthlySnapshot(currentMonth.AsOfDate, currentMonth.Label);
+        mergedMonth.Employees.AddRange(currentMonth.Employees);
+
+        var currentEmployeeIds = currentMonth.Employees
+            .Select(employee => employee.EmployeeId)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var employee in previousMonth.Employees)
+        {
+            if (!currentEmployeeIds.Contains(employee.EmployeeId))
+            {
+                mergedMonth.Employees.Add(employee);
+            }
+        }
+
+        return mergedMonth;
     }
 
     private static IReadOnlyList<MonthlySnapshot> GetFiscalYearMonths(

--- a/web/tests/server.tests/Services/AccrualOverviewCalculatorTests.cs
+++ b/web/tests/server.tests/Services/AccrualOverviewCalculatorTests.cs
@@ -134,6 +134,60 @@ public sealed class AccrualOverviewCalculatorTests
     }
 
     [Fact]
+    public void Build_carries_forward_previous_month_employees_missing_from_latest_month()
+    {
+        var records = new List<EmployeeAccrualBalanceRecord>
+        {
+            CreateRecord(
+                employeeId: "E001",
+                employeeName: "Biweekly,Employee",
+                asOfDate: new DateTime(2026, 3, 31),
+                departmentCode: "030003",
+                department: "PLANT SCIENCES",
+                employeeClassDescription: "Staff: Career",
+                calculatedBal: 240m,
+                accrualLimit: 240m,
+                accrualHours: 8m,
+                accrualPercentage: 100m),
+            CreateRecord(
+                employeeId: "E001",
+                employeeName: "Biweekly,Employee",
+                asOfDate: new DateTime(2026, 4, 11),
+                departmentCode: "030003",
+                department: "PLANT SCIENCES",
+                employeeClassDescription: "Staff: Career",
+                calculatedBal: 240m,
+                accrualLimit: 240m,
+                accrualHours: 8m,
+                accrualPercentage: 100m),
+            CreateRecord(
+                employeeId: "E002",
+                employeeName: "Monthly,Employee",
+                asOfDate: new DateTime(2026, 3, 31),
+                departmentCode: "030090",
+                department: "NUTRITION",
+                employeeClassDescription: "Academic: Faculty",
+                calculatedBal: 384m,
+                accrualLimit: 384m,
+                accrualHours: 16m,
+                accrualPercentage: 100m),
+        };
+
+        var result = AccrualOverviewCalculator.Build(records);
+
+        result.AsOfDate.Should().Be(new DateTime(2026, 4, 11));
+        result.TotalEmployees.Should().Be(2);
+        result.AtCapCount.Should().Be(2);
+        result.LostCostMonth.Should().Be(1508m);
+        result.MonthlyLostCost.Should().HaveCount(2);
+        result.MonthlyLostCost[^1].LostCost.Should().Be(1508m);
+        result.EmployeeStatusOverTime[^1].AtCap.Should().Be(2);
+        result.DepartmentBreakdown.Should().HaveCount(2);
+        result.DepartmentBreakdown.Select(row => row.DepartmentCode)
+            .Should().BeEquivalentTo(["030003", "030090"]);
+    }
+
+    [Fact]
     public void BuildDepartmentDetail_returns_summary_and_employees_for_department_code()
     {
         var records = new List<EmployeeAccrualBalanceRecord>
@@ -219,6 +273,58 @@ public sealed class AccrualOverviewCalculatorTests
         result.Employees[1].EmployeeId.Should().Be("E002");
         result.Employees[1].MonthsToCap.Should().Be(8);
         result.Employees[1].PctOfCap.Should().Be(83.9m);
+    }
+
+    [Fact]
+    public void BuildDepartmentDetail_carries_forward_department_employee_missing_from_latest_month()
+    {
+        var records = new List<EmployeeAccrualBalanceRecord>
+        {
+            CreateRecord(
+                employeeId: "E001",
+                employeeName: "Biweekly,Employee",
+                asOfDate: new DateTime(2026, 3, 31),
+                departmentCode: "030003",
+                department: "PLANT SCIENCES",
+                employeeClassDescription: "Staff: Career",
+                calculatedBal: 200m,
+                accrualLimit: 240m,
+                accrualHours: 8m,
+                accrualPercentage: 83.3m),
+            CreateRecord(
+                employeeId: "E001",
+                employeeName: "Biweekly,Employee",
+                asOfDate: new DateTime(2026, 4, 11),
+                departmentCode: "030003",
+                department: "PLANT SCIENCES",
+                employeeClassDescription: "Staff: Career",
+                calculatedBal: 208m,
+                accrualLimit: 240m,
+                accrualHours: 8m,
+                accrualPercentage: 86.7m),
+            CreateRecord(
+                employeeId: "E002",
+                employeeName: "Monthly,Employee",
+                asOfDate: new DateTime(2026, 3, 31),
+                departmentCode: "030003",
+                department: "PLANT SCIENCES",
+                employeeClassDescription: "Academic: Faculty",
+                calculatedBal: 384m,
+                accrualLimit: 384m,
+                accrualHours: 16m,
+                accrualPercentage: 100m),
+        };
+
+        var result = AccrualOverviewCalculator.BuildDepartmentDetail(records, "030003");
+
+        result.Should().NotBeNull();
+        result!.AsOfDate.Should().Be(new DateTime(2026, 4, 11));
+        result.Headcount.Should().Be(2);
+        result.AtCapCount.Should().Be(1);
+        result.ApproachingCapCount.Should().Be(1);
+        result.Employees.Should().HaveCount(2);
+        result.Employees.Select(employee => employee.EmployeeName)
+            .Should().Contain(["Biweekly,Employee", "Monthly,Employee"]);
     }
 
     private static EmployeeAccrualBalanceRecord CreateRecord(

--- a/web/tests/server.tests/Services/AccrualOverviewCalculatorTests.cs
+++ b/web/tests/server.tests/Services/AccrualOverviewCalculatorTests.cs
@@ -188,6 +188,58 @@ public sealed class AccrualOverviewCalculatorTests
     }
 
     [Fact]
+    public void Build_does_not_carry_forward_previous_month_employees_into_month_end_snapshot()
+    {
+        var records = new List<EmployeeAccrualBalanceRecord>
+        {
+            CreateRecord(
+                employeeId: "E001",
+                employeeName: "Current,Employee",
+                asOfDate: new DateTime(2026, 3, 31),
+                departmentCode: "030003",
+                department: "PLANT SCIENCES",
+                employeeClassDescription: "Staff: Career",
+                calculatedBal: 200m,
+                accrualLimit: 240m,
+                accrualHours: 8m,
+                accrualPercentage: 83.3m),
+            CreateRecord(
+                employeeId: "E001",
+                employeeName: "Current,Employee",
+                asOfDate: new DateTime(2026, 4, 30),
+                departmentCode: "030003",
+                department: "PLANT SCIENCES",
+                employeeClassDescription: "Staff: Career",
+                calculatedBal: 208m,
+                accrualLimit: 240m,
+                accrualHours: 8m,
+                accrualPercentage: 86.7m),
+            CreateRecord(
+                employeeId: "E002",
+                employeeName: "Departed,Employee",
+                asOfDate: new DateTime(2026, 3, 31),
+                departmentCode: "030090",
+                department: "NUTRITION",
+                employeeClassDescription: "Academic: Faculty",
+                calculatedBal: 384m,
+                accrualLimit: 384m,
+                accrualHours: 16m,
+                accrualPercentage: 100m),
+        };
+
+        var result = AccrualOverviewCalculator.Build(records);
+
+        result.AsOfDate.Should().Be(new DateTime(2026, 4, 30));
+        result.TotalEmployees.Should().Be(1);
+        result.AtCapCount.Should().Be(0);
+        result.ApproachingCapCount.Should().Be(1);
+        result.LostCostMonth.Should().Be(0m);
+        result.EmployeeStatusOverTime[^1].AtCap.Should().Be(0);
+        result.DepartmentBreakdown.Should().ContainSingle();
+        result.DepartmentBreakdown[0].DepartmentCode.Should().Be("030003");
+    }
+
+    [Fact]
     public void BuildDepartmentDetail_returns_summary_and_employees_for_department_code()
     {
         var records = new List<EmployeeAccrualBalanceRecord>


### PR DESCRIPTION
If the current most recent report is mid-month, we only catch bi-weekly employees so we need to carry forward monthly employees so everyone can be represented in the most recent snapshot.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Accrual calculations now detect partial (pre-month-end) data extracts and automatically carry forward missing employees from the previous reporting period; month-end snapshots are treated normally (no carry-forward), improving headcount accuracy.

* **Tests**
  * Added test coverage validating carry-forward behavior and correct handling of month-end vs partial snapshots.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->