### PR TITLE
updates and centralizes accrual settings and logic

### DIFF
--- a/web/client/src/components/accrual/VacationAccrualAbout.tsx
+++ b/web/client/src/components/accrual/VacationAccrualAbout.tsx
@@ -6,45 +6,34 @@ import {
   InformationCircleIcon,
 } from '@heroicons/react/24/outline';
 import { Link } from '@tanstack/react-router';
+import { type AccrualAssumptionsResponse } from '@/queries/accrual.ts';
 
 type AssumptionRow = {
   label: string;
   value: string;
 };
 
-const thresholdRows: AssumptionRow[] = [
-  { label: 'At Cap', value: '96.0% and above' },
-  { label: 'Approaching Cap', value: '80.0% to 95.9%' },
-  { label: 'Active', value: 'Below 80.0%' },
-];
+const percentFormatter = new Intl.NumberFormat('en-US', {
+  maximumFractionDigits: 1,
+  minimumFractionDigits: 1,
+});
 
-const benefitsRows: AssumptionRow[] = [
-  { label: 'FY Faculty', value: '41% composite benefits load' },
-  { label: 'All other classes', value: '51% composite benefits load' },
-];
+const compactPercentFormatter = new Intl.NumberFormat('en-US', {
+  maximumFractionDigits: 1,
+  minimumFractionDigits: 0,
+});
 
-const hourlyRateRows: AssumptionRow[] = [
-  { label: 'FY Acad Admin', value: '$65.00/hr' },
-  { label: 'FY Acad Coord', value: '$62.00/hr' },
-  { label: 'FY Faculty', value: '$78.00/hr' },
-  { label: 'FY Researcher', value: '$68.00/hr' },
-  { label: 'MSP', value: '$52.00/hr' },
-  { label: 'PSS', value: '$32.50/hr' },
-  { label: 'SMG', value: '$72.00/hr' },
-  { label: 'Fallback academic', value: '$70.00/hr' },
-  { label: 'Fallback staff', value: '$45.00/hr' },
-];
+const currencyFormatter = new Intl.NumberFormat('en-US', {
+  currency: 'USD',
+  maximumFractionDigits: 2,
+  minimumFractionDigits: 2,
+  style: 'currency',
+});
 
-const accrualFallbackRows: AssumptionRow[] = [
-  { label: '384+ cap hours', value: '16.00 hrs/month' },
-  { label: '368+ cap hours', value: '15.33 hrs/month' },
-  { label: '352+ cap hours', value: '14.67 hrs/month' },
-  { label: '336+ cap hours', value: '14.00 hrs/month' },
-  { label: '320+ cap hours', value: '13.33 hrs/month' },
-  { label: '288+ cap hours', value: '12.00 hrs/month' },
-  { label: '240+ cap hours', value: '10.00 hrs/month' },
-  { label: 'Below 240 cap hours', value: '10.00 hrs/month' },
-];
+const hoursFormatter = new Intl.NumberFormat('en-US', {
+  maximumFractionDigits: 2,
+  minimumFractionDigits: 2,
+});
 
 function AssumptionsTable({
   rows,
@@ -74,7 +63,41 @@ function AssumptionsTable({
   );
 }
 
-export function VacationAccrualAbout() {
+export function VacationAccrualAbout({
+  data,
+}: {
+  data: AccrualAssumptionsResponse;
+}) {
+  const thresholdRows: AssumptionRow[] = [
+    {
+      label: 'At Cap',
+      value: `${percentFormatter.format(data.atCapThresholdPct)}% and above`,
+    },
+    {
+      label: 'Approaching Cap',
+      value: `${percentFormatter.format(data.approachingThresholdPct)}% to ${percentFormatter.format(data.atCapThresholdPct - 0.1)}%`,
+    },
+    {
+      label: 'Active',
+      value: `Below ${percentFormatter.format(data.approachingThresholdPct)}%`,
+    },
+  ];
+
+  const benefitsRows: AssumptionRow[] = data.benefitsRates.map((row) => ({
+    label: row.label,
+    value: `${compactPercentFormatter.format(row.rate * 100)}% composite benefits load`,
+  }));
+
+  const hourlyRateRows: AssumptionRow[] = data.hourlyRates.map((row) => ({
+    label: row.label,
+    value: `${currencyFormatter.format(row.hourlyRate)}/hr`,
+  }));
+
+  const accrualFallbackRows: AssumptionRow[] = data.fallbackAccrualTiers.map((row) => ({
+    label: row.label,
+    value: `${hoursFormatter.format(row.monthlyAccrualHours)} hrs/month`,
+  }));
+
   return (
     <main className="mt-8">
       <div className="container">

--- a/web/client/src/components/accrual/VacationAccrualAbout.tsx
+++ b/web/client/src/components/accrual/VacationAccrualAbout.tsx
@@ -1,0 +1,201 @@
+import {
+  ArrowLongLeftIcon,
+  CalculatorIcon,
+  ChartBarIcon,
+  CurrencyDollarIcon,
+  InformationCircleIcon,
+} from '@heroicons/react/24/outline';
+import { Link } from '@tanstack/react-router';
+
+type AssumptionRow = {
+  label: string;
+  value: string;
+};
+
+const thresholdRows: AssumptionRow[] = [
+  { label: 'At Cap', value: '96.0% and above' },
+  { label: 'Approaching Cap', value: '80.0% to 95.9%' },
+  { label: 'Active', value: 'Below 80.0%' },
+];
+
+const benefitsRows: AssumptionRow[] = [
+  { label: 'FY Faculty', value: '41% composite benefits load' },
+  { label: 'All other classes', value: '51% composite benefits load' },
+];
+
+const hourlyRateRows: AssumptionRow[] = [
+  { label: 'FY Acad Admin', value: '$65.00/hr' },
+  { label: 'FY Acad Coord', value: '$62.00/hr' },
+  { label: 'FY Faculty', value: '$78.00/hr' },
+  { label: 'FY Researcher', value: '$68.00/hr' },
+  { label: 'MSP', value: '$52.00/hr' },
+  { label: 'PSS', value: '$32.50/hr' },
+  { label: 'SMG', value: '$72.00/hr' },
+  { label: 'Fallback academic', value: '$70.00/hr' },
+  { label: 'Fallback staff', value: '$45.00/hr' },
+];
+
+const accrualFallbackRows: AssumptionRow[] = [
+  { label: '384+ cap hours', value: '16.00 hrs/month' },
+  { label: '368+ cap hours', value: '15.33 hrs/month' },
+  { label: '352+ cap hours', value: '14.67 hrs/month' },
+  { label: '336+ cap hours', value: '14.00 hrs/month' },
+  { label: '320+ cap hours', value: '13.33 hrs/month' },
+  { label: '288+ cap hours', value: '12.00 hrs/month' },
+  { label: '240+ cap hours', value: '10.00 hrs/month' },
+  { label: 'Below 240 cap hours', value: '10.00 hrs/month' },
+];
+
+function AssumptionsTable({
+  rows,
+  title,
+}: {
+  rows: AssumptionRow[];
+  title: string;
+}) {
+  return (
+    <section className="card bg-base-100 border border-main-border shadow-sm">
+      <div className="card-body gap-4">
+        <h2 className="card-title">{title}</h2>
+        <div className="overflow-x-auto">
+          <table className="table table-zebra">
+            <tbody>
+              {rows.map((row) => (
+                <tr key={row.label}>
+                  <th className="font-semibold">{row.label}</th>
+                  <td>{row.value}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export function VacationAccrualAbout() {
+  return (
+    <main className="mt-8">
+      <div className="container">
+        <div className="mx-auto max-w-6xl space-y-8">
+          <section className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+            <div className="space-y-3">
+              <div className="badge badge-outline badge-primary">
+                Vacation Accruals
+              </div>
+              <div className="space-y-2">
+                <h1 className="h1">About This Report</h1>
+                <p className="max-w-3xl text-lg text-base-content/70">
+                  This page summarizes the current assumptions behind the
+                  vacation accrual overview, with a focus on how estimated lost
+                  cost is calculated for employees who are near or at their
+                  accrual cap.
+                </p>
+              </div>
+            </div>
+
+            <Link className="btn btn-outline" to="/accruals">
+              <ArrowLongLeftIcon className="h-4 w-4" />
+              Back to Overview
+            </Link>
+          </section>
+
+          <section className="grid gap-4 lg:grid-cols-3">
+            <section className="card bg-base-100 border border-main-border shadow-sm lg:col-span-2">
+              <div className="card-body gap-4">
+                <div className="flex items-center gap-2 text-sm font-semibold tracking-[0.14em] uppercase text-base-content/60">
+                  <CalculatorIcon className="h-5 w-5 text-primary" />
+                  <span>Lost Cost Formula</span>
+                </div>
+                <p className="text-base-content/75">
+                  Lost cost per employee is estimated only when the employee is
+                  classified as at cap.
+                </p>
+                <div className="rounded-box bg-base-200/60 px-5 py-4 font-mono text-sm md:text-base">
+                  monthly accrual hours × hourly rate × (1 + benefits load)
+                </div>
+                <p className="text-sm text-base-content/70">
+                  The report treats this as an estimated unrecoverable accrual
+                  cost for the latest month-end snapshot. It is a planning
+                  estimate, not a payroll posting.
+                </p>
+              </div>
+            </section>
+
+            <section className="card bg-base-100 border border-main-border shadow-sm">
+              <div className="card-body gap-4">
+                <div className="flex items-center gap-2 text-sm font-semibold tracking-[0.14em] uppercase text-base-content/60">
+                  <InformationCircleIcon className="h-5 w-5 text-info" />
+                  <span>Scope</span>
+                </div>
+                <p className="text-sm text-base-content/75">
+                  Current assumptions apply to the accrual report only. They are
+                  intended to make the report understandable and directionally
+                  useful, not to replace detailed payroll accounting.
+                </p>
+              </div>
+            </section>
+          </section>
+
+          <section className="grid gap-4 xl:grid-cols-2">
+            <AssumptionsTable rows={thresholdRows} title="Status Thresholds" />
+            <AssumptionsTable rows={benefitsRows} title="Benefits Loads" />
+          </section>
+
+          <section className="grid gap-4 xl:grid-cols-2">
+            <AssumptionsTable
+              rows={hourlyRateRows}
+              title="Hourly Rate Assumptions"
+            />
+            <AssumptionsTable
+              rows={accrualFallbackRows}
+              title="Monthly Accrual Fallback Tiers"
+            />
+          </section>
+
+          <section className="grid gap-4 lg:grid-cols-2">
+            <section className="card bg-base-100 border border-main-border shadow-sm">
+              <div className="card-body gap-4">
+                <div className="flex items-center gap-2 text-sm font-semibold tracking-[0.14em] uppercase text-base-content/60">
+                  <CurrencyDollarIcon className="h-5 w-5 text-secondary" />
+                  <span>Rate Selection</span>
+                </div>
+                <p className="text-sm text-base-content/75">
+                  The report normalizes each employee into a reporting class,
+                  then applies the corresponding hourly-rate bucket. If a class
+                  does not match a configured bucket, the report falls back to
+                  an academic default or a staff default.
+                </p>
+                <p className="text-sm text-base-content/75">
+                  Benefits load is then layered on top of the base hourly rate
+                  using the assumptions shown above.
+                </p>
+              </div>
+            </section>
+
+            <section className="card bg-base-100 border border-main-border shadow-sm">
+              <div className="card-body gap-4">
+                <div className="flex items-center gap-2 text-sm font-semibold tracking-[0.14em] uppercase text-base-content/60">
+                  <ChartBarIcon className="h-5 w-5 text-accent" />
+                  <span>Other Notes</span>
+                </div>
+                <p className="text-sm text-base-content/75">
+                  Monthly accrual hours come from the latest positive accrual
+                  history when available. If that history is missing or zero,
+                  the report falls back to the cap-based tier table shown on
+                  this page.
+                </p>
+                <p className="text-sm text-base-content/75">
+                  Waste rate on the overview is shown as lost cost divided by
+                  estimated monthly accrual charges. Because lost cost includes
+                  benefits load, that percentage can exceed 100% in some cases.
+                </p>
+              </div>
+            </section>
+          </section>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/web/client/src/components/accrual/VacationAccrualAbout.tsx
+++ b/web/client/src/components/accrual/VacationAccrualAbout.tsx
@@ -65,8 +65,10 @@ function AssumptionsTable({
 
 export function VacationAccrualAbout({
   data,
+  departmentCode,
 }: {
   data: AccrualAssumptionsResponse;
+  departmentCode?: string;
 }) {
   const thresholdRows: AssumptionRow[] = [
     {
@@ -118,10 +120,21 @@ export function VacationAccrualAbout({
               </div>
             </div>
 
-            <Link className="btn btn-outline" to="/accruals">
-              <ArrowLongLeftIcon className="h-4 w-4" />
-              Back to Overview
-            </Link>
+            {departmentCode ? (
+              <Link
+                className="btn btn-outline"
+                params={{ departmentCode }}
+                to="/accruals/department/$departmentCode"
+              >
+                <ArrowLongLeftIcon className="h-4 w-4" />
+                Back to Department
+              </Link>
+            ) : (
+              <Link className="btn btn-outline" to="/accruals">
+                <ArrowLongLeftIcon className="h-4 w-4" />
+                Back to Overview
+              </Link>
+            )}
           </section>
 
           <section className="grid gap-4 lg:grid-cols-3">

--- a/web/client/src/components/accrual/VacationAccrualDepartmentDetail.tsx
+++ b/web/client/src/components/accrual/VacationAccrualDepartmentDetail.tsx
@@ -4,7 +4,6 @@ import {
   ArrowLongLeftIcon,
   ChartBarIcon,
   FireIcon,
-  MagnifyingGlassIcon,
   NoSymbolIcon,
   UserGroupIcon,
   ClipboardDocumentListIcon,
@@ -46,7 +45,11 @@ const departmentEmployeeCsvColumns = [
   { header: '% of Cap', key: 'pctOfCap' as const },
   { header: 'Accrual/Mo', key: 'accrualHoursPerMonth' as const },
   { header: 'Months to Cap', key: 'monthsToCap' as const },
-  { format: 'date' as const, header: 'Last Vacation', key: 'lastVacationDate' as const },
+  {
+    format: 'date' as const,
+    header: 'Last Vacation',
+    key: 'lastVacationDate' as const,
+  },
   {
     format: 'currency' as const,
     header: 'Lost Cost/Mo',
@@ -133,11 +136,7 @@ function getStatusClassName(status: EmployeeStatus): string {
   return 'border-success/20 bg-success/10 text-success';
 }
 
-function ClassificationBadge({
-  classification,
-}: {
-  classification: string;
-}) {
+function ClassificationBadge({ classification }: { classification: string }) {
   let className = 'bg-success/10 text-success';
 
   if (classification === 'PSS') {
@@ -278,19 +277,25 @@ export function VacationAccrualDepartmentDetail({
 
   const classifications = useMemo(
     () =>
-      [...new Set(data.employees.map((employee) => employee.classification))].sort(
-        (left, right) => left.localeCompare(right)
-      ),
+      [
+        ...new Set(data.employees.map((employee) => employee.classification)),
+      ].sort((left, right) => left.localeCompare(right)),
     [data.employees]
   );
 
   const academicClassifications = useMemo(
-    () => classifications.filter((classification) => isAcademicClassification(classification)),
+    () =>
+      classifications.filter((classification) =>
+        isAcademicClassification(classification)
+      ),
     [classifications]
   );
 
   const staffClassifications = useMemo(
-    () => classifications.filter((classification) => !isAcademicClassification(classification)),
+    () =>
+      classifications.filter(
+        (classification) => !isAcademicClassification(classification)
+      ),
     [classifications]
   );
 
@@ -307,18 +312,24 @@ export function VacationAccrualDepartmentDetail({
         return false;
       }
 
-      if (classificationFilter === 'academic' &&
-          !isAcademicClassification(employee.classification)) {
+      if (
+        classificationFilter === 'academic' &&
+        !isAcademicClassification(employee.classification)
+      ) {
         return false;
       }
 
-      if (classificationFilter === 'staff' &&
-          isAcademicClassification(employee.classification)) {
+      if (
+        classificationFilter === 'staff' &&
+        isAcademicClassification(employee.classification)
+      ) {
         return false;
       }
 
-      if (!['all', 'academic', 'staff'].includes(classificationFilter) &&
-          employee.classification !== classificationFilter) {
+      if (
+        !['all', 'academic', 'staff'].includes(classificationFilter) &&
+        employee.classification !== classificationFilter
+      ) {
         return false;
       }
 
@@ -420,7 +431,8 @@ export function VacationAccrualDepartmentDetail({
     },
     {
       accessorKey: 'monthsToCap',
-      cell: (info) => renderProjectedMonths(info.row.original, statusThresholds),
+      cell: (info) =>
+        renderProjectedMonths(info.row.original, statusThresholds),
       header: 'Projected',
       size: 140,
     },
@@ -505,9 +517,14 @@ export function VacationAccrualDepartmentDetail({
                     As Of
                   </div>
                   <div className="text-lg font-semibold">
-                    {asOfDate ? asOfDateFormatter.format(asOfDate) : 'Unavailable'}
+                    {asOfDate
+                      ? asOfDateFormatter.format(asOfDate)
+                      : 'Unavailable'}
                   </div>
-                  <Link className="link link-primary text-sm font-semibold" to="/accruals/about">
+                  <Link
+                    className="link link-primary text-sm font-semibold"
+                    to="/accruals/about"
+                  >
                     About this report
                   </Link>
                 </div>
@@ -557,11 +574,13 @@ export function VacationAccrualDepartmentDetail({
             <div className="card-body gap-5 p-5">
               <div className="flex flex-col gap-4 xl:flex-row xl:items-center xl:justify-between">
                 <div className="join">
-                  {([
-                    ['all', 'All'],
-                    ['approaching', 'Approaching'],
-                    ['at-cap', 'At Cap'],
-                  ] as const).map(([value, label]) => (
+                  {(
+                    [
+                      ['all', 'All'],
+                      ['approaching', 'Approaching'],
+                      ['at-cap', 'At Cap'],
+                    ] as const
+                  ).map(([value, label]) => (
                     <button
                       className={`btn btn-sm join-item ${
                         statusFilter === value ? 'btn-primary' : 'btn-ghost'
@@ -603,7 +622,22 @@ export function VacationAccrualDepartmentDetail({
                   </select>
 
                   <label className="input input-bordered input-sm flex items-center gap-2 w-full sm:w-72">
-                    <MagnifyingGlassIcon className="h-4 w-4 opacity-50" />
+                    <svg
+                      className="h-[1em] opacity-50"
+                      viewBox="0 0 24 24"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <g
+                        fill="none"
+                        stroke="currentColor"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth="2.5"
+                      >
+                        <circle cx="11" cy="11" r="8"></circle>
+                        <path d="m21 21-4.3-4.3"></path>
+                      </g>
+                    </svg>
                     <input
                       className="grow"
                       onChange={(event) => setSearchTerm(event.target.value)}
@@ -611,6 +645,22 @@ export function VacationAccrualDepartmentDetail({
                       type="text"
                       value={searchTerm}
                     />
+                    {searchTerm ? (
+                      <button
+                        className="btn btn-ghost btn-sm btn-circle"
+                        onClick={() => setSearchTerm('')}
+                        type="button"
+                      >
+                        <svg
+                          className="h-4 w-4"
+                          fill="currentColor"
+                          viewBox="0 0 16 16"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path d="M5.28 4.22a.75.75 0 0 0-1.06 1.06L6.94 8l-2.72 2.72a.75.75 0 1 0 1.06 1.06L8 9.06l2.72 2.72a.75.75 0 1 0 1.06-1.06L9.06 8l2.72-2.72a.75.75 0 0 0-1.06-1.06L8 6.94 5.28 4.22Z" />
+                        </svg>
+                      </button>
+                    ) : null}
                   </label>
                 </div>
               </div>
@@ -628,6 +678,20 @@ export function VacationAccrualDepartmentDetail({
                 defaultColumnSize={140}
                 expandable={false}
                 footerRowClassName="totaltr bg-base-200/70"
+                getRowProps={(row) => {
+                  const status = getEmployeeStatus(
+                    row.original,
+                    statusThresholds
+                  );
+                  return {
+                    className:
+                      status === 'at-cap'
+                        ? 'bg-error/5'
+                        : status === 'approaching'
+                          ? 'bg-warning/5'
+                          : undefined,
+                  };
+                }}
                 globalFilter="none"
                 initialState={{
                   pagination: { pageSize: 50 },
@@ -640,17 +704,6 @@ export function VacationAccrualDepartmentDetail({
                     filename={`vacation-accrual-${data.departmentCode}.csv`}
                   />
                 }
-                getRowProps={(row) => {
-                  const status = getEmployeeStatus(row.original, statusThresholds);
-                  return {
-                    className:
-                      status === 'at-cap'
-                        ? 'bg-error/5'
-                        : status === 'approaching'
-                          ? 'bg-warning/5'
-                          : undefined,
-                  };
-                }}
                 tableClassName="table-zebra"
               />
             </div>

--- a/web/client/src/components/accrual/VacationAccrualDepartmentDetail.tsx
+++ b/web/client/src/components/accrual/VacationAccrualDepartmentDetail.tsx
@@ -65,6 +65,9 @@ type StatusFilter = 'all' | 'approaching' | 'at-cap';
 type ClassificationFilter = 'all' | 'academic' | 'staff' | string;
 type EmployeeStatus = 'active' | 'approaching' | 'at-cap';
 
+const APPROACHING_THRESHOLD_PCT = 80;
+const AT_CAP_THRESHOLD_PCT = 96;
+
 function SummaryCard({
   accentClassName,
   description,
@@ -95,11 +98,11 @@ function isAcademicClassification(classification: string): boolean {
 function getEmployeeStatus(
   employee: AccrualDepartmentEmployeeRow
 ): EmployeeStatus {
-  if (employee.pctOfCap >= 100) {
+  if (employee.pctOfCap >= AT_CAP_THRESHOLD_PCT) {
     return 'at-cap';
   }
 
-  if (employee.pctOfCap >= 80) {
+  if (employee.pctOfCap >= APPROACHING_THRESHOLD_PCT) {
     return 'approaching';
   }
 
@@ -168,7 +171,11 @@ function CapProgressBar({
   pctOfCap: number;
 }) {
   const status =
-    pctOfCap >= 100 ? 'at-cap' : pctOfCap >= 80 ? 'approaching' : 'active';
+    pctOfCap >= AT_CAP_THRESHOLD_PCT
+      ? 'at-cap'
+      : pctOfCap >= APPROACHING_THRESHOLD_PCT
+        ? 'approaching'
+        : 'active';
   const fillClassName =
     status === 'at-cap'
       ? 'bg-error'

--- a/web/client/src/components/accrual/VacationAccrualDepartmentDetail.tsx
+++ b/web/client/src/components/accrual/VacationAccrualDepartmentDetail.tsx
@@ -16,6 +16,7 @@ import { PageEmpty } from '@/components/states/PageEmpty.tsx';
 import { formatCurrency } from '@/lib/currency.ts';
 import { formatDate } from '@/lib/date.ts';
 import {
+  type AccrualAssumptionsResponse,
   type AccrualDepartmentDetailResponse,
   type AccrualDepartmentEmployeeRow,
 } from '@/queries/accrual.ts';
@@ -65,8 +66,10 @@ type StatusFilter = 'all' | 'approaching' | 'at-cap';
 type ClassificationFilter = 'all' | 'academic' | 'staff' | string;
 type EmployeeStatus = 'active' | 'approaching' | 'at-cap';
 
-const APPROACHING_THRESHOLD_PCT = 80;
-const AT_CAP_THRESHOLD_PCT = 96;
+type StatusThresholds = Pick<
+  AccrualAssumptionsResponse,
+  'approachingThresholdPct' | 'atCapThresholdPct'
+>;
 
 function SummaryCard({
   accentClassName,
@@ -96,13 +99,14 @@ function isAcademicClassification(classification: string): boolean {
 }
 
 function getEmployeeStatus(
-  employee: AccrualDepartmentEmployeeRow
+  employee: AccrualDepartmentEmployeeRow,
+  thresholds: StatusThresholds
 ): EmployeeStatus {
-  if (employee.pctOfCap >= AT_CAP_THRESHOLD_PCT) {
+  if (employee.pctOfCap >= thresholds.atCapThresholdPct) {
     return 'at-cap';
   }
 
-  if (employee.pctOfCap >= APPROACHING_THRESHOLD_PCT) {
+  if (employee.pctOfCap >= thresholds.approachingThresholdPct) {
     return 'approaching';
   }
 
@@ -153,8 +157,14 @@ function ClassificationBadge({
   );
 }
 
-function StatusBadge({ employee }: { employee: AccrualDepartmentEmployeeRow }) {
-  const status = getEmployeeStatus(employee);
+function StatusBadge({
+  employee,
+  thresholds,
+}: {
+  employee: AccrualDepartmentEmployeeRow;
+  thresholds: StatusThresholds;
+}) {
+  const status = getEmployeeStatus(employee, thresholds);
 
   return (
     <span
@@ -167,13 +177,15 @@ function StatusBadge({ employee }: { employee: AccrualDepartmentEmployeeRow }) {
 
 function CapProgressBar({
   pctOfCap,
+  thresholds,
 }: {
   pctOfCap: number;
+  thresholds: StatusThresholds;
 }) {
   const status =
-    pctOfCap >= AT_CAP_THRESHOLD_PCT
+    pctOfCap >= thresholds.atCapThresholdPct
       ? 'at-cap'
-      : pctOfCap >= APPROACHING_THRESHOLD_PCT
+      : pctOfCap >= thresholds.approachingThresholdPct
         ? 'approaching'
         : 'active';
   const fillClassName =
@@ -210,8 +222,11 @@ function CapProgressBar({
   );
 }
 
-function renderProjectedMonths(employee: AccrualDepartmentEmployeeRow) {
-  const status = getEmployeeStatus(employee);
+function renderProjectedMonths(
+  employee: AccrualDepartmentEmployeeRow,
+  thresholds: StatusThresholds
+) {
+  const status = getEmployeeStatus(employee, thresholds);
   if (status === 'at-cap') {
     return <span className="font-semibold text-error">At Cap</span>;
   }
@@ -232,10 +247,12 @@ function renderProjectedMonths(employee: AccrualDepartmentEmployeeRow) {
 }
 
 interface VacationAccrualDepartmentDetailProps {
+  assumptions: AccrualAssumptionsResponse;
   data: AccrualDepartmentDetailResponse;
 }
 
 export function VacationAccrualDepartmentDetail({
+  assumptions,
   data,
 }: VacationAccrualDepartmentDetailProps) {
   const navigate = useNavigate();
@@ -251,6 +268,13 @@ export function VacationAccrualDepartmentDetail({
   }, [data.departmentCode]);
 
   const asOfDate = data.asOfDate ? new Date(data.asOfDate) : null;
+  const statusThresholds = useMemo(
+    () => ({
+      approachingThresholdPct: assumptions.approachingThresholdPct,
+      atCapThresholdPct: assumptions.atCapThresholdPct,
+    }),
+    [assumptions.approachingThresholdPct, assumptions.atCapThresholdPct]
+  );
 
   const classifications = useMemo(
     () =>
@@ -274,7 +298,7 @@ export function VacationAccrualDepartmentDetail({
     const normalizedSearchTerm = searchTerm.trim().toLowerCase();
 
     return data.employees.filter((employee) => {
-      const status = getEmployeeStatus(employee);
+      const status = getEmployeeStatus(employee, statusThresholds);
       if (statusFilter === 'at-cap' && status !== 'at-cap') {
         return false;
       }
@@ -307,7 +331,13 @@ export function VacationAccrualDepartmentDetail({
         employee.employeeId.toLowerCase().includes(normalizedSearchTerm)
       );
     });
-  }, [classificationFilter, data.employees, searchTerm, statusFilter]);
+  }, [
+    classificationFilter,
+    data.employees,
+    searchTerm,
+    statusFilter,
+    statusThresholds,
+  ]);
 
   const employeeColumns: ColumnDef<AccrualDepartmentEmployeeRow>[] = [
     {
@@ -336,8 +366,13 @@ export function VacationAccrualDepartmentDetail({
       size: 140,
     },
     {
-      accessorFn: (row) => getEmployeeStatus(row),
-      cell: (info) => <StatusBadge employee={info.row.original} />,
+      accessorFn: (row) => getEmployeeStatus(row, statusThresholds),
+      cell: (info) => (
+        <StatusBadge
+          employee={info.row.original}
+          thresholds={statusThresholds}
+        />
+      ),
       header: 'Status',
       id: 'status',
       size: 140,
@@ -364,7 +399,12 @@ export function VacationAccrualDepartmentDetail({
     },
     {
       accessorKey: 'pctOfCap',
-      cell: (info) => <CapProgressBar pctOfCap={info.getValue<number>()} />,
+      cell: (info) => (
+        <CapProgressBar
+          pctOfCap={info.getValue<number>()}
+          thresholds={statusThresholds}
+        />
+      ),
       header: '% of Cap',
       size: 180,
     },
@@ -380,7 +420,7 @@ export function VacationAccrualDepartmentDetail({
     },
     {
       accessorKey: 'monthsToCap',
-      cell: (info) => renderProjectedMonths(info.row.original),
+      cell: (info) => renderProjectedMonths(info.row.original, statusThresholds),
       header: 'Projected',
       size: 140,
     },
@@ -601,7 +641,7 @@ export function VacationAccrualDepartmentDetail({
                   />
                 }
                 getRowProps={(row) => {
-                  const status = getEmployeeStatus(row.original);
+                  const status = getEmployeeStatus(row.original, statusThresholds);
                   return {
                     className:
                       status === 'at-cap'

--- a/web/client/src/components/accrual/VacationAccrualDepartmentDetail.tsx
+++ b/web/client/src/components/accrual/VacationAccrualDepartmentDetail.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import type { ComponentType, SVGProps } from 'react';
 import {
   ArrowLongLeftIcon,
@@ -68,6 +68,12 @@ type SummaryCardProps = {
 type StatusFilter = 'all' | 'approaching' | 'at-cap';
 type ClassificationFilter = 'all' | 'academic' | 'staff' | string;
 type EmployeeStatus = 'active' | 'approaching' | 'at-cap';
+type DepartmentFilters = {
+  classificationFilter: ClassificationFilter;
+  departmentCode: string;
+  searchTerm: string;
+  statusFilter: StatusFilter;
+};
 
 type StatusThresholds = Pick<
   AccrualAssumptionsResponse,
@@ -245,6 +251,15 @@ function renderProjectedMonths(
   );
 }
 
+function createDepartmentFilters(departmentCode: string): DepartmentFilters {
+  return {
+    classificationFilter: 'all',
+    departmentCode,
+    searchTerm: '',
+    statusFilter: 'all',
+  };
+}
+
 interface VacationAccrualDepartmentDetailProps {
   assumptions: AccrualAssumptionsResponse;
   data: AccrualDepartmentDetailResponse;
@@ -255,16 +270,25 @@ export function VacationAccrualDepartmentDetail({
   data,
 }: VacationAccrualDepartmentDetailProps) {
   const navigate = useNavigate();
-  const [classificationFilter, setClassificationFilter] =
-    useState<ClassificationFilter>('all');
-  const [searchTerm, setSearchTerm] = useState('');
-  const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
-
-  useEffect(() => {
-    setClassificationFilter('all');
-    setSearchTerm('');
-    setStatusFilter('all');
-  }, [data.departmentCode]);
+  const [filters, setFilters] = useState<DepartmentFilters>(() =>
+    createDepartmentFilters(data.departmentCode)
+  );
+  const activeFilters =
+    filters.departmentCode === data.departmentCode
+      ? filters
+      : createDepartmentFilters(data.departmentCode);
+  const { classificationFilter, searchTerm, statusFilter } = activeFilters;
+  const updateFilters = (
+    updater: (current: DepartmentFilters) => DepartmentFilters
+  ) => {
+    setFilters((current) =>
+      updater(
+        current.departmentCode === data.departmentCode
+          ? current
+          : createDepartmentFilters(data.departmentCode)
+      )
+    );
+  };
 
   const asOfDate = data.asOfDate ? new Date(data.asOfDate) : null;
   const statusThresholds = useMemo(
@@ -586,7 +610,13 @@ export function VacationAccrualDepartmentDetail({
                         statusFilter === value ? 'btn-primary' : 'btn-ghost'
                       }`}
                       key={value}
-                      onClick={() => setStatusFilter(value)}
+                      onClick={() =>
+                        updateFilters((current) => ({
+                          ...current,
+                          departmentCode: data.departmentCode,
+                          statusFilter: value,
+                        }))
+                      }
                       type="button"
                     >
                       {label}
@@ -598,7 +628,11 @@ export function VacationAccrualDepartmentDetail({
                   <select
                     className="select select-bordered select-sm w-full sm:w-56"
                     onChange={(event) =>
-                      setClassificationFilter(event.target.value)
+                      updateFilters((current) => ({
+                        ...current,
+                        classificationFilter: event.target.value,
+                        departmentCode: data.departmentCode,
+                      }))
                     }
                     value={classificationFilter}
                   >
@@ -640,7 +674,13 @@ export function VacationAccrualDepartmentDetail({
                     </svg>
                     <input
                       className="grow"
-                      onChange={(event) => setSearchTerm(event.target.value)}
+                      onChange={(event) =>
+                        updateFilters((current) => ({
+                          ...current,
+                          departmentCode: data.departmentCode,
+                          searchTerm: event.target.value,
+                        }))
+                      }
                       placeholder="Search by name or ID..."
                       type="text"
                       value={searchTerm}
@@ -648,7 +688,13 @@ export function VacationAccrualDepartmentDetail({
                     {searchTerm ? (
                       <button
                         className="btn btn-ghost btn-sm btn-circle"
-                        onClick={() => setSearchTerm('')}
+                        onClick={() =>
+                          updateFilters((current) => ({
+                            ...current,
+                            departmentCode: data.departmentCode,
+                            searchTerm: '',
+                          }))
+                        }
                         type="button"
                       >
                         <svg

--- a/web/client/src/components/accrual/VacationAccrualDepartmentDetail.tsx
+++ b/web/client/src/components/accrual/VacationAccrualDepartmentDetail.tsx
@@ -427,7 +427,7 @@ export function VacationAccrualDepartmentDetail({
       <div className="container">
         <div className="mx-auto max-w-7xl space-y-8">
           <section className="space-y-4">
-            <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+            <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
               <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
                 <Link
                   className="inline-flex items-center gap-2 text-sm font-medium text-primary no-underline"
@@ -459,11 +459,19 @@ export function VacationAccrualDepartmentDetail({
                 </select>
               </div>
 
-              {asOfDate ? (
-                <p className="text-sm text-base-content/60">
-                  As of {asOfDateFormatter.format(asOfDate)}
-                </p>
-              ) : null}
+              <div className="card bg-base-100 border border-main-border shadow-sm lg:min-w-64">
+                <div className="card-body gap-1 p-4">
+                  <div className="text-xs font-semibold tracking-[0.14em] uppercase text-base-content/55">
+                    As Of
+                  </div>
+                  <div className="text-lg font-semibold">
+                    {asOfDate ? asOfDateFormatter.format(asOfDate) : 'Unavailable'}
+                  </div>
+                  <Link className="link link-primary text-sm font-semibold" to="/accruals/about">
+                    About this report
+                  </Link>
+                </div>
+              </div>
             </div>
           </section>
 

--- a/web/client/src/components/accrual/VacationAccrualDepartmentDetail.tsx
+++ b/web/client/src/components/accrual/VacationAccrualDepartmentDetail.tsx
@@ -547,6 +547,7 @@ export function VacationAccrualDepartmentDetail({
                   </div>
                   <Link
                     className="link link-primary text-sm font-semibold"
+                    search={{ departmentCode: data.departmentCode }}
                     to="/accruals/about"
                   >
                     About this report

--- a/web/client/src/components/accrual/VacationAccrualOverview.tsx
+++ b/web/client/src/components/accrual/VacationAccrualOverview.tsx
@@ -1,4 +1,4 @@
-import type { ComponentType, SVGProps } from 'react';
+import type { ComponentType, MouseEvent, SVGProps } from 'react';
 import {
   ArrowTrendingDownIcon,
   ChartBarIcon,
@@ -113,9 +113,35 @@ export function VacationAccrualOverview({
   }
 
   const asOfDate = data.asOfDate ? new Date(data.asOfDate) : null;
+  const shouldSkipRowNavigation = (
+    event: MouseEvent<HTMLTableRowElement>
+  ): boolean => {
+    const interactiveTarget = (event.target as HTMLElement | null)?.closest(
+      'a, button, input, select, textarea, summary, [role="button"], [role="link"]'
+    );
+    if (interactiveTarget) {
+      return true;
+    }
+
+    const selection = window.getSelection();
+    return Boolean(selection && !selection.isCollapsed);
+  };
   const departmentColumns: ColumnDef<AccrualDepartmentBreakdownRow>[] = [
     {
       accessorKey: 'department',
+      cell: (info) => (
+        <div className="flex items-start">
+          <Link
+            aria-label={`Open ${info.getValue<string>()} department details`}
+            className="link link-hover text-inherit"
+            params={{ departmentCode: info.row.original.departmentCode }}
+            title="Open department details"
+            to="/accruals/department/$departmentCode"
+          >
+            {info.getValue<string>()}
+          </Link>
+        </div>
+      ),
       footer: () => 'CAES Total',
       header: 'Department',
       minSize: 260,
@@ -406,26 +432,18 @@ export function VacationAccrualOverview({
                   footerRowClassName="totaltr bg-base-200/70"
                   getRowProps={(row) => ({
                     className: 'cursor-pointer hover:bg-base-200',
-                    onClick: () =>
-                      navigate({
+                    onClick: (event) => {
+                      if (shouldSkipRowNavigation(event)) {
+                        return;
+                      }
+
+                      void navigate({
                         params: {
                           departmentCode: row.original.departmentCode,
                         },
                         to: '/accruals/department/$departmentCode',
-                      }),
-                    onKeyDown: (event) => {
-                      if (event.key === 'Enter' || event.key === ' ') {
-                        event.preventDefault();
-                        void navigate({
-                          params: {
-                            departmentCode: row.original.departmentCode,
-                          },
-                          to: '/accruals/department/$departmentCode',
-                        });
-                      }
+                      });
                     },
-                    role: 'link',
-                    tabIndex: 0,
                   })}
                   initialState={{
                     pagination: { pageSize: 50 },

--- a/web/client/src/components/accrual/VacationAccrualOverview.tsx
+++ b/web/client/src/components/accrual/VacationAccrualOverview.tsx
@@ -18,7 +18,7 @@ import {
   XAxis,
   YAxis,
 } from 'recharts';
-import { useNavigate } from '@tanstack/react-router';
+import { Link, useNavigate } from '@tanstack/react-router';
 import { ColumnDef } from '@tanstack/react-table';
 import { ExportDataButton } from '@/components/ExportDataButton.tsx';
 import { PageEmpty } from '@/components/states/PageEmpty.tsx';
@@ -215,15 +215,28 @@ export function VacationAccrualOverview({
     <main className="mt-8">
       <div className="container">
         <div className="mx-auto max-w-7xl space-y-8">
-          <section>
-            <h1 className="h1">Vacation Accrual Overview</h1>
-            <p className="mt-2 text-sm text-base-content/65">
-              {data.totalEmployees.toLocaleString('en-US')} employees across{' '}
-              {data.totalDepartments.toLocaleString('en-US')} departments
-              {asOfDate ? (
-                <> as of {asOfDateFormatter.format(asOfDate)}</>
-              ) : null}
-            </p>
+          <section className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+            <div>
+              <h1 className="h1">Vacation Accrual Overview</h1>
+              <p className="mt-2 text-sm text-base-content/65">
+                {data.totalEmployees.toLocaleString('en-US')} employees across{' '}
+                {data.totalDepartments.toLocaleString('en-US')} departments
+              </p>
+            </div>
+
+            <div className="card bg-base-100 border border-main-border shadow-sm lg:min-w-64">
+              <div className="card-body gap-1 p-4">
+                <div className="text-xs font-semibold tracking-[0.14em] uppercase text-base-content/55">
+                  As Of
+                </div>
+                <div className="text-lg font-semibold">
+                  {asOfDate ? asOfDateFormatter.format(asOfDate) : 'Unavailable'}
+                </div>
+                <Link className="link link-primary text-sm font-semibold" to="/accruals/about">
+                  About this report
+                </Link>
+              </div>
+            </div>
           </section>
 
           <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-5">

--- a/web/client/src/components/accrual/VacationAccrualOverview.tsx
+++ b/web/client/src/components/accrual/VacationAccrualOverview.tsx
@@ -178,7 +178,9 @@ export function VacationAccrualOverview({
           {formatCurrency(data.lostCostMonth)}
         </span>
       ),
-      header: () => <span className="flex justify-end w-full">Lost Cost/Mo</span>,
+      header: () => (
+        <span className="flex justify-end w-full">Lost Cost/Mo</span>
+      ),
       size: 160,
     },
     {
@@ -193,7 +195,9 @@ export function VacationAccrualOverview({
           {formatCurrency(data.lostCostYtd)}
         </span>
       ),
-      header: () => <span className="flex justify-end w-full">Lost Cost YTD</span>,
+      header: () => (
+        <span className="flex justify-end w-full">Lost Cost YTD</span>
+      ),
       size: 170,
     },
     {
@@ -206,7 +210,9 @@ export function VacationAccrualOverview({
       footer: () => (
         <span className="flex justify-end w-full text-base-content/55">-</span>
       ),
-      header: () => <span className="flex justify-end w-full">Avg Balance</span>,
+      header: () => (
+        <span className="flex justify-end w-full">Avg Balance</span>
+      ),
       size: 140,
     },
   ];
@@ -230,9 +236,14 @@ export function VacationAccrualOverview({
                   As Of
                 </div>
                 <div className="text-lg font-semibold">
-                  {asOfDate ? asOfDateFormatter.format(asOfDate) : 'Unavailable'}
+                  {asOfDate
+                    ? asOfDateFormatter.format(asOfDate)
+                    : 'Unavailable'}
                 </div>
-                <Link className="link link-primary text-sm font-semibold" to="/accruals/about">
+                <Link
+                  className="link link-primary text-sm font-semibold"
+                  to="/accruals/about"
+                >
                   About this report
                 </Link>
               </div>
@@ -393,10 +404,6 @@ export function VacationAccrualOverview({
                   expandable={false}
                   filterPlaceholder="Search departments..."
                   footerRowClassName="totaltr bg-base-200/70"
-                  initialState={{
-                    pagination: { pageSize: 50 },
-                    sorting: [{ desc: false, id: 'department' }],
-                  }}
                   getRowProps={(row) => ({
                     className: 'cursor-pointer hover:bg-base-200',
                     onClick: () =>
@@ -420,6 +427,10 @@ export function VacationAccrualOverview({
                     role: 'link',
                     tabIndex: 0,
                   })}
+                  initialState={{
+                    pagination: { pageSize: 50 },
+                    sorting: [{ desc: false, id: 'department' }],
+                  }}
                   tableActions={
                     <ExportDataButton
                       columns={departmentCsvColumns}

--- a/web/client/src/queries/accrual.ts
+++ b/web/client/src/queries/accrual.ts
@@ -31,6 +31,21 @@ export interface AccrualDepartmentOption {
   name: string;
 }
 
+export interface AccrualBenefitsRateRow {
+  label: string;
+  rate: number;
+}
+
+export interface AccrualFallbackAccrualTierRow {
+  label: string;
+  monthlyAccrualHours: number;
+}
+
+export interface AccrualHourlyRateRow {
+  hourlyRate: number;
+  label: string;
+}
+
 export interface AccrualDepartmentEmployeeRow {
   accrualHoursPerMonth: number;
   balanceHours: number;
@@ -74,6 +89,14 @@ export interface AccrualOverviewResponse {
   ytdMonthCount: number;
 }
 
+export interface AccrualAssumptionsResponse {
+  approachingThresholdPct: number;
+  atCapThresholdPct: number;
+  benefitsRates: AccrualBenefitsRateRow[];
+  fallbackAccrualTiers: AccrualFallbackAccrualTierRow[];
+  hourlyRates: AccrualHourlyRateRow[];
+}
+
 export const accrualOverviewQueryOptions = () => ({
   queryFn: async (): Promise<AccrualOverviewResponse> => {
     return await fetchJson<AccrualOverviewResponse>('/api/accrual/overview');
@@ -84,6 +107,18 @@ export const accrualOverviewQueryOptions = () => ({
 
 export const useAccrualOverviewQuery = () => {
   return useQuery(accrualOverviewQueryOptions());
+};
+
+export const accrualAssumptionsQueryOptions = () => ({
+  queryFn: async (): Promise<AccrualAssumptionsResponse> => {
+    return await fetchJson<AccrualAssumptionsResponse>('/api/accrual/assumptions');
+  },
+  queryKey: ['accruals', 'assumptions'] as const,
+  staleTime: 60 * 60 * 1000, // 1 hour
+});
+
+export const useAccrualAssumptionsQuery = () => {
+  return useQuery(accrualAssumptionsQueryOptions());
 };
 
 export const accrualDepartmentDetailQueryOptions = (departmentCode: string) => ({

--- a/web/client/src/queries/accrual.ts
+++ b/web/client/src/queries/accrual.ts
@@ -16,9 +16,9 @@ export interface AccrualStatusTrendPoint {
 }
 
 export interface AccrualDepartmentBreakdownRow {
-  avgBalanceHours: number;
   approachingCapCount: number;
   atCapCount: number;
+  avgBalanceHours: number;
   department: string;
   departmentCode: string;
   headcount: number;
@@ -60,10 +60,10 @@ export interface AccrualDepartmentEmployeeRow {
 }
 
 export interface AccrualDepartmentDetailResponse {
-  asOfDate: string;
-  avgBalanceHours: number;
   approachingCapCount: number;
+  asOfDate: string;
   atCapCount: number;
+  avgBalanceHours: number;
   departmentCode: string;
   departmentName: string;
   departments: AccrualDepartmentOption[];
@@ -111,7 +111,9 @@ export const useAccrualOverviewQuery = () => {
 
 export const accrualAssumptionsQueryOptions = () => ({
   queryFn: async (): Promise<AccrualAssumptionsResponse> => {
-    return await fetchJson<AccrualAssumptionsResponse>('/api/accrual/assumptions');
+    return await fetchJson<AccrualAssumptionsResponse>(
+      '/api/accrual/assumptions'
+    );
   },
   queryKey: ['accruals', 'assumptions'] as const,
   staleTime: 60 * 60 * 1000, // 1 hour
@@ -121,7 +123,9 @@ export const useAccrualAssumptionsQuery = () => {
   return useQuery(accrualAssumptionsQueryOptions());
 };
 
-export const accrualDepartmentDetailQueryOptions = (departmentCode: string) => ({
+export const accrualDepartmentDetailQueryOptions = (
+  departmentCode: string
+) => ({
   queryFn: async (): Promise<AccrualDepartmentDetailResponse> => {
     return await fetchJson<AccrualDepartmentDetailResponse>(
       `/api/accrual/department/${encodeURIComponent(departmentCode)}`

--- a/web/client/src/routeTree.gen.ts
+++ b/web/client/src/routeTree.gen.ts
@@ -25,6 +25,7 @@ import { Route as authenticatedReportsIndexRouteImport } from './routes/(authent
 import { Route as authenticatedAdminIndexRouteImport } from './routes/(authenticated)/admin/index'
 import { Route as authenticatedAccrualsIndexRouteImport } from './routes/(authenticated)/accruals/index'
 import { Route as authenticatedAdminUsersRouteImport } from './routes/(authenticated)/admin/users'
+import { Route as authenticatedAccrualsAboutRouteImport } from './routes/(authenticated)/accruals/about'
 import { Route as authenticatedProjectsEmployeeIdRouteRouteImport } from './routes/(authenticated)/projects/$employeeId/route'
 import { Route as authenticatedProjectsEmployeeIdIndexRouteImport } from './routes/(authenticated)/projects/$employeeId/index'
 import { Route as authenticatedProjectsByNumberProjectNumberRouteImport } from './routes/(authenticated)/projects/by-number/$projectNumber'
@@ -117,6 +118,12 @@ const authenticatedAdminUsersRoute = authenticatedAdminUsersRouteImport.update({
   path: '/users',
   getParentRoute: () => authenticatedAdminRouteRoute,
 } as any)
+const authenticatedAccrualsAboutRoute =
+  authenticatedAccrualsAboutRouteImport.update({
+    id: '/accruals/about',
+    path: '/accruals/about',
+    getParentRoute: () => authenticatedRouteRoute,
+  } as any)
 const authenticatedProjectsEmployeeIdRouteRoute =
   authenticatedProjectsEmployeeIdRouteRouteImport.update({
     id: '/$employeeId',
@@ -181,6 +188,7 @@ export interface FileRoutesByFullPath {
   '/styles': typeof authenticatedStylesRoute
   '/': typeof authenticatedIndexRoute
   '/projects/$employeeId': typeof authenticatedProjectsEmployeeIdRouteRouteWithChildren
+  '/accruals/about': typeof authenticatedAccrualsAboutRoute
   '/admin/users': typeof authenticatedAdminUsersRoute
   '/accruals': typeof authenticatedAccrualsIndexRoute
   '/admin/': typeof authenticatedAdminIndexRoute
@@ -203,6 +211,7 @@ export interface FileRoutesByTo {
   '/principalInvestigators': typeof authenticatedPrincipalInvestigatorsRoute
   '/styles': typeof authenticatedStylesRoute
   '/': typeof authenticatedIndexRoute
+  '/accruals/about': typeof authenticatedAccrualsAboutRoute
   '/admin/users': typeof authenticatedAdminUsersRoute
   '/accruals': typeof authenticatedAccrualsIndexRoute
   '/admin': typeof authenticatedAdminIndexRoute
@@ -230,6 +239,7 @@ export interface FileRoutesById {
   '/(authenticated)/styles': typeof authenticatedStylesRoute
   '/(authenticated)/': typeof authenticatedIndexRoute
   '/(authenticated)/projects/$employeeId': typeof authenticatedProjectsEmployeeIdRouteRouteWithChildren
+  '/(authenticated)/accruals/about': typeof authenticatedAccrualsAboutRoute
   '/(authenticated)/admin/users': typeof authenticatedAdminUsersRoute
   '/(authenticated)/accruals/': typeof authenticatedAccrualsIndexRoute
   '/(authenticated)/admin/': typeof authenticatedAdminIndexRoute
@@ -257,6 +267,7 @@ export interface FileRouteTypes {
     | '/styles'
     | '/'
     | '/projects/$employeeId'
+    | '/accruals/about'
     | '/admin/users'
     | '/accruals'
     | '/admin/'
@@ -279,6 +290,7 @@ export interface FileRouteTypes {
     | '/principalInvestigators'
     | '/styles'
     | '/'
+    | '/accruals/about'
     | '/admin/users'
     | '/accruals'
     | '/admin'
@@ -305,6 +317,7 @@ export interface FileRouteTypes {
     | '/(authenticated)/styles'
     | '/(authenticated)/'
     | '/(authenticated)/projects/$employeeId'
+    | '/(authenticated)/accruals/about'
     | '/(authenticated)/admin/users'
     | '/(authenticated)/accruals/'
     | '/(authenticated)/admin/'
@@ -436,6 +449,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/admin/users'
       preLoaderRoute: typeof authenticatedAdminUsersRouteImport
       parentRoute: typeof authenticatedAdminRouteRoute
+    }
+    '/(authenticated)/accruals/about': {
+      id: '/(authenticated)/accruals/about'
+      path: '/accruals/about'
+      fullPath: '/accruals/about'
+      preLoaderRoute: typeof authenticatedAccrualsAboutRouteImport
+      parentRoute: typeof authenticatedRouteRoute
     }
     '/(authenticated)/projects/$employeeId': {
       id: '/(authenticated)/projects/$employeeId'
@@ -579,6 +599,7 @@ interface authenticatedRouteRouteChildren {
   authenticatedReportsRoute: typeof authenticatedReportsRouteWithChildren
   authenticatedStylesRoute: typeof authenticatedStylesRoute
   authenticatedIndexRoute: typeof authenticatedIndexRoute
+  authenticatedAccrualsAboutRoute: typeof authenticatedAccrualsAboutRoute
   authenticatedAccrualsIndexRoute: typeof authenticatedAccrualsIndexRoute
   authenticatedAccrualsDepartmentDepartmentCodeRoute: typeof authenticatedAccrualsDepartmentDepartmentCodeRoute
 }
@@ -595,6 +616,7 @@ const authenticatedRouteRouteChildren: authenticatedRouteRouteChildren = {
   authenticatedReportsRoute: authenticatedReportsRouteWithChildren,
   authenticatedStylesRoute: authenticatedStylesRoute,
   authenticatedIndexRoute: authenticatedIndexRoute,
+  authenticatedAccrualsAboutRoute: authenticatedAccrualsAboutRoute,
   authenticatedAccrualsIndexRoute: authenticatedAccrualsIndexRoute,
   authenticatedAccrualsDepartmentDepartmentCodeRoute:
     authenticatedAccrualsDepartmentDepartmentCodeRoute,

--- a/web/client/src/routes/(authenticated)/accruals/about.tsx
+++ b/web/client/src/routes/(authenticated)/accruals/about.tsx
@@ -1,10 +1,41 @@
 import { createFileRoute } from '@tanstack/react-router';
 import { VacationAccrualAbout } from '@/components/accrual/VacationAccrualAbout.tsx';
+import { PageError } from '@/components/states/PageError.tsx';
+import { PageLoading } from '@/components/states/PageLoading.tsx';
+import {
+  accrualAssumptionsQueryOptions,
+  useAccrualAssumptionsQuery,
+} from '@/queries/accrual.ts';
 
 export const Route = createFileRoute('/(authenticated)/accruals/about')({
+  loader: ({ context: { queryClient } }) =>
+    queryClient.ensureQueryData(accrualAssumptionsQueryOptions()),
+  pendingComponent: () => (
+    <PageLoading message="Loading accrual assumptions..." />
+  ),
   component: RouteComponent,
 });
 
 function RouteComponent() {
-  return <VacationAccrualAbout />;
+  const { data, error, isError } = useAccrualAssumptionsQuery();
+
+  if (isError) {
+    return (
+      <main className="mt-8">
+        <div className="container">
+          <PageError
+            detail={error.message}
+            message="Walter could not load the accrual assumptions."
+            title="About page unavailable"
+          />
+        </div>
+      </main>
+    );
+  }
+
+  if (!data) {
+    return <PageLoading message="Loading accrual assumptions..." />;
+  }
+
+  return <VacationAccrualAbout data={data} />;
 }

--- a/web/client/src/routes/(authenticated)/accruals/about.tsx
+++ b/web/client/src/routes/(authenticated)/accruals/about.tsx
@@ -1,7 +1,12 @@
-import { createFileRoute } from '@tanstack/react-router';
+import {
+  createFileRoute,
+  type ErrorComponentProps,
+  Link,
+} from '@tanstack/react-router';
 import { VacationAccrualAbout } from '@/components/accrual/VacationAccrualAbout.tsx';
 import { PageError } from '@/components/states/PageError.tsx';
 import { PageLoading } from '@/components/states/PageLoading.tsx';
+import { getErrorPresentation } from '@/lib/errorPresentation.ts';
 import {
   accrualAssumptionsQueryOptions,
   useAccrualAssumptionsQuery,
@@ -10,6 +15,7 @@ import {
 export const Route = createFileRoute('/(authenticated)/accruals/about')({
   loader: ({ context: { queryClient } }) =>
     queryClient.ensureQueryData(accrualAssumptionsQueryOptions()),
+  errorComponent: RouteErrorBoundary,
   pendingComponent: () => (
     <PageLoading message="Loading accrual assumptions..." />
   ),
@@ -38,4 +44,36 @@ function RouteComponent() {
   }
 
   return <VacationAccrualAbout data={data} />;
+}
+
+function RouteErrorBoundary({ error, reset }: ErrorComponentProps) {
+  const presentation = getErrorPresentation(error, {
+    404: {
+      message: 'Walter could not load the accrual assumptions.',
+      title: 'About page unavailable',
+    },
+  });
+
+  return (
+    <main className="mt-8">
+      <div className="container">
+        <PageError
+          actions={
+            <>
+              <button className="btn btn-primary" onClick={() => reset()} type="button">
+                Try again
+              </button>
+              <Link className="btn btn-outline" to="/accruals">
+                Back to overview
+              </Link>
+            </>
+          }
+          detail={presentation.detail}
+          message={presentation.message}
+          statusCode={presentation.statusCode}
+          title={presentation.title}
+        />
+      </div>
+    </main>
+  );
 }

--- a/web/client/src/routes/(authenticated)/accruals/about.tsx
+++ b/web/client/src/routes/(authenticated)/accruals/about.tsx
@@ -12,6 +12,10 @@ import {
   useAccrualAssumptionsQuery,
 } from '@/queries/accrual.ts';
 
+interface SearchParams {
+  departmentCode?: string;
+}
+
 export const Route = createFileRoute('/(authenticated)/accruals/about')({
   loader: ({ context: { queryClient } }) =>
     queryClient.ensureQueryData(accrualAssumptionsQueryOptions()),
@@ -19,10 +23,14 @@ export const Route = createFileRoute('/(authenticated)/accruals/about')({
   pendingComponent: () => (
     <PageLoading message="Loading accrual assumptions..." />
   ),
+  validateSearch: (search: Record<string, unknown>): SearchParams => ({
+    departmentCode: (search.departmentCode as string) ?? undefined,
+  }),
   component: RouteComponent,
 });
 
 function RouteComponent() {
+  const { departmentCode } = Route.useSearch();
   const { data, error, isError } = useAccrualAssumptionsQuery();
 
   if (isError) {
@@ -43,10 +51,11 @@ function RouteComponent() {
     return <PageLoading message="Loading accrual assumptions..." />;
   }
 
-  return <VacationAccrualAbout data={data} />;
+  return <VacationAccrualAbout data={data} departmentCode={departmentCode} />;
 }
 
 function RouteErrorBoundary({ error, reset }: ErrorComponentProps) {
+  const { departmentCode } = Route.useSearch();
   const presentation = getErrorPresentation(error, {
     404: {
       message: 'Walter could not load the accrual assumptions.',
@@ -63,9 +72,19 @@ function RouteErrorBoundary({ error, reset }: ErrorComponentProps) {
               <button className="btn btn-primary" onClick={() => reset()} type="button">
                 Try again
               </button>
-              <Link className="btn btn-outline" to="/accruals">
-                Back to overview
-              </Link>
+              {departmentCode ? (
+                <Link
+                  className="btn btn-outline"
+                  params={{ departmentCode }}
+                  to="/accruals/department/$departmentCode"
+                >
+                  Back to department
+                </Link>
+              ) : (
+                <Link className="btn btn-outline" to="/accruals">
+                  Back to overview
+                </Link>
+              )}
             </>
           }
           detail={presentation.detail}

--- a/web/client/src/routes/(authenticated)/accruals/about.tsx
+++ b/web/client/src/routes/(authenticated)/accruals/about.tsx
@@ -1,0 +1,10 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { VacationAccrualAbout } from '@/components/accrual/VacationAccrualAbout.tsx';
+
+export const Route = createFileRoute('/(authenticated)/accruals/about')({
+  component: RouteComponent,
+});
+
+function RouteComponent() {
+  return <VacationAccrualAbout />;
+}

--- a/web/client/src/routes/(authenticated)/accruals/department/$departmentCode.tsx
+++ b/web/client/src/routes/(authenticated)/accruals/department/$departmentCode.tsx
@@ -2,7 +2,10 @@ import { PageError } from '@/components/states/PageError.tsx';
 import { PageLoading } from '@/components/states/PageLoading.tsx';
 import { VacationAccrualDepartmentDetail } from '@/components/accrual/VacationAccrualDepartmentDetail.tsx';
 import { getErrorPresentation } from '@/lib/errorPresentation.ts';
-import { accrualDepartmentDetailQueryOptions } from '@/queries/accrual.ts';
+import {
+  accrualAssumptionsQueryOptions,
+  accrualDepartmentDetailQueryOptions,
+} from '@/queries/accrual.ts';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import {
   createFileRoute,
@@ -15,10 +18,12 @@ export const Route = createFileRoute(
 )({
   component: RouteComponent,
   errorComponent: RouteErrorBoundary,
-  loader: ({ context: { queryClient }, params: { departmentCode } }) =>
-    queryClient.ensureQueryData(
-      accrualDepartmentDetailQueryOptions(departmentCode)
-    ),
+  loader: async ({ context: { queryClient }, params: { departmentCode } }) => {
+    await Promise.all([
+      queryClient.ensureQueryData(accrualDepartmentDetailQueryOptions(departmentCode)),
+      queryClient.ensureQueryData(accrualAssumptionsQueryOptions()),
+    ]);
+  },
   pendingComponent: () => (
     <PageLoading message="Loading department accrual detail..." />
   ),
@@ -29,8 +34,11 @@ function RouteComponent() {
   const { data } = useSuspenseQuery(
     accrualDepartmentDetailQueryOptions(departmentCode)
   );
+  const { data: assumptions } = useSuspenseQuery(accrualAssumptionsQueryOptions());
 
-  return <VacationAccrualDepartmentDetail data={data} />;
+  return (
+    <VacationAccrualDepartmentDetail assumptions={assumptions} data={data} />
+  );
 }
 
 function RouteErrorBoundary({ error, reset }: ErrorComponentProps) {

--- a/web/client/src/test/routes/(authenticated)/accrual-overview.test.tsx
+++ b/web/client/src/test/routes/(authenticated)/accrual-overview.test.tsx
@@ -97,6 +97,35 @@ describe('vacation accrual overview route', () => {
       expect(screen.getByText('CAES Total')).toBeInTheDocument();
       expect(screen.getAllByText('$3,817.00')).toHaveLength(2);
       expect(screen.getByText('3.1%')).toBeInTheDocument();
+      expect(
+        screen.getByRole('link', { name: 'About this report' })
+      ).toHaveAttribute('href', '/accruals/about');
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('renders the accrual assumptions page', async () => {
+    server.use(http.get('/api/user/me', () => HttpResponse.json(mockUser)));
+
+    const { cleanup } = renderRoute({ initialPath: '/accruals/about' });
+
+    try {
+      expect(
+        await screen.findByRole('heading', { name: 'About This Report' })
+      ).toBeInTheDocument();
+      expect(screen.getByText('Lost Cost Formula')).toBeInTheDocument();
+      expect(screen.getByText('Status Thresholds')).toBeInTheDocument();
+      expect(screen.getByText('Benefits Loads')).toBeInTheDocument();
+      expect(screen.getByText('96.0% and above')).toBeInTheDocument();
+      expect(
+        screen.getByText('41% composite benefits load')
+      ).toBeInTheDocument();
+      expect(screen.getByText('$78.00/hr')).toBeInTheDocument();
+      expect(screen.getByText('14.67 hrs/month')).toBeInTheDocument();
+      expect(
+        screen.getByRole('link', { name: /Back to Overview/i })
+      ).toHaveAttribute('href', '/accruals');
     } finally {
       cleanup();
     }
@@ -206,6 +235,9 @@ describe('vacation accrual overview route', () => {
         await screen.findByRole('link', { name: /College Overview/i })
       ).toBeInTheDocument();
       expect(screen.getByLabelText('Department')).toHaveValue('030003');
+      expect(
+        screen.getByRole('link', { name: 'About this report' })
+      ).toHaveAttribute('href', '/accruals/about');
       expect(screen.getByText('Gradziel,Thomas M')).toBeInTheDocument();
       expect(screen.getByText('Saichaie,Amanda M')).toBeInTheDocument();
       expect(screen.queryByText('Preview')).not.toBeInTheDocument();

--- a/web/client/src/test/routes/(authenticated)/accrual-overview.test.tsx
+++ b/web/client/src/test/routes/(authenticated)/accrual-overview.test.tsx
@@ -169,6 +169,37 @@ describe('vacation accrual overview route', () => {
     }
   });
 
+  it('shows the route error state when the accrual assumptions prefetch fails', async () => {
+    server.use(
+      http.get('/api/user/me', () => HttpResponse.json(mockUser)),
+      http.get('/api/accrual/assumptions', () =>
+        HttpResponse.json(
+          { message: 'Assumptions unavailable' },
+          { status: 503 }
+        )
+      )
+    );
+
+    const { cleanup } = renderRoute({ initialPath: '/accruals/about' });
+
+    try {
+      expect(
+        await screen.findByRole('heading', { name: 'We could not reach the server' })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          'Try again in a moment. If the problem keeps happening, the service may be unavailable.'
+        )
+      ).toBeInTheDocument();
+      expect(screen.getByText('Assumptions unavailable')).toBeInTheDocument();
+      expect(
+        screen.getByRole('link', { name: /Back to overview/i })
+      ).toHaveAttribute('href', '/accruals');
+    } finally {
+      cleanup();
+    }
+  });
+
   it('navigates to the department drilldown when a department row is clicked', async () => {
     const user = userEvent.setup();
 

--- a/web/client/src/test/routes/(authenticated)/accrual-overview.test.tsx
+++ b/web/client/src/test/routes/(authenticated)/accrual-overview.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { screen } from '@testing-library/react';
+import { screen, within } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
 import { server } from '@/test/mswUtils.ts';
@@ -12,6 +12,38 @@ const mockUser = {
   kerberos: 'accruals',
   name: 'Accrual Viewer',
   roles: ['AccrualViewer'],
+};
+
+const mockAccrualAssumptions = {
+  approachingThresholdPct: 80,
+  atCapThresholdPct: 96,
+  benefitsRates: [
+    { label: 'FY Acad Admin', rate: 0.41 },
+    { label: 'FY Acad Coord', rate: 0.41 },
+    { label: 'FY Faculty', rate: 0.41 },
+    { label: 'All other classes', rate: 0.51 },
+  ],
+  fallbackAccrualTiers: [
+    { label: '384+ cap hours', monthlyAccrualHours: 16 },
+    { label: '368+ cap hours', monthlyAccrualHours: 15.33 },
+    { label: '352+ cap hours', monthlyAccrualHours: 14.67 },
+    { label: '336+ cap hours', monthlyAccrualHours: 14 },
+    { label: '320+ cap hours', monthlyAccrualHours: 13.33 },
+    { label: '288+ cap hours', monthlyAccrualHours: 12 },
+    { label: '240+ cap hours', monthlyAccrualHours: 10 },
+    { label: 'Below 240 cap hours', monthlyAccrualHours: 10 },
+  ],
+  hourlyRates: [
+    { label: 'FY Acad Admin', hourlyRate: 65 },
+    { label: 'FY Acad Coord', hourlyRate: 62 },
+    { label: 'FY Faculty', hourlyRate: 78 },
+    { label: 'FY Researcher', hourlyRate: 68 },
+    { label: 'MSP', hourlyRate: 52 },
+    { label: 'PSS', hourlyRate: 32.5 },
+    { label: 'SMG', hourlyRate: 72 },
+    { label: 'Fallback academic', hourlyRate: 70 },
+    { label: 'Fallback staff', hourlyRate: 45 },
+  ],
 };
 
 describe('vacation accrual overview route', () => {
@@ -109,37 +141,7 @@ describe('vacation accrual overview route', () => {
     server.use(
       http.get('/api/user/me', () => HttpResponse.json(mockUser)),
       http.get('/api/accrual/assumptions', () =>
-        HttpResponse.json({
-          approachingThresholdPct: 80,
-          atCapThresholdPct: 96,
-          benefitsRates: [
-            { label: 'FY Acad Admin', rate: 0.41 },
-            { label: 'FY Acad Coord', rate: 0.41 },
-            { label: 'FY Faculty', rate: 0.41 },
-            { label: 'All other classes', rate: 0.51 },
-          ],
-          fallbackAccrualTiers: [
-            { label: '384+ cap hours', monthlyAccrualHours: 16 },
-            { label: '368+ cap hours', monthlyAccrualHours: 15.33 },
-            { label: '352+ cap hours', monthlyAccrualHours: 14.67 },
-            { label: '336+ cap hours', monthlyAccrualHours: 14 },
-            { label: '320+ cap hours', monthlyAccrualHours: 13.33 },
-            { label: '288+ cap hours', monthlyAccrualHours: 12 },
-            { label: '240+ cap hours', monthlyAccrualHours: 10 },
-            { label: 'Below 240 cap hours', monthlyAccrualHours: 10 },
-          ],
-          hourlyRates: [
-            { label: 'FY Acad Admin', hourlyRate: 65 },
-            { label: 'FY Acad Coord', hourlyRate: 62 },
-            { label: 'FY Faculty', hourlyRate: 78 },
-            { label: 'FY Researcher', hourlyRate: 68 },
-            { label: 'MSP', hourlyRate: 52 },
-            { label: 'PSS', hourlyRate: 32.5 },
-            { label: 'SMG', hourlyRate: 72 },
-            { label: 'Fallback academic', hourlyRate: 70 },
-            { label: 'Fallback staff', hourlyRate: 45 },
-          ],
-        })
+        HttpResponse.json(mockAccrualAssumptions)
       )
     );
 
@@ -172,6 +174,9 @@ describe('vacation accrual overview route', () => {
 
     server.use(
       http.get('/api/user/me', () => HttpResponse.json(mockUser)),
+      http.get('/api/accrual/assumptions', () =>
+        HttpResponse.json(mockAccrualAssumptions)
+      ),
       http.get('/api/accrual/overview', () =>
         HttpResponse.json({
           approachingCapCount: 7,
@@ -287,6 +292,9 @@ describe('vacation accrual overview route', () => {
 
     server.use(
       http.get('/api/user/me', () => HttpResponse.json(mockUser)),
+      http.get('/api/accrual/assumptions', () =>
+        HttpResponse.json(mockAccrualAssumptions)
+      ),
       http.get('/api/accrual/overview', () =>
         HttpResponse.json({
           approachingCapCount: 7,
@@ -446,6 +454,89 @@ describe('vacation accrual overview route', () => {
           'No employees are available for this department in the current accrual snapshot.'
         )
       ).not.toBeInTheDocument();
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('uses the centralized threshold assumptions on the department detail page', async () => {
+    server.use(
+      http.get('/api/user/me', () => HttpResponse.json(mockUser)),
+      http.get('/api/accrual/assumptions', () =>
+        HttpResponse.json({
+          ...mockAccrualAssumptions,
+          approachingThresholdPct: 85,
+          atCapThresholdPct: 95,
+        })
+      ),
+      http.get('/api/accrual/department/:departmentCode', ({ params }) => {
+        if (params.departmentCode !== '030003') {
+          return HttpResponse.json({ message: 'Not found' }, { status: 404 });
+        }
+
+        return HttpResponse.json({
+          asOfDate: '2026-03-31T00:00:00',
+          avgBalanceHours: 178,
+          approachingCapCount: 1,
+          atCapCount: 1,
+          departmentCode: '030003',
+          departmentName: 'PLANT SCIENCES',
+          departments: [
+            {
+              code: '030003',
+              name: 'PLANT SCIENCES',
+            },
+          ],
+          employees: [
+            {
+              accrualHoursPerMonth: 16,
+              balanceHours: 365,
+              capHours: 384,
+              classification: 'FY Faculty',
+              employeeId: '10206082',
+              employeeName: 'Threshold,Casey',
+              lastVacationDate: '2026-01-31T00:00:00',
+              lostCostMonth: 1248,
+              monthsToCap: 1,
+              pctOfCap: 95,
+            },
+            {
+              accrualHoursPerMonth: 8,
+              balanceHours: 334,
+              capHours: 384,
+              classification: 'PSS',
+              employeeId: '10243193',
+              employeeName: 'Approach,Alex',
+              lastVacationDate: '2026-02-28T00:00:00',
+              lostCostMonth: 0,
+              monthsToCap: 2,
+              pctOfCap: 87,
+            },
+          ],
+          headcount: 2,
+          lostCostMonth: 1248,
+          lostCostYtd: 1248,
+          ytdMonthCount: 9,
+        });
+      })
+    );
+
+    const { cleanup } = renderRoute({
+      initialPath: '/accruals/department/030003',
+    });
+
+    try {
+      const atCapRow = (
+        await screen.findByText('Threshold,Casey')
+      ).closest('tr');
+      const approachingRow = screen.getByText('Approach,Alex').closest('tr');
+
+      expect(atCapRow).not.toBeNull();
+      expect(approachingRow).not.toBeNull();
+      expect(within(atCapRow!).getAllByText('At Cap').length).toBeGreaterThan(0);
+      expect(
+        within(approachingRow!).getAllByText('Approaching').length
+      ).toBeGreaterThan(0);
     } finally {
       cleanup();
     }

--- a/web/client/src/test/routes/(authenticated)/accrual-overview.test.tsx
+++ b/web/client/src/test/routes/(authenticated)/accrual-overview.test.tsx
@@ -106,7 +106,42 @@ describe('vacation accrual overview route', () => {
   });
 
   it('renders the accrual assumptions page', async () => {
-    server.use(http.get('/api/user/me', () => HttpResponse.json(mockUser)));
+    server.use(
+      http.get('/api/user/me', () => HttpResponse.json(mockUser)),
+      http.get('/api/accrual/assumptions', () =>
+        HttpResponse.json({
+          approachingThresholdPct: 80,
+          atCapThresholdPct: 96,
+          benefitsRates: [
+            { label: 'FY Acad Admin', rate: 0.41 },
+            { label: 'FY Acad Coord', rate: 0.41 },
+            { label: 'FY Faculty', rate: 0.41 },
+            { label: 'All other classes', rate: 0.51 },
+          ],
+          fallbackAccrualTiers: [
+            { label: '384+ cap hours', monthlyAccrualHours: 16 },
+            { label: '368+ cap hours', monthlyAccrualHours: 15.33 },
+            { label: '352+ cap hours', monthlyAccrualHours: 14.67 },
+            { label: '336+ cap hours', monthlyAccrualHours: 14 },
+            { label: '320+ cap hours', monthlyAccrualHours: 13.33 },
+            { label: '288+ cap hours', monthlyAccrualHours: 12 },
+            { label: '240+ cap hours', monthlyAccrualHours: 10 },
+            { label: 'Below 240 cap hours', monthlyAccrualHours: 10 },
+          ],
+          hourlyRates: [
+            { label: 'FY Acad Admin', hourlyRate: 65 },
+            { label: 'FY Acad Coord', hourlyRate: 62 },
+            { label: 'FY Faculty', hourlyRate: 78 },
+            { label: 'FY Researcher', hourlyRate: 68 },
+            { label: 'MSP', hourlyRate: 52 },
+            { label: 'PSS', hourlyRate: 32.5 },
+            { label: 'SMG', hourlyRate: 72 },
+            { label: 'Fallback academic', hourlyRate: 70 },
+            { label: 'Fallback staff', hourlyRate: 45 },
+          ],
+        })
+      )
+    );
 
     const { cleanup } = renderRoute({ initialPath: '/accruals/about' });
 
@@ -118,8 +153,9 @@ describe('vacation accrual overview route', () => {
       expect(screen.getByText('Status Thresholds')).toBeInTheDocument();
       expect(screen.getByText('Benefits Loads')).toBeInTheDocument();
       expect(screen.getByText('96.0% and above')).toBeInTheDocument();
+      expect(screen.getAllByText('41% composite benefits load')).toHaveLength(3);
       expect(
-        screen.getByText('41% composite benefits load')
+        screen.getByText('51% composite benefits load')
       ).toBeInTheDocument();
       expect(screen.getByText('$78.00/hr')).toBeInTheDocument();
       expect(screen.getByText('14.67 hrs/month')).toBeInTheDocument();

--- a/web/client/src/test/routes/(authenticated)/accrual-overview.test.tsx
+++ b/web/client/src/test/routes/(authenticated)/accrual-overview.test.tsx
@@ -309,10 +309,34 @@ describe('vacation accrual overview route', () => {
       expect(screen.getByLabelText('Department')).toHaveValue('030003');
       expect(
         screen.getByRole('link', { name: 'About this report' })
-      ).toHaveAttribute('href', '/accruals/about');
+      ).toHaveAttribute('href', '/accruals/about?departmentCode=030003');
       expect(screen.getByText('Gradziel,Thomas M')).toBeInTheDocument();
       expect(screen.getByText('Saichaie,Amanda M')).toBeInTheDocument();
       expect(screen.queryByText('Preview')).not.toBeInTheDocument();
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('returns to the current department from the about page when department context is provided', async () => {
+    server.use(
+      http.get('/api/user/me', () => HttpResponse.json(mockUser)),
+      http.get('/api/accrual/assumptions', () =>
+        HttpResponse.json(mockAccrualAssumptions)
+      )
+    );
+
+    const { cleanup } = renderRoute({
+      initialPath: '/accruals/about?departmentCode=030003',
+    });
+
+    try {
+      expect(
+        await screen.findByRole('heading', { name: 'About This Report' })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('link', { name: /Back to Department/i })
+      ).toHaveAttribute('href', '/accruals/department/030003');
     } finally {
       cleanup();
     }

--- a/web/client/src/test/routes/(authenticated)/accrual-overview.test.tsx
+++ b/web/client/src/test/routes/(authenticated)/accrual-overview.test.tsx
@@ -471,6 +471,20 @@ describe('vacation accrual overview route', () => {
         await screen.findByText('Saichaie,Amanda M')
       ).toBeInTheDocument();
 
+      const employeeSearch = screen.getByPlaceholderText('Search by name or ID...');
+      await user.type(employeeSearch, 'Amanda');
+
+      expect(screen.getByText('Saichaie,Amanda M')).toBeInTheDocument();
+      expect(screen.queryByText('Gradziel,Thomas M')).not.toBeInTheDocument();
+
+      const clearSearchButton = within(
+        employeeSearch.parentElement as HTMLElement
+      ).getByRole('button');
+      await user.click(clearSearchButton);
+
+      expect(employeeSearch).toHaveValue('');
+      expect(screen.getByText('Gradziel,Thomas M')).toBeInTheDocument();
+
       const classificationSelect = screen.getAllByRole('combobox')[1];
       await user.selectOptions(classificationSelect, 'PSS');
 

--- a/web/server/Controllers/AccrualController.cs
+++ b/web/server/Controllers/AccrualController.cs
@@ -47,8 +47,9 @@ public sealed class AccrualController : ApiControllerBase
     }
 
     [HttpGet("assumptions")]
-    public IActionResult GetAssumptions()
+    public Task<IActionResult> GetAssumptionsAsync(CancellationToken cancellationToken)
     {
-        return Ok(AccrualOverviewCalculator.GetAssumptions());
+        cancellationToken.ThrowIfCancellationRequested();
+        return Task.FromResult<IActionResult>(Ok(AccrualOverviewCalculator.GetAssumptions()));
     }
 }

--- a/web/server/Controllers/AccrualController.cs
+++ b/web/server/Controllers/AccrualController.cs
@@ -45,4 +45,10 @@ public sealed class AccrualController : ApiControllerBase
 
         return Ok(detail);
     }
+
+    [HttpGet("assumptions")]
+    public IActionResult GetAssumptions()
+    {
+        return Ok(AccrualOverviewCalculator.GetAssumptions());
+    }
 }

--- a/web/server/Models/AccrualAssumptionsResponse.cs
+++ b/web/server/Models/AccrualAssumptionsResponse.cs
@@ -1,0 +1,28 @@
+namespace server.Models;
+
+public sealed class AccrualAssumptionsResponse
+{
+    public decimal ApproachingThresholdPct { get; init; }
+    public decimal AtCapThresholdPct { get; init; }
+    public IReadOnlyList<AccrualBenefitsRateRow> BenefitsRates { get; init; } = [];
+    public IReadOnlyList<AccrualFallbackAccrualTierRow> FallbackAccrualTiers { get; init; } = [];
+    public IReadOnlyList<AccrualHourlyRateRow> HourlyRates { get; init; } = [];
+}
+
+public sealed class AccrualBenefitsRateRow
+{
+    public string Label { get; init; } = string.Empty;
+    public decimal Rate { get; init; }
+}
+
+public sealed class AccrualHourlyRateRow
+{
+    public string Label { get; init; } = string.Empty;
+    public decimal HourlyRate { get; init; }
+}
+
+public sealed class AccrualFallbackAccrualTierRow
+{
+    public string Label { get; init; } = string.Empty;
+    public decimal MonthlyAccrualHours { get; init; }
+}

--- a/web/server/Services/AccrualCalculationSettings.cs
+++ b/web/server/Services/AccrualCalculationSettings.cs
@@ -1,0 +1,178 @@
+using server.Models;
+
+namespace server.Services;
+
+public sealed class AccrualCalculationSettings
+{
+    private static readonly StringComparer ClassificationComparer = StringComparer.OrdinalIgnoreCase;
+
+    public static AccrualCalculationSettings Current { get; } = new(
+        approachingThresholdPct: 80m,
+        atCapThresholdPct: 96m,
+        facultyLikeBenefitsRate: 0.41m,
+        defaultBenefitsRate: 0.51m,
+        defaultAcademicRate: 70m,
+        defaultStaffRate: 45m,
+        facultyLikeClassifications:
+        [
+            "FY Acad Admin",
+            "FY Acad Coord",
+            "FY Faculty",
+        ],
+        hourlyRateBuckets:
+        [
+            new RateBucket("FY Acad Admin", 65m),
+            new RateBucket("FY Acad Coord", 62m),
+            new RateBucket("FY Faculty", 78m),
+            new RateBucket("FY Researcher", 68m),
+            new RateBucket("MSP", 52m),
+            new RateBucket("PSS", 32.5m),
+            new RateBucket("SMG", 72m),
+        ],
+        fallbackAccrualTiers:
+        [
+            new FallbackAccrualTier(384m, 16m),
+            new FallbackAccrualTier(368m, 15.33m),
+            new FallbackAccrualTier(352m, 14.67m),
+            new FallbackAccrualTier(336m, 14m),
+            new FallbackAccrualTier(320m, 13.33m),
+            new FallbackAccrualTier(288m, 12m),
+            new FallbackAccrualTier(240m, 10m),
+        ]);
+
+    private readonly HashSet<string> _facultyLikeClassificationSet;
+
+    private AccrualCalculationSettings(
+        decimal approachingThresholdPct,
+        decimal atCapThresholdPct,
+        decimal facultyLikeBenefitsRate,
+        decimal defaultBenefitsRate,
+        decimal defaultAcademicRate,
+        decimal defaultStaffRate,
+        IReadOnlyList<string> facultyLikeClassifications,
+        IReadOnlyList<RateBucket> hourlyRateBuckets,
+        IReadOnlyList<FallbackAccrualTier> fallbackAccrualTiers)
+    {
+        ApproachingThresholdPct = approachingThresholdPct;
+        AtCapThresholdPct = atCapThresholdPct;
+        FacultyLikeBenefitsRate = facultyLikeBenefitsRate;
+        DefaultBenefitsRate = defaultBenefitsRate;
+        DefaultAcademicRate = defaultAcademicRate;
+        DefaultStaffRate = defaultStaffRate;
+        FacultyLikeClassifications = facultyLikeClassifications;
+        HourlyRateBuckets = hourlyRateBuckets;
+        FallbackAccrualTiers = fallbackAccrualTiers;
+        _facultyLikeClassificationSet = new HashSet<string>(facultyLikeClassifications, ClassificationComparer);
+    }
+
+    public decimal ApproachingThresholdPct { get; }
+    public decimal AtCapThresholdPct { get; }
+    public decimal DefaultAcademicRate { get; }
+    public decimal DefaultBenefitsRate { get; }
+    public decimal DefaultStaffRate { get; }
+    public decimal FacultyLikeBenefitsRate { get; }
+    public IReadOnlyList<string> FacultyLikeClassifications { get; }
+    public IReadOnlyList<FallbackAccrualTier> FallbackAccrualTiers { get; }
+    public IReadOnlyList<RateBucket> HourlyRateBuckets { get; }
+
+    public decimal GetBenefitsRate(string classification)
+    {
+        return _facultyLikeClassificationSet.Contains(classification)
+            ? FacultyLikeBenefitsRate
+            : DefaultBenefitsRate;
+    }
+
+    public decimal GetHourlyRate(string classification)
+    {
+        foreach (var bucket in HourlyRateBuckets)
+        {
+            if (ClassificationComparer.Equals(bucket.Label, classification))
+            {
+                return bucket.HourlyRate;
+            }
+        }
+
+        return classification.Contains("Academic", StringComparison.OrdinalIgnoreCase)
+            ? DefaultAcademicRate
+            : DefaultStaffRate;
+    }
+
+    public decimal GetLoadedHourlyRate(string classification, decimal? hourlyRate = null)
+    {
+        var baseRate = hourlyRate ?? GetHourlyRate(classification);
+        return baseRate * (1m + GetBenefitsRate(classification));
+    }
+
+    public decimal GetNormalMonthlyAccrual(decimal accrualLimit)
+    {
+        foreach (var tier in FallbackAccrualTiers)
+        {
+            if (accrualLimit >= tier.MinCapHours)
+            {
+                return tier.MonthlyAccrualHours;
+            }
+        }
+
+        return FallbackAccrualTiers[^1].MonthlyAccrualHours;
+    }
+
+    public AccrualAssumptionsResponse ToResponse()
+    {
+        var benefitsRates = FacultyLikeClassifications
+            .Select(classification => new AccrualBenefitsRateRow
+            {
+                Label = classification,
+                Rate = FacultyLikeBenefitsRate,
+            })
+            .Append(new AccrualBenefitsRateRow
+            {
+                Label = "All other classes",
+                Rate = DefaultBenefitsRate,
+            })
+            .ToList();
+
+        var hourlyRates = HourlyRateBuckets
+            .Select(bucket => new AccrualHourlyRateRow
+            {
+                HourlyRate = bucket.HourlyRate,
+                Label = bucket.Label,
+            })
+            .Append(new AccrualHourlyRateRow
+            {
+                HourlyRate = DefaultAcademicRate,
+                Label = "Fallback academic",
+            })
+            .Append(new AccrualHourlyRateRow
+            {
+                HourlyRate = DefaultStaffRate,
+                Label = "Fallback staff",
+            })
+            .ToList();
+
+        var fallbackTiers = FallbackAccrualTiers
+            .Select(tier => new AccrualFallbackAccrualTierRow
+            {
+                Label = $"{tier.MinCapHours:0}+ cap hours",
+                MonthlyAccrualHours = tier.MonthlyAccrualHours,
+            })
+            .Append(new AccrualFallbackAccrualTierRow
+            {
+                Label = $"Below {FallbackAccrualTiers[^1].MinCapHours:0} cap hours",
+                MonthlyAccrualHours = FallbackAccrualTiers[^1].MonthlyAccrualHours,
+            })
+            .ToList();
+
+        return new AccrualAssumptionsResponse
+        {
+            ApproachingThresholdPct = ApproachingThresholdPct,
+            AtCapThresholdPct = AtCapThresholdPct,
+            BenefitsRates = benefitsRates,
+            FallbackAccrualTiers = fallbackTiers,
+            HourlyRates = hourlyRates,
+        };
+    }
+
+    public sealed record FallbackAccrualTier(decimal MinCapHours, decimal MonthlyAccrualHours);
+
+    public sealed record RateBucket(string Label, decimal HourlyRate);
+}

--- a/web/server/Services/AccrualOverviewCalculator.cs
+++ b/web/server/Services/AccrualOverviewCalculator.cs
@@ -5,6 +5,9 @@ namespace server.Services;
 
 public static class AccrualOverviewCalculator
 {
+    private const decimal ApproachingThresholdPct = 80m;
+    private const decimal AtCapThresholdPct = 96m;
+
     // These rates are used to estimate the cost of lost vacation accrual for employees who are at or approaching their accrual cap.
     // Using data from Nephi 2026 -- should be replaced with actual data from the system when available.
     private const decimal DefaultAcademicRate = 70m;
@@ -498,6 +501,8 @@ public static class AccrualOverviewCalculator
         {
             >= 384m => 16m,
             >= 368m => 15.33m,
+            >= 352m => 14.67m,
+            >= 336m => 14m,
             >= 320m => 13.33m,
             >= 288m => 12m,
             >= 240m => 10m,
@@ -523,8 +528,8 @@ public static class AccrualOverviewCalculator
     {
         return percentage switch
         {
-            >= 100m => AccrualStatus.AtCap,
-            >= 80m => AccrualStatus.Approaching,
+            >= AtCapThresholdPct => AccrualStatus.AtCap,
+            >= ApproachingThresholdPct => AccrualStatus.Approaching,
             _ => AccrualStatus.Active,
         };
     }

--- a/web/server/Services/AccrualOverviewCalculator.cs
+++ b/web/server/Services/AccrualOverviewCalculator.cs
@@ -7,6 +7,8 @@ public static class AccrualOverviewCalculator
 {
     private const decimal ApproachingThresholdPct = 80m;
     private const decimal AtCapThresholdPct = 96m;
+    private const decimal FacultyLikeBenefitsRate = 0.41m;
+    private const decimal DefaultBenefitsRate = 0.51m;
 
     // These rates are used to estimate the cost of lost vacation accrual for employees who are at or approaching their accrual cap.
     // Using data from Nephi 2026 -- should be replaced with actual data from the system when available.
@@ -307,7 +309,7 @@ public static class AccrualOverviewCalculator
             hourlyRate,
             lastVacationDate,
             status == AccrualStatus.AtCap
-                ? DecimalRound(normalMonthlyAccrual * hourlyRate)
+                ? DecimalRound(normalMonthlyAccrual * GetLoadedHourlyRate(classification, hourlyRate))
                 : 0m,
             monthsToCap,
             DecimalRound(normalMonthlyAccrual),
@@ -521,6 +523,19 @@ public static class AccrualOverviewCalculator
         return employeeClassDescription.Contains("Academic", StringComparison.OrdinalIgnoreCase)
             ? DefaultAcademicRate
             : DefaultStaffRate;
+    }
+
+    // Applies the current parity rule: faculty-like classes use 41% benefits load, all others use 51%.
+    private static decimal GetBenefitsRate(string classification)
+    {
+        return string.Equals(classification, "FY Faculty", StringComparison.OrdinalIgnoreCase)
+            ? FacultyLikeBenefitsRate
+            : DefaultBenefitsRate;
+    }
+
+    private static decimal GetLoadedHourlyRate(string classification, decimal hourlyRate)
+    {
+        return hourlyRate * (1m + GetBenefitsRate(classification));
     }
 
     // Classifies employees into the status groupings shown in the overview and detail screens.

--- a/web/server/Services/AccrualOverviewCalculator.cs
+++ b/web/server/Services/AccrualOverviewCalculator.cs
@@ -5,25 +5,12 @@ namespace server.Services;
 
 public static class AccrualOverviewCalculator
 {
-    private const decimal ApproachingThresholdPct = 80m;
-    private const decimal AtCapThresholdPct = 96m;
-    private const decimal FacultyLikeBenefitsRate = 0.41m;
-    private const decimal DefaultBenefitsRate = 0.51m;
+    private static readonly AccrualCalculationSettings Settings = AccrualCalculationSettings.Current;
 
-    // These rates are used to estimate the cost of lost vacation accrual for employees who are at or approaching their accrual cap.
-    // Using data from Nephi 2026 -- should be replaced with actual data from the system when available.
-    private const decimal DefaultAcademicRate = 70m;
-    private const decimal DefaultStaffRate = 45m;
-    private static readonly Dictionary<string, decimal> HourlyRates = new(StringComparer.OrdinalIgnoreCase)
+    public static AccrualAssumptionsResponse GetAssumptions()
     {
-        ["FY Acad Admin"] = 65m,
-        ["FY Acad Coord"] = 62m,
-        ["FY Faculty"] = 78m,
-        ["FY Researcher"] = 68m,
-        ["MSP"] = 52m,
-        ["PSS"] = 32.5m,
-        ["SMG"] = 72m,
-    };
+        return Settings.ToResponse();
+    }
 
     // Builds the top-level overview response from the available accrual history.
     public static AccrualOverviewResponse Build(IReadOnlyList<EmployeeAccrualBalanceRecord> records)
@@ -499,54 +486,39 @@ public static class AccrualOverviewCalculator
     // Derives the standard monthly accrual from the employee's accrual cap tiers.
     private static decimal GetNormalMonthlyAccrual(decimal accrualLimit)
     {
-        return accrualLimit switch
-        {
-            >= 384m => 16m,
-            >= 368m => 15.33m,
-            >= 352m => 14.67m,
-            >= 336m => 14m,
-            >= 320m => 13.33m,
-            >= 288m => 12m,
-            >= 240m => 10m,
-            _ => 10m,
-        };
+        return Settings.GetNormalMonthlyAccrual(accrualLimit);
     }
 
     // Chooses an hourly rate bucket for lost-cost estimation.
     private static decimal GetHourlyRate(string employeeClassDescription)
     {
-        if (HourlyRates.TryGetValue(employeeClassDescription, out var rate))
-        {
-            return rate;
-        }
-
-        return employeeClassDescription.Contains("Academic", StringComparison.OrdinalIgnoreCase)
-            ? DefaultAcademicRate
-            : DefaultStaffRate;
+        return Settings.GetHourlyRate(employeeClassDescription);
     }
 
-    // Applies the current parity rule: faculty-like classes use 41% benefits load, all others use 51%.
     private static decimal GetBenefitsRate(string classification)
     {
-        return string.Equals(classification, "FY Faculty", StringComparison.OrdinalIgnoreCase)
-            ? FacultyLikeBenefitsRate
-            : DefaultBenefitsRate;
+        return Settings.GetBenefitsRate(classification);
     }
 
     private static decimal GetLoadedHourlyRate(string classification, decimal hourlyRate)
     {
-        return hourlyRate * (1m + GetBenefitsRate(classification));
+        return Settings.GetLoadedHourlyRate(classification, hourlyRate);
     }
 
     // Classifies employees into the status groupings shown in the overview and detail screens.
     private static AccrualStatus GetStatus(decimal percentage)
     {
-        return percentage switch
+        if (percentage >= Settings.AtCapThresholdPct)
         {
-            >= AtCapThresholdPct => AccrualStatus.AtCap,
-            >= ApproachingThresholdPct => AccrualStatus.Approaching,
-            _ => AccrualStatus.Active,
-        };
+            return AccrualStatus.AtCap;
+        }
+
+        if (percentage >= Settings.ApproachingThresholdPct)
+        {
+            return AccrualStatus.Approaching;
+        }
+
+        return AccrualStatus.Active;
     }
 
     // Picks the most common non-empty string from duplicated source rows.

--- a/web/tests/server.tests/Services/AccrualOverviewCalculatorTests.cs
+++ b/web/tests/server.tests/Services/AccrualOverviewCalculatorTests.cs
@@ -18,6 +18,20 @@ public sealed class AccrualOverviewCalculatorTests
     }
 
     [Fact]
+    public void GetAssumptions_returns_centralized_settings()
+    {
+        var result = AccrualOverviewCalculator.GetAssumptions();
+
+        result.AtCapThresholdPct.Should().Be(96m);
+        result.ApproachingThresholdPct.Should().Be(80m);
+        result.BenefitsRates.Should().Contain(row => row.Label == "FY Faculty" && row.Rate == 0.41m);
+        result.BenefitsRates.Should().Contain(row => row.Label == "All other classes" && row.Rate == 0.51m);
+        result.HourlyRates.Should().Contain(row => row.Label == "FY Faculty" && row.HourlyRate == 78m);
+        result.FallbackAccrualTiers.Should().Contain(row => row.Label == "352+ cap hours" && row.MonthlyAccrualHours == 14.67m);
+        result.FallbackAccrualTiers.Should().Contain(row => row.Label == "Below 240 cap hours" && row.MonthlyAccrualHours == 10m);
+    }
+
+    [Fact]
     public void Build_uses_latest_month_snapshot_and_deduplicates_employee_rows()
     {
         var records = new List<EmployeeAccrualBalanceRecord>

--- a/web/tests/server.tests/Services/AccrualOverviewCalculatorTests.cs
+++ b/web/tests/server.tests/Services/AccrualOverviewCalculatorTests.cs
@@ -379,6 +379,121 @@ public sealed class AccrualOverviewCalculatorTests
             .Should().Contain(["Biweekly,Employee", "Monthly,Employee"]);
     }
 
+    [Fact]
+    public void Build_treats_employees_at_or_above_96_percent_as_at_cap()
+    {
+        var records = new List<EmployeeAccrualBalanceRecord>
+        {
+            CreateRecord(
+                employeeId: "E001",
+                employeeName: "Threshold,Employee",
+                asOfDate: new DateTime(2026, 2, 28),
+                departmentCode: "030090",
+                department: "NUTRITION",
+                employeeClassDescription: "Academic: Faculty",
+                calculatedBal: 360m,
+                accrualLimit: 384m,
+                accrualHours: 12m,
+                accrualPercentage: 93.8m),
+            CreateRecord(
+                employeeId: "E001",
+                employeeName: "Threshold,Employee",
+                asOfDate: new DateTime(2026, 3, 31),
+                departmentCode: "030090",
+                department: "NUTRITION",
+                employeeClassDescription: "Academic: Faculty",
+                calculatedBal: 372m,
+                accrualLimit: 384m,
+                accrualHours: 0m,
+                accrualPercentage: 96.9m),
+        };
+
+        var result = AccrualOverviewCalculator.Build(records);
+
+        result.TotalEmployees.Should().Be(1);
+        result.AtCapCount.Should().Be(1);
+        result.ApproachingCapCount.Should().Be(0);
+        result.LostCostMonth.Should().Be(936m);
+        result.LostCostYtd.Should().Be(936m);
+        result.DepartmentBreakdown.Should().ContainSingle();
+        result.DepartmentBreakdown[0].AtCapCount.Should().Be(1);
+        result.DepartmentBreakdown[0].ApproachingCapCount.Should().Be(0);
+    }
+
+    [Fact]
+    public void Build_keeps_employees_below_96_percent_in_approaching()
+    {
+        var records = new List<EmployeeAccrualBalanceRecord>
+        {
+            CreateRecord(
+                employeeId: "E001",
+                employeeName: "Boundary,Employee",
+                asOfDate: new DateTime(2026, 3, 31),
+                departmentCode: "030090",
+                department: "NUTRITION",
+                employeeClassDescription: "Academic: Faculty",
+                calculatedBal: 368m,
+                accrualLimit: 384m,
+                accrualHours: 16m,
+                accrualPercentage: 95.8m),
+        };
+
+        var result = AccrualOverviewCalculator.Build(records);
+
+        result.TotalEmployees.Should().Be(1);
+        result.AtCapCount.Should().Be(0);
+        result.ApproachingCapCount.Should().Be(1);
+        result.LostCostMonth.Should().Be(0m);
+        result.DepartmentBreakdown.Should().ContainSingle();
+        result.DepartmentBreakdown[0].AtCapCount.Should().Be(0);
+        result.DepartmentBreakdown[0].ApproachingCapCount.Should().Be(1);
+    }
+
+    [Fact]
+    public void BuildDepartmentDetail_uses_mid_tier_fallback_accrual_rates_when_current_history_has_no_positive_accrual()
+    {
+        var records = new List<EmployeeAccrualBalanceRecord>
+        {
+            CreateRecord(
+                employeeId: "E001",
+                employeeName: "Fallback352,Employee",
+                asOfDate: new DateTime(2026, 3, 31),
+                departmentCode: "030003",
+                department: "PLANT SCIENCES",
+                employeeClassDescription: "Staff: Career",
+                calculatedBal: 352m,
+                accrualLimit: 352m,
+                accrualHours: 0m,
+                accrualPercentage: 100m),
+            CreateRecord(
+                employeeId: "E002",
+                employeeName: "Fallback336,Employee",
+                asOfDate: new DateTime(2026, 3, 31),
+                departmentCode: "030003",
+                department: "PLANT SCIENCES",
+                employeeClassDescription: "Staff: Career",
+                calculatedBal: 336m,
+                accrualLimit: 336m,
+                accrualHours: 0m,
+                accrualPercentage: 100m),
+        };
+
+        var result = AccrualOverviewCalculator.BuildDepartmentDetail(records, "030003");
+
+        result.Should().NotBeNull();
+        result!.Employees.Should().HaveCount(2);
+        result.Employees.Should().ContainSingle(employee =>
+            employee.EmployeeId == "E001" &&
+            employee.AccrualHoursPerMonth == 14.67m &&
+            employee.LostCostMonth == 476.78m);
+        result.Employees.Should().ContainSingle(employee =>
+            employee.EmployeeId == "E002" &&
+            employee.AccrualHoursPerMonth == 14m &&
+            employee.LostCostMonth == 455m);
+        result.LostCostMonth.Should().Be(931.78m);
+        result.AtCapCount.Should().Be(2);
+    }
+
     private static EmployeeAccrualBalanceRecord CreateRecord(
         string employeeId,
         string departmentCode,

--- a/web/tests/server.tests/Services/AccrualOverviewCalculatorTests.cs
+++ b/web/tests/server.tests/Services/AccrualOverviewCalculatorTests.cs
@@ -105,15 +105,15 @@ public sealed class AccrualOverviewCalculatorTests
         result.TotalDepartments.Should().Be(2);
         result.AtCapCount.Should().Be(1);
         result.ApproachingCapCount.Should().Be(1);
-        result.LostCostMonth.Should().Be(936m);
-        result.LostCostYtd.Should().Be(936m);
+        result.LostCostMonth.Should().Be(1319.76m);
+        result.LostCostYtd.Should().Be(1319.76m);
         result.YtdMonthCount.Should().Be(9);
-        result.WasteRate.Should().Be(74.2m);
+        result.WasteRate.Should().Be(104.7m);
 
         result.MonthlyLostCost.Should().HaveCount(2);
         result.MonthlyLostCost.Select(point => point.Label)
             .Should().ContainInOrder("Feb 26", "Mar 26");
-        result.MonthlyLostCost[^1].LostCost.Should().Be(936m);
+        result.MonthlyLostCost[^1].LostCost.Should().Be(1319.76m);
 
         result.EmployeeStatusOverTime.Should().HaveCount(2);
         result.EmployeeStatusOverTime[^1].AtCap.Should().Be(1);
@@ -124,8 +124,8 @@ public sealed class AccrualOverviewCalculatorTests
         result.DepartmentBreakdown[0].Department.Should().Be("NUTRITION");
         result.DepartmentBreakdown[0].DepartmentCode.Should().Be("030090");
         result.DepartmentBreakdown[0].Headcount.Should().Be(1);
-        result.DepartmentBreakdown[0].LostCostMonth.Should().Be(936m);
-        result.DepartmentBreakdown[0].LostCostYtd.Should().Be(936m);
+        result.DepartmentBreakdown[0].LostCostMonth.Should().Be(1319.76m);
+        result.DepartmentBreakdown[0].LostCostYtd.Should().Be(1319.76m);
         result.DepartmentBreakdown[0].AtCapCount.Should().Be(1);
         result.DepartmentBreakdown[1].Department.Should().Be("PLANT SCIENCES");
         result.DepartmentBreakdown[1].DepartmentCode.Should().Be("030003");
@@ -178,9 +178,9 @@ public sealed class AccrualOverviewCalculatorTests
         result.AsOfDate.Should().Be(new DateTime(2026, 4, 11));
         result.TotalEmployees.Should().Be(2);
         result.AtCapCount.Should().Be(2);
-        result.LostCostMonth.Should().Be(1508m);
+        result.LostCostMonth.Should().Be(2152.28m);
         result.MonthlyLostCost.Should().HaveCount(2);
-        result.MonthlyLostCost[^1].LostCost.Should().Be(1508m);
+        result.MonthlyLostCost[^1].LostCost.Should().Be(2152.28m);
         result.EmployeeStatusOverTime[^1].AtCap.Should().Be(2);
         result.DepartmentBreakdown.Should().HaveCount(2);
         result.DepartmentBreakdown.Select(row => row.DepartmentCode)
@@ -314,14 +314,14 @@ public sealed class AccrualOverviewCalculatorTests
         result.Headcount.Should().Be(2);
         result.AtCapCount.Should().Be(1);
         result.ApproachingCapCount.Should().Be(1);
-        result.LostCostMonth.Should().Be(1248m);
-        result.LostCostYtd.Should().Be(1248m);
+        result.LostCostMonth.Should().Be(1759.68m);
+        result.LostCostYtd.Should().Be(1759.68m);
         result.Departments.Select(d => d.Code).Should().ContainInOrder("030090", "030003");
         result.Employees.Should().HaveCount(2);
         result.Employees[0].EmployeeName.Should().Be("Gradziel,Thomas M");
         result.Employees[0].MonthsToCap.Should().Be(0);
         result.Employees[0].LastVacationDate.Should().Be(new DateTime(2026, 1, 31));
-        result.Employees[0].LostCostMonth.Should().Be(1248m);
+        result.Employees[0].LostCostMonth.Should().Be(1759.68m);
         result.Employees[1].EmployeeId.Should().Be("E002");
         result.Employees[1].MonthsToCap.Should().Be(8);
         result.Employees[1].PctOfCap.Should().Be(83.9m);
@@ -413,8 +413,8 @@ public sealed class AccrualOverviewCalculatorTests
         result.TotalEmployees.Should().Be(1);
         result.AtCapCount.Should().Be(1);
         result.ApproachingCapCount.Should().Be(0);
-        result.LostCostMonth.Should().Be(936m);
-        result.LostCostYtd.Should().Be(936m);
+        result.LostCostMonth.Should().Be(1319.76m);
+        result.LostCostYtd.Should().Be(1319.76m);
         result.DepartmentBreakdown.Should().ContainSingle();
         result.DepartmentBreakdown[0].AtCapCount.Should().Be(1);
         result.DepartmentBreakdown[0].ApproachingCapCount.Should().Be(0);
@@ -485,12 +485,12 @@ public sealed class AccrualOverviewCalculatorTests
         result.Employees.Should().ContainSingle(employee =>
             employee.EmployeeId == "E001" &&
             employee.AccrualHoursPerMonth == 14.67m &&
-            employee.LostCostMonth == 476.78m);
+            employee.LostCostMonth == 719.93m);
         result.Employees.Should().ContainSingle(employee =>
             employee.EmployeeId == "E002" &&
             employee.AccrualHoursPerMonth == 14m &&
-            employee.LostCostMonth == 455m);
-        result.LostCostMonth.Should().Be(931.78m);
+            employee.LostCostMonth == 687.05m);
+        result.LostCostMonth.Should().Be(1406.98m);
         result.AtCapCount.Should().Be(2);
     }
 


### PR DESCRIPTION
BARN v2 has new logic around cap and calc w/ benefit rates.  Also added an about screen which shows calc details

<img width="848" height="952" alt="image" src="https://github.com/user-attachments/assets/fdd0a5ed-9c19-4070-a12d-85bc05f47958" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an "About Accruals" page showing calculation assumptions, benefits rates, hourly rates, and accrual thresholds
  * Exposed accrual assumptions to the client via a new API and query hooks
  * Department rows now link to department detail; improved row navigation behavior
  * Employee status logic now uses configurable thresholds; added consistent "As Of" cards

* **Tests**
  * Added and updated tests covering the new about page, thresholds, and back-navigation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->