### PR TITLE
Extended beta feedback: personnel column renames, search filters

### DIFF
--- a/web/client/src/components/project/InternalProjectsTable.tsx
+++ b/web/client/src/components/project/InternalProjectsTable.tsx
@@ -121,10 +121,12 @@ export function InternalProjectsTable({
 
   const columns = useMemo(
     () => [
-      columnHelper.accessor('displayName', {
+      // Accessor concatenates name + number so the global filter matches on
+      // either — the cell visibly renders both, but TanStack only filters
+      // accessor values, not rendered output.
+      columnHelper.accessor((row) => `${row.displayName} ${row.projectNumber}`, {
         cell: (info) => {
-          const name = info.getValue();
-          const { projectNumber } = info.row.original;
+          const { displayName: name, projectNumber } = info.row.original;
           return (
             <div className="flex items-start gap-1">
               <Link
@@ -151,6 +153,7 @@ export function InternalProjectsTable({
         },
         footer: () => 'Totals',
         header: 'Project',
+        id: 'displayName',
       }),
       columnHelper.accessor('taskNum', {
         cell: (info) => (

--- a/web/client/src/components/project/PersonnelTable.tsx
+++ b/web/client/src/components/project/PersonnelTable.tsx
@@ -153,20 +153,20 @@ function DistributionSubtable({
               </span>
             </th>
             <th>
-              <span className="flex justify-end w-full">Funding Effective</span>
+              <span className="flex justify-end w-full">Funding Eff. Date</span>
             </th>
             <th>
-              <span className="flex justify-end w-full">Funding End</span>
+              <span className="flex justify-end w-full">Funding End Date</span>
             </th>
             <th>
-              <span className="flex justify-end w-full">Salary</span>
+              <span className="flex justify-end w-full">Monthly Salary</span>
             </th>
             <th>
               <span className="flex justify-end w-full">
                 <TooltipLabel
-                  label="CBR"
+                  label="Monthly CBR"
                   placement="bottom"
-                  tooltip={tooltipDefinitions.cbr}
+                  tooltip={tooltipDefinitions.monthlyCbr}
                 />
               </span>
             </th>

--- a/web/client/src/components/project/SponsoredProjectsTable.tsx
+++ b/web/client/src/components/project/SponsoredProjectsTable.tsx
@@ -158,10 +158,12 @@ export function SponsoredProjectsTable({
 
   const columns = useMemo(
     () => [
-      columnHelper.accessor('displayName', {
+      // Accessor concatenates name + number so the global filter matches on
+      // either — the cell visibly renders both, but TanStack only filters
+      // accessor values, not rendered output.
+      columnHelper.accessor((row) => `${row.displayName} ${row.projectNumber}`, {
         cell: (info) => {
-          const name = info.getValue();
-          const { projectNumber } = info.row.original;
+          const { displayName: name, projectNumber } = info.row.original;
           return (
             <Link
               className="link no-underline flex items-start gap-1"
@@ -181,6 +183,7 @@ export function SponsoredProjectsTable({
         },
         footer: () => 'Totals',
         header: 'Project',
+        id: 'displayName',
         minSize: 250,
         size: 300,
       }),

--- a/web/client/src/test/components/PersonnelTable.test.tsx
+++ b/web/client/src/test/components/PersonnelTable.test.tsx
@@ -259,10 +259,12 @@ describe('PersonnelTable', () => {
 
     await user.unhover(distLabel.parentElement as HTMLElement);
 
-    const cbrLabel = screen.getByText('CBR');
-    await user.hover(cbrLabel.parentElement as HTMLElement);
+    // Two occurrences after expand: outer header and subtable header. Hover
+    // the subtable's (last) one.
+    const cbrLabels = screen.getAllByText('Monthly CBR');
+    await user.hover(cbrLabels[cbrLabels.length - 1].parentElement as HTMLElement);
     expect(await screen.findByRole('tooltip')).toHaveTextContent(
-      tooltipDefinitions.cbr
+      tooltipDefinitions.monthlyCbr
     );
   });
 

--- a/web/client/src/test/components/project/ProjectsTable.test.tsx
+++ b/web/client/src/test/components/project/ProjectsTable.test.tsx
@@ -236,4 +236,41 @@ describe('InternalProjectsTable', () => {
     expect(csv).not.toContain('Rainy Project');
     expect(filename).toBe('internal-projects-filtered.csv');
   });
+
+  it('filters rows by project number', () => {
+    const projects = [
+      createProject({
+        displayName: 'Sunny Project',
+        projectName: 'Sunny Project',
+        projectNumber: 'KAOSUN001',
+        projectType: 'Internal',
+        taskNum: 'T001',
+      }),
+      createProject({
+        displayName: 'Rainy Project',
+        projectName: 'Rainy Project',
+        projectNumber: 'KAORAI002',
+        projectType: 'Internal',
+        taskNum: 'T002',
+      }),
+    ];
+
+    render(
+      <InternalProjectsTable
+        discrepancies={new Set()}
+        employeeId="123"
+        records={projects}
+      />
+    );
+
+    expect(screen.getByText('KAOSUN001')).toBeInTheDocument();
+    expect(screen.getByText('KAORAI002')).toBeInTheDocument();
+
+    fireEvent.input(screen.getByPlaceholderText('Search all columns...'), {
+      target: { value: 'KAOSUN' },
+    });
+
+    expect(screen.getByText('KAOSUN001')).toBeInTheDocument();
+    expect(screen.queryByText('KAORAI002')).not.toBeInTheDocument();
+  });
 });

--- a/web/client/src/test/components/project/SponsoredProjectsTable.test.tsx
+++ b/web/client/src/test/components/project/SponsoredProjectsTable.test.tsx
@@ -134,4 +134,32 @@ describe('SponsoredProjectsTable', () => {
     expect(csv).toContain('01/01/2024');
     expect(filename).toBe('projects-filtered.csv');
   });
+
+  it('filters rows by project number', () => {
+    const projects = [
+      createProject({
+        displayName: 'Sunny Project',
+        projectName: 'Sunny Project',
+        projectNumber: 'KAOSUN001',
+      }),
+      createProject({
+        awardNumber: 'AWD002',
+        displayName: 'Rainy Project',
+        projectName: 'Rainy Project',
+        projectNumber: 'KAORAI002',
+      }),
+    ];
+
+    render(<SponsoredProjectsTable employeeId="123" records={projects} />);
+
+    expect(screen.getByText('Sunny Project')).toBeInTheDocument();
+    expect(screen.getByText('Rainy Project')).toBeInTheDocument();
+
+    fireEvent.input(screen.getByPlaceholderText('Search all columns...'), {
+      target: { value: 'KAOSUN' },
+    });
+
+    expect(screen.getByText('Sunny Project')).toBeInTheDocument();
+    expect(screen.queryByText('Rainy Project')).not.toBeInTheDocument();
+  });
 });

--- a/web/server/Controllers/SearchController.cs
+++ b/web/server/Controllers/SearchController.cs
@@ -116,12 +116,17 @@ public sealed class SearchController : ApiControllerBase
             ["personnel", "payroll"]
         ));
 
-        reports.Add(new SearchReport(
-            "reports",
-            "All Reports",
-            "/reports",
-            ["reports", "all reports"]
-        ));
+        // Only surface "All Reports" if the user can actually see something on /reports.
+        // Today that means CanViewAccruals; revisit when more reports land on that page.
+        if (canViewAccruals.Succeeded)
+        {
+            reports.Add(new SearchReport(
+                "reports",
+                "All Reports",
+                "/reports",
+                ["reports", "all reports"]
+            ));
+        }
 
         return Ok(new SearchCatalog(Array.Empty<SearchProject>(), reports));
     }

--- a/web/tests/server.tests/Controllers/SearchControllerTests.cs
+++ b/web/tests/server.tests/Controllers/SearchControllerTests.cs
@@ -82,6 +82,48 @@ public sealed class SearchControllerTests
     }
 
     [Fact]
+    public async Task GetCatalog_excludes_all_reports_entry_when_user_has_no_reports()
+    {
+        using AppDbContext ctx = TestDbContextFactory.CreateInMemory();
+        var authorizationService = CreateAuthorizationService();
+
+        var controller = CreateController(
+            ctx,
+            authorizationService,
+            new FakeGraphService(),
+            new FakeIdentityService(),
+            roles: []);
+
+        var result = await controller.GetCatalog(CancellationToken.None);
+
+        var catalog = result.Should().BeOfType<OkObjectResult>().Which.Value
+            .Should().BeOfType<SearchController.SearchCatalog>().Which;
+
+        catalog.Reports.Select(r => r.Id).Should().NotContain("reports");
+    }
+
+    [Fact]
+    public async Task GetCatalog_includes_all_reports_entry_when_user_can_view_accruals()
+    {
+        using AppDbContext ctx = TestDbContextFactory.CreateInMemory();
+        var authorizationService = CreateAuthorizationService();
+
+        var controller = CreateController(
+            ctx,
+            authorizationService,
+            new FakeGraphService(),
+            new FakeIdentityService(),
+            roles: [server.core.Domain.Role.Names.AccrualViewer]);
+
+        var result = await controller.GetCatalog(CancellationToken.None);
+
+        var catalog = result.Should().BeOfType<OkObjectResult>().Which.Value
+            .Should().BeOfType<SearchController.SearchCatalog>().Which;
+
+        catalog.Reports.Select(r => r.Id).Should().Contain("reports");
+    }
+
+    [Fact]
     public async Task SearchPeople_returns_empty_for_non_financial_users()
     {
         using AppDbContext ctx = TestDbContextFactory.CreateInMemory();


### PR DESCRIPTION
## Summary
Three items from issue #224 (extended beta feedback). Hourly rate work is deferred to a separate issue.

- **Personnel distribution subtable column renames** (`fcd4fb94`) — Salary → Monthly Salary, CBR → Monthly CBR (with monthlyCbr tooltip), Funding Effective → Funding Eff. Date, Funding End → Funding End Date.
- **Hide "All Reports" search entry for users with no reports** (`391bc020`) — server gates the catalog entry on the same condition that decides whether `/reports` has visible items (currently `CanViewAccruals`). Tests added mirroring existing accruals coverage.
- **Project number search in project tables** (`6d49fff9`) — `InternalProjectsTable` and `SponsoredProjectsTable` now match the global filter against project number as well as name. The cell already rendered both, but TanStack only filters accessor values; the displayName accessor now concatenates name + number. Sidebar and command palette already searched by project number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search functionality now includes project numbers for filtering results.
  * Report visibility now controlled by user authorization levels.

* **Improvements**
  * Updated table column headers with clearer terminology ("Date" for funding periods, "Monthly" for salary and cost metrics).
  * Project tables now display project numbers alongside project names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->