### PR TITLE
Exclude Jun-23 period from GL/PPM reconciliation

### DIFF
--- a/datamart/StoredProcedures/usp_GetGLPPMReconciliation.sql
+++ b/datamart/StoredProcedures/usp_GetGLPPMReconciliation.sql
@@ -52,7 +52,7 @@ BEGIN
             ACTIVITY_DESCRIPTION,
             SUM(ACTUAL_AMOUNT) AS GL_ACTUAL_AMOUNT
         FROM ae_dwh.transactional_listing_report
-        WHERE PROJECT IN (' + @ProjectIdFilter + ')'
+        WHERE PROJECT IN (' + @ProjectIdFilter + ') AND PERIOD_NAME <> ''Jun-23'''
         + CASE WHEN @ExcludedDocNumbers IS NOT NULL
                THEN ' AND ACCOUNTING_SEQUENCE_NUMBER NOT IN (' + @ExcludedDocNumbers + ')'
                ELSE ''


### PR DESCRIPTION
## Summary
- Adds `AND PERIOD_NAME <> 'Jun-23'` to the Redshift query in `usp_GetGLPPMReconciliation` so carryforward-era journals stop double-counting against PPM totals.
- Diagnostic test requested after AD-419 vs Walter discrepancy on PPMRC00001 / fund 12100 (Walter showed a $63,338.62 overstatement vs AD-419's $0).


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the reconciliation report to exclude June 2023 records from query results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->