### PR TITLE
Extract reusable TableExportActions component

### DIFF
--- a/web/client/src/components/TableExportActions.tsx
+++ b/web/client/src/components/TableExportActions.tsx
@@ -1,0 +1,44 @@
+import type { Table } from '@tanstack/react-table';
+import { type CsvColumn } from '@/lib/csv.ts';
+import { ExportDataButton } from '@/components/ExportDataButton.tsx';
+
+interface TableExportActionsProps<TTableRow extends object, TExportRow extends object> {
+  baseFilename: string;
+  columns: CsvColumn<TExportRow>[];
+  data: TTableRow[];
+  table: Table<TTableRow>;
+  toRows: (rows: TTableRow[]) => TExportRow[];
+}
+
+export function TableExportActions<
+  TTableRow extends object,
+  TExportRow extends object,
+>({
+  baseFilename,
+  columns,
+  data,
+  table,
+  toRows,
+}: TableExportActionsProps<TTableRow, TExportRow>) {
+  const hasActiveFilter =
+    String(table.getState().globalFilter ?? '').trim() !== '';
+  const filteredRows = table.getFilteredRowModel().rows.map((row) => row.original);
+
+  return (
+    <>
+      <ExportDataButton
+        columns={columns}
+        data={toRows(data)}
+        filename={`${baseFilename}.csv`}
+      />
+      {hasActiveFilter ? (
+        <ExportDataButton
+          columns={columns}
+          data={toRows(filteredRows)}
+          filename={`${baseFilename}-filtered.csv`}
+          label="Export filtered"
+        />
+      ) : null}
+    </>
+  );
+}

--- a/web/client/src/components/project/InternalProjectsTable.tsx
+++ b/web/client/src/components/project/InternalProjectsTable.tsx
@@ -1,8 +1,8 @@
 import { useMemo, useState } from 'react';
 import { Link } from '@tanstack/react-router';
-import { createColumnHelper, type Table } from '@tanstack/react-table';
+import { createColumnHelper } from '@tanstack/react-table';
 import { ExclamationTriangleIcon } from '@heroicons/react/24/outline';
-import { ExportDataButton } from '@/components/ExportDataButton.tsx';
+import { TableExportActions } from '@/components/TableExportActions.tsx';
 import { formatCurrency } from '@/lib/currency.ts';
 import type { ProjectRecord } from '@/queries/project.ts';
 import { DataTable } from '@/shared/DataTable.tsx';
@@ -86,47 +86,6 @@ interface InternalProjectsTableProps {
   discrepancies?: Set<string>;
   employeeId: string;
   records: ProjectRecord[];
-}
-
-function renderTableActions(
-  table: Table<AggregatedProject>,
-  inactiveCount: number,
-  projects: AggregatedProject[],
-  showInactive: boolean,
-  toggleInactive: () => void
-) {
-  const hasActiveFilter =
-    String(table.getState().globalFilter ?? '').trim() !== '';
-  const filteredProjects = table
-    .getFilteredRowModel()
-    .rows.map((row) => row.original);
-
-  return (
-    <div className="flex flex-wrap items-center gap-2">
-      {inactiveCount > 0 && (
-        <button
-          className={`btn btn-sm ${showInactive ? 'btn-active' : 'btn-default'}`}
-          onClick={toggleInactive}
-          type="button"
-        >
-          {showInactive ? 'Hide' : 'Show'} inactive tasks ({inactiveCount})
-        </button>
-      )}
-      <ExportDataButton
-        columns={csvColumns}
-        data={projects}
-        filename="internal-projects.csv"
-      />
-      {hasActiveFilter ? (
-        <ExportDataButton
-          columns={csvColumns}
-          data={filteredProjects}
-          filename="internal-projects-filtered.csv"
-          label="Export filtered"
-        />
-      ) : null}
-    </div>
-  );
 }
 
 export function InternalProjectsTable({
@@ -288,12 +247,25 @@ export function InternalProjectsTable({
         globalFilter="left"
         initialState={{ pagination: { pageSize: 25 } }}
         tableActions={(table) =>
-          renderTableActions(
-            table,
-            inactiveCount,
-            projects,
-            showInactive,
-            () => setShowInactive((current) => !current)
+          (
+            <div className="flex flex-wrap items-center gap-2">
+              {inactiveCount > 0 && (
+                <button
+                  className={`btn btn-sm ${showInactive ? 'btn-active' : 'btn-default'}`}
+                  onClick={() => setShowInactive((current) => !current)}
+                  type="button"
+                >
+                  {showInactive ? 'Hide' : 'Show'} inactive tasks ({inactiveCount})
+                </button>
+              )}
+              <TableExportActions
+                baseFilename="internal-projects"
+                columns={csvColumns}
+                data={projects}
+                table={table}
+                toRows={(rows) => rows}
+              />
+            </div>
           )
         }
       />

--- a/web/client/src/components/project/PersonnelTable.tsx
+++ b/web/client/src/components/project/PersonnelTable.tsx
@@ -1,11 +1,11 @@
 import { useMemo, useState } from 'react';
-import { createColumnHelper, type Table } from '@tanstack/react-table';
+import { createColumnHelper } from '@tanstack/react-table';
 import {
   ChevronDownIcon,
   ChevronUpIcon,
   ClockIcon,
 } from '@heroicons/react/24/outline';
-import { ExportDataButton } from '@/components/ExportDataButton.tsx';
+import { TableExportActions } from '@/components/TableExportActions.tsx';
 import { formatCurrency } from '@/lib/currency.ts';
 import { formatDate } from '@/lib/date.ts';
 import type { PersonnelRecord } from '@/queries/personnel.ts';
@@ -285,47 +285,6 @@ function isUnfilled(position: AggregatedPosition): boolean {
   return !position.name;
 }
 
-function renderTableActions(
-  table: Table<AggregatedPosition>,
-  positions: AggregatedPosition[],
-  showUnfilled: boolean,
-  toggleUnfilled: () => void,
-  unfilledCount: number
-) {
-  const hasActiveFilter =
-    String(table.getState().globalFilter ?? '').trim() !== '';
-  const filteredPositions = table
-    .getFilteredRowModel()
-    .rows.map((row) => row.original);
-
-  return (
-    <div className="flex flex-wrap items-center gap-2">
-      {unfilledCount > 0 && (
-        <button
-          className={`btn btn-sm ${showUnfilled ? 'btn-active' : 'btn-default'}`}
-          onClick={toggleUnfilled}
-          type="button"
-        >
-          {showUnfilled ? 'Hide' : 'Show'} unfilled ({unfilledCount})
-        </button>
-      )}
-      <ExportDataButton
-        columns={personnelCsvColumns}
-        data={getExportData(positions)}
-        filename="personnel.csv"
-      />
-      {hasActiveFilter ? (
-        <ExportDataButton
-          columns={personnelCsvColumns}
-          data={getExportData(filteredPositions)}
-          filename="personnel-filtered.csv"
-          label="Export filtered"
-        />
-      ) : null}
-    </div>
-  );
-}
-
 export function PersonnelTable({
   data,
   showTotals = true,
@@ -528,12 +487,25 @@ export function PersonnelTable({
         )}
         subComponentRowClassName="pivot-row"
         tableActions={(table) =>
-          renderTableActions(
-            table,
-            positions,
-            showUnfilled,
-            () => setShowUnfilled((current) => !current),
-            unfilledCount
+          (
+            <div className="flex flex-wrap items-center gap-2">
+              {unfilledCount > 0 && (
+                <button
+                  className={`btn btn-sm ${showUnfilled ? 'btn-active' : 'btn-default'}`}
+                  onClick={() => setShowUnfilled((current) => !current)}
+                  type="button"
+                >
+                  {showUnfilled ? 'Hide' : 'Show'} unfilled ({unfilledCount})
+                </button>
+              )}
+              <TableExportActions
+                baseFilename="personnel"
+                columns={personnelCsvColumns}
+                data={positions}
+                table={table}
+                toRows={getExportData}
+              />
+            </div>
           )
         }
       />

--- a/web/client/src/components/project/SponsoredProjectsTable.tsx
+++ b/web/client/src/components/project/SponsoredProjectsTable.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from 'react';
 import { Link } from '@tanstack/react-router';
-import { createColumnHelper, type Table } from '@tanstack/react-table';
-import { ExportDataButton } from '@/components/ExportDataButton.tsx';
+import { createColumnHelper } from '@tanstack/react-table';
+import { TableExportActions } from '@/components/TableExportActions.tsx';
 import { formatCurrency } from '@/lib/currency.ts';
 import { formatDate } from '@/lib/date.ts';
 import type { ProjectRecord } from '@/queries/project.ts';
@@ -119,47 +119,6 @@ const csvColumns = [
 interface SponsoredProjectsTableProps {
   employeeId: string;
   records: ProjectRecord[];
-}
-
-function renderTableActions(
-  table: Table<AggregatedProject>,
-  expiredCount: number,
-  projects: AggregatedProject[],
-  showExpired: boolean,
-  toggleExpired: () => void
-) {
-  const hasActiveFilter =
-    String(table.getState().globalFilter ?? '').trim() !== '';
-  const filteredProjects = table
-    .getFilteredRowModel()
-    .rows.map((row) => row.original);
-
-  return (
-    <div className="flex flex-wrap items-center gap-2">
-      {expiredCount > 0 && (
-        <button
-          className={`btn btn-sm ${showExpired ? 'btn-active' : 'btn-default'}`}
-          onClick={toggleExpired}
-          type="button"
-        >
-          {showExpired ? 'Hide' : 'Show'} expired ({expiredCount})
-        </button>
-      )}
-      <ExportDataButton
-        columns={csvColumns}
-        data={projects}
-        filename="projects.csv"
-      />
-      {hasActiveFilter ? (
-        <ExportDataButton
-          columns={csvColumns}
-          data={filteredProjects}
-          filename="projects-filtered.csv"
-          label="Export filtered"
-        />
-      ) : null}
-    </div>
-  );
 }
 
 export function SponsoredProjectsTable({
@@ -338,12 +297,25 @@ export function SponsoredProjectsTable({
         globalFilter="left"
         initialState={{ pagination: { pageSize: 25 } }}
         tableActions={(table) =>
-          renderTableActions(
-            table,
-            expiredCount,
-            projects,
-            showExpired,
-            () => setShowExpired((current) => !current)
+          (
+            <div className="flex flex-wrap items-center gap-2">
+              {expiredCount > 0 && (
+                <button
+                  className={`btn btn-sm ${showExpired ? 'btn-active' : 'btn-default'}`}
+                  onClick={() => setShowExpired((current) => !current)}
+                  type="button"
+                >
+                  {showExpired ? 'Hide' : 'Show'} expired ({expiredCount})
+                </button>
+              )}
+              <TableExportActions
+                baseFilename="projects"
+                columns={csvColumns}
+                data={projects}
+                table={table}
+                toRows={(rows) => rows}
+              />
+            </div>
           )
         }
       />

--- a/web/client/src/components/project/TaskBreakdown.tsx
+++ b/web/client/src/components/project/TaskBreakdown.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from 'react';
 import { Link } from '@tanstack/react-router';
-import { createColumnHelper, type Table } from '@tanstack/react-table';
-import { ExportDataButton } from '@/components/ExportDataButton.tsx';
+import { createColumnHelper } from '@tanstack/react-table';
+import { TableExportActions } from '@/components/TableExportActions.tsx';
 import { formatCurrency } from '@/lib/currency.ts';
 import type { ProjectRecord } from '@/queries/project.ts';
 import { DataTable } from '@/shared/DataTable.tsx';
@@ -93,46 +93,6 @@ interface TaskBreakdownProps {
 
 function isClosedTask(row: TaskBreakdownRow): boolean {
   return row.taskStatus === 'Inactive';
-}
-
-function renderTableActions(
-  table: Table<TaskBreakdownRow>,
-  closedCount: number,
-  projectNumber: string,
-  rows: TaskBreakdownRow[],
-  showClosed: boolean,
-  toggleClosed: () => void
-) {
-  const hasActiveFilter =
-    String(table.getState().globalFilter ?? '').trim() !== '';
-  const filteredRows = table.getFilteredRowModel().rows.map((row) => row.original);
-
-  return (
-    <div className="flex flex-wrap items-center gap-2">
-      {closedCount > 0 && (
-        <button
-          className={`btn btn-sm ${showClosed ? 'btn-active' : 'btn-default'}`}
-          onClick={toggleClosed}
-          type="button"
-        >
-          {showClosed ? 'Hide' : 'Show'} closed ({closedCount})
-        </button>
-      )}
-      <ExportDataButton
-        columns={csvColumns}
-        data={rows}
-        filename={`task-breakdown-${projectNumber}.csv`}
-      />
-      {hasActiveFilter ? (
-        <ExportDataButton
-          columns={csvColumns}
-          data={filteredRows}
-          filename={`task-breakdown-${projectNumber}-filtered.csv`}
-          label="Export filtered"
-        />
-      ) : null}
-    </div>
-  );
 }
 
 export function TaskBreakdown({ employeeId, projectNumber, records }: TaskBreakdownProps) {
@@ -308,13 +268,25 @@ export function TaskBreakdown({ employeeId, projectNumber, records }: TaskBreakd
       footerRowClassName="totaltr"
       pagination="off"
       tableActions={(table) =>
-        renderTableActions(
-          table,
-          closedCount,
-          projectNumber,
-          rows,
-          showClosed,
-          () => setShowClosed((current) => !current)
+        (
+          <div className="flex flex-wrap items-center gap-2">
+            {closedCount > 0 && (
+              <button
+                className={`btn btn-sm ${showClosed ? 'btn-active' : 'btn-default'}`}
+                onClick={() => setShowClosed((current) => !current)}
+                type="button"
+              >
+                {showClosed ? 'Hide' : 'Show'} closed ({closedCount})
+              </button>
+            )}
+            <TableExportActions
+              baseFilename={`task-breakdown-${projectNumber}`}
+              columns={csvColumns}
+              data={rows}
+              table={table}
+              toRows={(tableRows) => tableRows}
+            />
+          </div>
         )
       }
     />


### PR DESCRIPTION
Consolidate duplicated logic for rendering "Export" and "Export filtered" buttons into a single component. This refactors the Internal Projects, Personnel, Sponsored Projects, and Task Breakdown tables to use the new shared component, reducing code duplication across the project.