### PR TITLE
Add admin-editable notification banner (#245)

### DIFF
--- a/web/client/src/components/NotificationBanner.tsx
+++ b/web/client/src/components/NotificationBanner.tsx
@@ -1,4 +1,5 @@
 import { useNotificationQuery } from '@/queries/notification.ts';
+import { MegaphoneIcon } from '@heroicons/react/24/outline';
 
 export function NotificationBanner() {
   const { data } = useNotificationQuery();
@@ -8,7 +9,11 @@ export function NotificationBanner() {
   }
 
   return (
-    <div className="alert alert-warning" role="alert">
+    <div
+      className="alert alert-warning alert-soft rounded-none border-x-0 border-t-0 px-6 py-2"
+      role="alert"
+    >
+      <MegaphoneIcon className="h-5 w-5 shrink-0" />
       <span>{data.message}</span>
     </div>
   );

--- a/web/client/src/components/NotificationBanner.tsx
+++ b/web/client/src/components/NotificationBanner.tsx
@@ -1,0 +1,15 @@
+import { useNotificationQuery } from '@/queries/notification.ts';
+
+export function NotificationBanner() {
+  const { data } = useNotificationQuery();
+
+  if (!data?.enabled || !data.message) {
+    return null;
+  }
+
+  return (
+    <div className="alert alert-warning" role="alert">
+      <span>{data.message}</span>
+    </div>
+  );
+}

--- a/web/client/src/queries/notification.ts
+++ b/web/client/src/queries/notification.ts
@@ -1,0 +1,22 @@
+import { fetchJson } from '@/lib/api.ts';
+import { useQuery } from '@tanstack/react-query';
+
+export type NotificationData = {
+  enabled: boolean;
+  message: string;
+  updatedOn: string | null;
+};
+
+export const notificationQueryOptions = () => ({
+  queryFn: async ({
+    signal,
+  }: {
+    signal: AbortSignal;
+  }): Promise<NotificationData> => {
+    return await fetchJson<NotificationData>('/api/notification', {}, signal);
+  },
+  queryKey: ['notification'] as const,
+  staleTime: 60_000,
+});
+
+export const useNotificationQuery = () => useQuery(notificationQueryOptions());

--- a/web/client/src/queries/notification.ts
+++ b/web/client/src/queries/notification.ts
@@ -20,3 +20,13 @@ export const notificationQueryOptions = () => ({
 });
 
 export const useNotificationQuery = () => useQuery(notificationQueryOptions());
+
+export async function updateNotification(input: {
+  enabled: boolean;
+  message: string;
+}): Promise<NotificationData> {
+  return await fetchJson<NotificationData>('/api/notification', {
+    body: JSON.stringify(input),
+    method: 'PUT',
+  });
+}

--- a/web/client/src/routeTree.gen.ts
+++ b/web/client/src/routeTree.gen.ts
@@ -25,6 +25,7 @@ import { Route as authenticatedReportsIndexRouteImport } from './routes/(authent
 import { Route as authenticatedAdminIndexRouteImport } from './routes/(authenticated)/admin/index'
 import { Route as authenticatedAccrualsIndexRouteImport } from './routes/(authenticated)/accruals/index'
 import { Route as authenticatedAdminUsersRouteImport } from './routes/(authenticated)/admin/users'
+import { Route as authenticatedAdminNotificationRouteImport } from './routes/(authenticated)/admin/notification'
 import { Route as authenticatedAccrualsAboutRouteImport } from './routes/(authenticated)/accruals/about'
 import { Route as authenticatedProjectsEmployeeIdRouteRouteImport } from './routes/(authenticated)/projects/$employeeId/route'
 import { Route as authenticatedProjectsEmployeeIdIndexRouteImport } from './routes/(authenticated)/projects/$employeeId/index'
@@ -118,6 +119,12 @@ const authenticatedAdminUsersRoute = authenticatedAdminUsersRouteImport.update({
   path: '/users',
   getParentRoute: () => authenticatedAdminRouteRoute,
 } as any)
+const authenticatedAdminNotificationRoute =
+  authenticatedAdminNotificationRouteImport.update({
+    id: '/notification',
+    path: '/notification',
+    getParentRoute: () => authenticatedAdminRouteRoute,
+  } as any)
 const authenticatedAccrualsAboutRoute =
   authenticatedAccrualsAboutRouteImport.update({
     id: '/accruals/about',
@@ -189,6 +196,7 @@ export interface FileRoutesByFullPath {
   '/': typeof authenticatedIndexRoute
   '/projects/$employeeId': typeof authenticatedProjectsEmployeeIdRouteRouteWithChildren
   '/accruals/about': typeof authenticatedAccrualsAboutRoute
+  '/admin/notification': typeof authenticatedAdminNotificationRoute
   '/admin/users': typeof authenticatedAdminUsersRoute
   '/accruals': typeof authenticatedAccrualsIndexRoute
   '/admin/': typeof authenticatedAdminIndexRoute
@@ -212,6 +220,7 @@ export interface FileRoutesByTo {
   '/styles': typeof authenticatedStylesRoute
   '/': typeof authenticatedIndexRoute
   '/accruals/about': typeof authenticatedAccrualsAboutRoute
+  '/admin/notification': typeof authenticatedAdminNotificationRoute
   '/admin/users': typeof authenticatedAdminUsersRoute
   '/accruals': typeof authenticatedAccrualsIndexRoute
   '/admin': typeof authenticatedAdminIndexRoute
@@ -240,6 +249,7 @@ export interface FileRoutesById {
   '/(authenticated)/': typeof authenticatedIndexRoute
   '/(authenticated)/projects/$employeeId': typeof authenticatedProjectsEmployeeIdRouteRouteWithChildren
   '/(authenticated)/accruals/about': typeof authenticatedAccrualsAboutRoute
+  '/(authenticated)/admin/notification': typeof authenticatedAdminNotificationRoute
   '/(authenticated)/admin/users': typeof authenticatedAdminUsersRoute
   '/(authenticated)/accruals/': typeof authenticatedAccrualsIndexRoute
   '/(authenticated)/admin/': typeof authenticatedAdminIndexRoute
@@ -268,6 +278,7 @@ export interface FileRouteTypes {
     | '/'
     | '/projects/$employeeId'
     | '/accruals/about'
+    | '/admin/notification'
     | '/admin/users'
     | '/accruals'
     | '/admin/'
@@ -291,6 +302,7 @@ export interface FileRouteTypes {
     | '/styles'
     | '/'
     | '/accruals/about'
+    | '/admin/notification'
     | '/admin/users'
     | '/accruals'
     | '/admin'
@@ -318,6 +330,7 @@ export interface FileRouteTypes {
     | '/(authenticated)/'
     | '/(authenticated)/projects/$employeeId'
     | '/(authenticated)/accruals/about'
+    | '/(authenticated)/admin/notification'
     | '/(authenticated)/admin/users'
     | '/(authenticated)/accruals/'
     | '/(authenticated)/admin/'
@@ -450,6 +463,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof authenticatedAdminUsersRouteImport
       parentRoute: typeof authenticatedAdminRouteRoute
     }
+    '/(authenticated)/admin/notification': {
+      id: '/(authenticated)/admin/notification'
+      path: '/notification'
+      fullPath: '/admin/notification'
+      preLoaderRoute: typeof authenticatedAdminNotificationRouteImport
+      parentRoute: typeof authenticatedAdminRouteRoute
+    }
     '/(authenticated)/accruals/about': {
       id: '/(authenticated)/accruals/about'
       path: '/accruals/about'
@@ -517,12 +537,14 @@ declare module '@tanstack/react-router' {
 }
 
 interface authenticatedAdminRouteRouteChildren {
+  authenticatedAdminNotificationRoute: typeof authenticatedAdminNotificationRoute
   authenticatedAdminUsersRoute: typeof authenticatedAdminUsersRoute
   authenticatedAdminIndexRoute: typeof authenticatedAdminIndexRoute
 }
 
 const authenticatedAdminRouteRouteChildren: authenticatedAdminRouteRouteChildren =
   {
+    authenticatedAdminNotificationRoute: authenticatedAdminNotificationRoute,
     authenticatedAdminUsersRoute: authenticatedAdminUsersRoute,
     authenticatedAdminIndexRoute: authenticatedAdminIndexRoute,
   }

--- a/web/client/src/routes/(authenticated)/admin/index.tsx
+++ b/web/client/src/routes/(authenticated)/admin/index.tsx
@@ -5,7 +5,7 @@ import {
   hasSystemRole,
 } from '@/shared/auth/roleAccess.ts';
 import { useUser } from '@/shared/auth/UserContext.tsx';
-import { UsersIcon } from '@heroicons/react/24/outline';
+import { MegaphoneIcon, UsersIcon } from '@heroicons/react/24/outline';
 
 export const Route = createFileRoute('/(authenticated)/admin/')({
   component: RouteComponent,
@@ -59,6 +59,12 @@ function RouteComponent() {
             <Link className="btn btn-primary btn-lg" to="/admin/users">
               <UsersIcon className="w-4 h-4" />
               User Management
+            </Link>
+          ) : null}
+          {isAdmin ? (
+            <Link className="btn btn-primary btn-lg" to="/admin/notification">
+              <MegaphoneIcon className="w-4 h-4" />
+              Site Notification
             </Link>
           ) : null}
         </div>

--- a/web/client/src/routes/(authenticated)/admin/notification.tsx
+++ b/web/client/src/routes/(authenticated)/admin/notification.tsx
@@ -1,0 +1,148 @@
+import { HttpError } from '@/lib/api.ts';
+import { RouterContext } from '@/main.tsx';
+import {
+  notificationQueryOptions,
+  updateNotification,
+  useNotificationQuery,
+} from '@/queries/notification.ts';
+import { meQueryOptions } from '@/queries/user.ts';
+import { hasAdminRole } from '@/shared/auth/roleAccess.ts';
+import { ArrowLeftIcon, MegaphoneIcon } from '@heroicons/react/24/outline';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { createFileRoute, Link, redirect } from '@tanstack/react-router';
+import { useEffect, useState } from 'react';
+
+export const Route = createFileRoute('/(authenticated)/admin/notification')({
+  beforeLoad: async ({ context }: { context: RouterContext }) => {
+    const user = await context.queryClient.ensureQueryData(meQueryOptions());
+
+    if (!hasAdminRole(user.roles)) {
+      throw redirect({ to: '/admin' });
+    }
+  },
+  component: RouteComponent,
+});
+
+function RouteComponent() {
+  const notificationQuery = useNotificationQuery();
+  const queryClient = useQueryClient();
+
+  const [enabled, setEnabled] = useState(false);
+  const [message, setMessage] = useState('');
+  const [hydrated, setHydrated] = useState(false);
+
+  useEffect(() => {
+    if (!hydrated && notificationQuery.data) {
+      setEnabled(notificationQuery.data.enabled);
+      setMessage(notificationQuery.data.message);
+      setHydrated(true);
+    }
+  }, [hydrated, notificationQuery.data]);
+
+  const saveMutation = useMutation({
+    mutationFn: updateNotification,
+    onSuccess: (data) => {
+      queryClient.setQueryData(notificationQueryOptions().queryKey, data);
+    },
+  });
+
+  const saveError = saveMutation.error;
+  const isSaving = saveMutation.isPending;
+  const isLoadingInitial = notificationQuery.isLoading;
+
+  return (
+    <main className="mt-8">
+      <div className="container">
+        <Link className="btn btn-sm mb-4" to="/admin">
+          <ArrowLeftIcon className="w-4 h-4" />
+          Back to Admin Dashboard
+        </Link>
+        <MegaphoneIcon className="w-6 h-6" />
+        <h1 className="h1">Site Notification</h1>
+        <p className="subtitle">
+          Edit the banner shown at the top of the landing and home pages.
+        </p>
+        <hr className="border-main-border my-4" />
+
+        {isLoadingInitial ? (
+          <div className="flex items-center gap-3 text-sm text-base-content/70">
+            <div className="loading loading-spinner loading-sm" />
+            <span>Loading notification…</span>
+          </div>
+        ) : (
+          <form
+            className="flex max-w-2xl flex-col gap-4"
+            onSubmit={(e) => {
+              e.preventDefault();
+              saveMutation.reset();
+              saveMutation.mutate({ enabled, message });
+            }}
+          >
+            <label className="label cursor-pointer justify-start gap-3">
+              <input
+                checked={enabled}
+                className="toggle toggle-primary"
+                onChange={(e) => setEnabled(e.target.checked)}
+                type="checkbox"
+              />
+              <span className="label-text">Show notification banner</span>
+            </label>
+
+            <div>
+              <label className="label" htmlFor="notification-message">
+                <span className="label-text">Message</span>
+              </label>
+              <textarea
+                className="textarea textarea-bordered w-full"
+                id="notification-message"
+                maxLength={2000}
+                onChange={(e) => setMessage(e.target.value)}
+                placeholder="e.g. Walter is in a test environment. Data may be stale."
+                rows={4}
+                value={message}
+              />
+              <p className="label">
+                <span className="label-text-alt">
+                  {message.length} / 2000
+                </span>
+              </p>
+            </div>
+
+            <div className="flex items-center gap-3">
+              <button
+                className="btn btn-primary"
+                disabled={isSaving}
+                type="submit"
+              >
+                {isSaving ? (
+                  <>
+                    <span className="loading loading-spinner loading-sm" />
+                    Saving…
+                  </>
+                ) : (
+                  'Save'
+                )}
+              </button>
+
+              {saveMutation.isSuccess ? (
+                <span className="text-sm text-success">Saved.</span>
+              ) : null}
+            </div>
+
+            {saveError ? (
+              <div className="alert alert-error">
+                <span>
+                  Failed to save{' '}
+                  {saveError instanceof HttpError
+                    ? `(HTTP ${saveError.status})`
+                    : ''}
+                  .
+                </span>
+              </div>
+            ) : null}
+          </form>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/web/client/src/routes/(authenticated)/index.tsx
+++ b/web/client/src/routes/(authenticated)/index.tsx
@@ -144,115 +144,117 @@ function RouteComponent() {
   }
 
   return (
-    <div className="container">
+    <>
       <NotificationBanner />
-      <div className="pt-10 pb-5 mx-auto w-full sm:max-w-[90%] md:max-w-[80%] xl:max-w-[66%]">
-        <h1 className="text-2xl font-proxima-bold">W.A.L.T.E.R.</h1>
-        <p className="uppercase">
-          warehouse analytics and ledger tools for enterprise reporting
-        </p>
-      </div>
+      <div className="container">
+        <div className="pt-10 pb-5 mx-auto w-full sm:max-w-[90%] md:max-w-[80%] xl:max-w-[66%]">
+          <h1 className="text-2xl font-proxima-bold">W.A.L.T.E.R.</h1>
+          <p className="uppercase">
+            warehouse analytics and ledger tools for enterprise reporting
+          </p>
+        </div>
 
-      <div className="home-search relative mx-auto w-full sm:max-w-[90%] md:max-w-[80%] xl:max-w-[66%]">
-        <SearchButton className="w-full" />
-      </div>
+        <div className="home-search relative mx-auto w-full sm:max-w-[90%] md:max-w-[80%] xl:max-w-[66%]">
+          <SearchButton className="w-full" />
+        </div>
 
-      {tabs.length > 0 && (
-        <div className="tabs mt-16" role="tablist">
-          {tabs.map((tab, index) => {
-            const tabId = `tab-${tab.id}`;
-            const panelId = `panel-${tab.id}`;
-            return (
-              <button
-                aria-controls={panelId}
-                aria-selected={selectedTab === tab.id}
-                className={`text-2xl tab ${index === 0 ? 'ps-0' : ''} ${selectedTab === tab.id ? 'tab-active' : ''}`}
-                id={tabId}
-                key={tab.id}
-                onClick={() => setActiveTab(tab.id)}
-                role="tab"
-                type="button"
-              >
-                {tab.label}
-                {tab.id === 'alerts' && alertsLoading && (
-                  <span className="loading loading-spinner loading-xs ms-2" />
-                )}
-                {tab.id === 'alerts' &&
-                  !alertsLoading &&
-                  allAlerts.length > 0 && (
-                    <span className="badge badge-sm badge-warning ms-2">
-                      {allAlerts.length}
-                    </span>
+        {tabs.length > 0 && (
+          <div className="tabs mt-16" role="tablist">
+            {tabs.map((tab, index) => {
+              const tabId = `tab-${tab.id}`;
+              const panelId = `panel-${tab.id}`;
+              return (
+                <button
+                  aria-controls={panelId}
+                  aria-selected={selectedTab === tab.id}
+                  className={`text-2xl tab ${index === 0 ? 'ps-0' : ''} ${selectedTab === tab.id ? 'tab-active' : ''}`}
+                  id={tabId}
+                  key={tab.id}
+                  onClick={() => setActiveTab(tab.id)}
+                  role="tab"
+                  type="button"
+                >
+                  {tab.label}
+                  {tab.id === 'alerts' && alertsLoading && (
+                    <span className="loading loading-spinner loading-xs ms-2" />
                   )}
-              </button>
-            );
-          })}
-        </div>
-      )}
+                  {tab.id === 'alerts' &&
+                    !alertsLoading &&
+                    allAlerts.length > 0 && (
+                      <span className="badge badge-sm badge-warning ms-2">
+                        {allAlerts.length}
+                      </span>
+                    )}
+                </button>
+              );
+            })}
+          </div>
+        )}
 
-      {showPiTab && selectedTab === 'pis' && (
-        <div aria-labelledby="tab-pis" id="panel-pis" role="tabpanel">
-          <PrincipalInvestigatorsTable pis={managedPis} />
-        </div>
-      )}
+        {showPiTab && selectedTab === 'pis' && (
+          <div aria-labelledby="tab-pis" id="panel-pis" role="tabpanel">
+            <PrincipalInvestigatorsTable pis={managedPis} />
+          </div>
+        )}
 
-      {showProjectsTab && selectedTab === 'projects' && (
-        <div aria-labelledby="tab-projects" id="panel-projects" role="tabpanel">
-          {sponsoredProjects.length > 0 && (
-            <div className="mt-4">
-              <h2 className="h2">Sponsored Projects</h2>
-              <SponsoredProjectsTable
-                employeeId={user.employeeId}
-                records={sponsoredProjects}
-              />
-            </div>
-          )}
-          {internalProjects.length > 0 && (
-            <div className="mt-4">
-              <h2 className="h2">Internal Projects</h2>
-              <p className="text-sm text-base-content/70 mt-1">
-                Totals for internal projects do not reflect transactions that
-                have occurred since the latest data refresh or manual updates
-                that are needed. Contact your fiscal officer with any questions.
-              </p>
-              <InternalProjectsTable
-                discrepancies={discrepancies}
-                employeeId={user.employeeId}
-                records={internalProjects}
-              />
-            </div>
-          )}
-        </div>
-      )}
-
-      {selectedTab === 'alerts' && (
-        <div aria-labelledby="tab-alerts" id="panel-alerts" role="tabpanel">
-          {isProjectManager && (
-            <PiProjectAlerts
-              managedPis={managedPis}
-              pmEmployeeId={user.employeeId}
-            />
-          )}
-          {isPrincipalInvestigator && piAlerts.length > 0 && (
-            <div className="mt-4 flex flex-col gap-4">
-              {piAlerts.map((alert) => (
-                <AlertCard
-                  alert={alert}
-                  balance={alert.balance}
-                  key={alert.id}
-                  linkParams={{
-                    employeeId: alert.piEmployeeId,
-                    projectNumber: alert.projectNumber,
-                  }}
+        {showProjectsTab && selectedTab === 'projects' && (
+          <div aria-labelledby="tab-projects" id="panel-projects" role="tabpanel">
+            {sponsoredProjects.length > 0 && (
+              <div className="mt-4">
+                <h2 className="h2">Sponsored Projects</h2>
+                <SponsoredProjectsTable
+                  employeeId={user.employeeId}
+                  records={sponsoredProjects}
                 />
-              ))}
-            </div>
-          )}
-          {isPrincipalInvestigator && piAlerts.length === 0 && (
-            <p className="mt-4 text-base-content/60">No alerts</p>
-          )}
-        </div>
-      )}
-    </div>
+              </div>
+            )}
+            {internalProjects.length > 0 && (
+              <div className="mt-4">
+                <h2 className="h2">Internal Projects</h2>
+                <p className="text-sm text-base-content/70 mt-1">
+                  Totals for internal projects do not reflect transactions that
+                  have occurred since the latest data refresh or manual updates
+                  that are needed. Contact your fiscal officer with any questions.
+                </p>
+                <InternalProjectsTable
+                  discrepancies={discrepancies}
+                  employeeId={user.employeeId}
+                  records={internalProjects}
+                />
+              </div>
+            )}
+          </div>
+        )}
+
+        {selectedTab === 'alerts' && (
+          <div aria-labelledby="tab-alerts" id="panel-alerts" role="tabpanel">
+            {isProjectManager && (
+              <PiProjectAlerts
+                managedPis={managedPis}
+                pmEmployeeId={user.employeeId}
+              />
+            )}
+            {isPrincipalInvestigator && piAlerts.length > 0 && (
+              <div className="mt-4 flex flex-col gap-4">
+                {piAlerts.map((alert) => (
+                  <AlertCard
+                    alert={alert}
+                    balance={alert.balance}
+                    key={alert.id}
+                    linkParams={{
+                      employeeId: alert.piEmployeeId,
+                      projectNumber: alert.projectNumber,
+                    }}
+                  />
+                ))}
+              </div>
+            )}
+            {isPrincipalInvestigator && piAlerts.length === 0 && (
+              <p className="mt-4 text-base-content/60">No alerts</p>
+            )}
+          </div>
+        )}
+      </div>
+    </>
   );
 }

--- a/web/client/src/routes/(authenticated)/index.tsx
+++ b/web/client/src/routes/(authenticated)/index.tsx
@@ -4,6 +4,7 @@ import {
   usePiProjectAlerts,
 } from '@/components/alerts/PiProjectAlerts.tsx';
 import { AlertCard } from '@/components/alerts/ProjectAlerts.tsx';
+import { NotificationBanner } from '@/components/NotificationBanner.tsx';
 import { PrincipalInvestigatorsTable } from '@/components/project/PrincipalInvestigatorsTable.tsx';
 import { InternalProjectsTable } from '@/components/project/InternalProjectsTable.tsx';
 import { SponsoredProjectsTable } from '@/components/project/SponsoredProjectsTable.tsx';
@@ -144,6 +145,7 @@ function RouteComponent() {
 
   return (
     <div className="container">
+      <NotificationBanner />
       <div className="pt-10 pb-5 mx-auto w-full sm:max-w-[90%] md:max-w-[80%] xl:max-w-[66%]">
         <h1 className="text-2xl font-proxima-bold">W.A.L.T.E.R.</h1>
         <p className="uppercase">

--- a/web/client/src/routes/about.tsx
+++ b/web/client/src/routes/about.tsx
@@ -1,4 +1,5 @@
 import { createFileRoute, Link } from '@tanstack/react-router';
+import { NotificationBanner } from '@/components/NotificationBanner.tsx';
 
 export const Route = createFileRoute('/about')({
   component: About,
@@ -7,6 +8,7 @@ export const Route = createFileRoute('/about')({
 function About() {
   return (
     <div className="min-h-dvh bg-white">
+      <NotificationBanner />
       <div className="flex min-h-dvh">
         <aside className="hidden w-72 walter-login-pattern shrink-0 md:block">
           <div className="h-full border-r border-main-border" />

--- a/web/client/src/test/components/NotificationBanner.test.tsx
+++ b/web/client/src/test/components/NotificationBanner.test.tsx
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+import { NotificationBanner } from '@/components/NotificationBanner.tsx';
+import { server } from '@/test/mswUtils.ts';
+
+afterEach(cleanup);
+
+function renderWithClient(node: ReactNode) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>{node}</QueryClientProvider>
+  );
+}
+
+describe('NotificationBanner', () => {
+  it('renders nothing when the notification is disabled', async () => {
+    server.use(
+      http.get('/api/notification', () =>
+        HttpResponse.json({
+          enabled: false,
+          message: 'Hidden because disabled',
+          updatedOn: null,
+        })
+      )
+    );
+
+    renderWithClient(<NotificationBanner />);
+
+    await waitFor(() =>
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    );
+  });
+
+  it('renders nothing when the message is empty', async () => {
+    server.use(
+      http.get('/api/notification', () =>
+        HttpResponse.json({ enabled: true, message: '', updatedOn: null })
+      )
+    );
+
+    renderWithClient(<NotificationBanner />);
+
+    await waitFor(() =>
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    );
+  });
+
+  it('renders the message when enabled and populated', async () => {
+    server.use(
+      http.get('/api/notification', () =>
+        HttpResponse.json({
+          enabled: true,
+          message: 'Heads up: data may be stale',
+          updatedOn: '2026-04-27T12:00:00Z',
+        })
+      )
+    );
+
+    renderWithClient(<NotificationBanner />);
+
+    expect(
+      await screen.findByText('Heads up: data may be stale')
+    ).toBeInTheDocument();
+  });
+});

--- a/web/client/src/test/mswUtils.ts
+++ b/web/client/src/test/mswUtils.ts
@@ -1,8 +1,18 @@
+import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { afterAll, afterEach, beforeAll } from 'vitest';
 
+// Default handlers cover ambient app fetches that fire on most pages and
+// otherwise force every test to opt in. Tests that want to assert against
+// these endpoints can still override via `server.use(...)`.
+const defaultHandlers = [
+  http.get('/api/notification', () =>
+    HttpResponse.json({ enabled: false, message: '', updatedOn: null })
+  ),
+];
+
 // Create a shared MSW server instance that can be used across all tests
-export const testServer = setupServer();
+export const testServer = setupServer(...defaultHandlers);
 
 // Global setup for MSW server
 // This will be automatically called when imported in test files

--- a/web/client/src/test/routes/(authenticated)/admin-notification.test.tsx
+++ b/web/client/src/test/routes/(authenticated)/admin-notification.test.tsx
@@ -1,0 +1,133 @@
+import { describe, expect, it } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
+import { server } from '@/test/mswUtils.ts';
+import { renderRoute } from '@/test/routerUtils.tsx';
+
+const createUser = (roles: string[]) => ({
+  email: 'test@example.com',
+  employeeId: '1000',
+  id: 'user-1',
+  kerberos: 'testuser',
+  name: 'Test User',
+  roles,
+});
+
+const registerHomeApis = () => {
+  server.use(
+    http.get('/api/project/managed/:employeeId', () => HttpResponse.json([])),
+    http.get('/api/project/:employeeId', () => HttpResponse.json([])),
+    http.get('/api/project/personnel', () => HttpResponse.json([]))
+  );
+};
+
+describe('Admin notification page', () => {
+  it('shows the Site Notification link on the admin index for Admin users', async () => {
+    server.use(
+      http.get('/api/user/me', () => HttpResponse.json(createUser(['Admin'])))
+    );
+    registerHomeApis();
+
+    const { cleanup } = renderRoute({ initialPath: '/admin' });
+
+    try {
+      expect(
+        await screen.findByRole('link', { name: 'Site Notification' })
+      ).toBeInTheDocument();
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('hides the Site Notification link from Manager users', async () => {
+    server.use(
+      http.get('/api/user/me', () => HttpResponse.json(createUser(['Manager'])))
+    );
+    registerHomeApis();
+
+    const { cleanup } = renderRoute({ initialPath: '/admin' });
+
+    try {
+      await screen.findByRole('heading', { name: 'Admin Dashboard' });
+      expect(
+        screen.queryByRole('link', { name: 'Site Notification' })
+      ).not.toBeInTheDocument();
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('redirects Manager users from /admin/notification to /admin', async () => {
+    server.use(
+      http.get('/api/user/me', () => HttpResponse.json(createUser(['Manager'])))
+    );
+    registerHomeApis();
+
+    const { cleanup } = renderRoute({ initialPath: '/admin/notification' });
+
+    try {
+      await waitFor(() => {
+        expect(
+          screen.getByRole('heading', { name: 'Admin Dashboard' })
+        ).toBeInTheDocument();
+      });
+      expect(
+        screen.queryByRole('heading', { name: 'Site Notification' })
+      ).not.toBeInTheDocument();
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('prefills the form from the current notification and saves edits', async () => {
+    server.use(
+      http.get('/api/user/me', () => HttpResponse.json(createUser(['Admin']))),
+      http.get('/api/notification', () =>
+        HttpResponse.json({
+          enabled: true,
+          message: 'Existing message',
+          updatedOn: '2026-04-01T00:00:00Z',
+        })
+      )
+    );
+    registerHomeApis();
+
+    let putBody: { enabled: boolean; message: string } | null = null;
+    server.use(
+      http.put('/api/notification', async ({ request }) => {
+        putBody = (await request.json()) as {
+          enabled: boolean;
+          message: string;
+        };
+        return HttpResponse.json({
+          enabled: putBody.enabled,
+          message: putBody.message,
+          updatedOn: '2026-04-27T00:00:00Z',
+        });
+      })
+    );
+
+    const user = userEvent.setup();
+    const { cleanup } = renderRoute({ initialPath: '/admin/notification' });
+
+    try {
+      const textarea = (await screen.findByLabelText(
+        'Message'
+      )) as HTMLTextAreaElement;
+      expect(textarea.value).toBe('Existing message');
+
+      await user.clear(textarea);
+      await user.type(textarea, 'Updated message');
+      await user.click(screen.getByRole('button', { name: 'Save' }));
+
+      await waitFor(() =>
+        expect(screen.getByText('Saved.')).toBeInTheDocument()
+      );
+
+      expect(putBody).toEqual({ enabled: true, message: 'Updated message' });
+    } finally {
+      cleanup();
+    }
+  });
+});

--- a/web/server.core/Data/AppDbContext.cs
+++ b/web/server.core/Data/AppDbContext.cs
@@ -8,6 +8,7 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
     public DbSet<User> Users => Set<User>();
     public DbSet<Role> Roles => Set<Role>();
     public DbSet<Permission> Permissions => Set<Permission>();
+    public DbSet<Notification> Notifications => Set<Notification>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -16,5 +17,6 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
         User.OnModelCreating(modelBuilder);
         Role.OnModelCreating(modelBuilder);
         Permission.OnModelCreating(modelBuilder);
+        Notification.OnModelCreating(modelBuilder);
     }
 }

--- a/web/server.core/Domain/Notification.cs
+++ b/web/server.core/Domain/Notification.cs
@@ -1,0 +1,36 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using Microsoft.EntityFrameworkCore;
+
+namespace server.core.Domain;
+
+public class Notification
+{
+    public const int SingletonId = 1;
+
+    [Key]
+    public int Id { get; set; }
+
+    public bool Enabled { get; set; }
+
+    [Required]
+    [MaxLength(2000)]
+    public string Message { get; set; } = "";
+
+    public DateTime UpdatedOn { get; set; }
+
+    [MaxLength(200)]
+    public string? UpdatedBy { get; set; }
+
+    internal static void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<Notification>().HasData(new Notification
+        {
+            Id = SingletonId,
+            Enabled = false,
+            Message = "",
+            UpdatedOn = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            UpdatedBy = null,
+        });
+    }
+}

--- a/web/server.core/Migrations/20260427140309_AddNotification.Designer.cs
+++ b/web/server.core/Migrations/20260427140309_AddNotification.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using server.core.Data;
 
@@ -11,9 +12,11 @@ using server.core.Data;
 namespace server.core.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260427140309_AddNotification")]
+    partial class AddNotification
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/web/server.core/Migrations/20260427140309_AddNotification.cs
+++ b/web/server.core/Migrations/20260427140309_AddNotification.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace server.core.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddNotification : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Notifications",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Enabled = table.Column<bool>(type: "bit", nullable: false),
+                    Message = table.Column<string>(type: "nvarchar(2000)", maxLength: 2000, nullable: false),
+                    UpdatedOn = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    UpdatedBy = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Notifications", x => x.Id);
+                });
+
+            migrationBuilder.InsertData(
+                table: "Notifications",
+                columns: new[] { "Id", "Enabled", "Message", "UpdatedBy", "UpdatedOn" },
+                values: new object[] { 1, false, "", null, new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc) });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Notifications");
+        }
+    }
+}

--- a/web/server/Controllers/NotificationController.cs
+++ b/web/server/Controllers/NotificationController.cs
@@ -1,0 +1,76 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using server.core.Data;
+using server.core.Domain;
+
+namespace Server.Controllers;
+
+[ApiController]
+[Route("api/notification")]
+public sealed class NotificationController : ControllerBase
+{
+    private const int MessageMaxLength = 2000;
+
+    private readonly AppDbContext _ctx;
+
+    public NotificationController(AppDbContext ctx)
+    {
+        _ctx = ctx;
+    }
+
+    public sealed record NotificationResponse(bool Enabled, string Message, DateTime? UpdatedOn);
+    public sealed record UpdateNotificationRequest(bool Enabled, string Message);
+
+    [HttpGet]
+    [AllowAnonymous]
+    public async Task<ActionResult<NotificationResponse>> Get(CancellationToken ct)
+    {
+        var n = await _ctx.Notifications
+            .AsNoTracking()
+            .FirstOrDefaultAsync(x => x.Id == Notification.SingletonId, ct);
+
+        if (n is null)
+        {
+            return Ok(new NotificationResponse(false, "", null));
+        }
+
+        return Ok(new NotificationResponse(n.Enabled, n.Message, n.UpdatedOn));
+    }
+
+    [HttpPut]
+    [Authorize(Roles = Role.Names.Admin)]
+    public async Task<ActionResult<NotificationResponse>> Update(
+        [FromBody] UpdateNotificationRequest request,
+        CancellationToken ct)
+    {
+        if (request is null)
+        {
+            return BadRequest("Body is required.");
+        }
+
+        var message = request.Message ?? "";
+        if (message.Length > MessageMaxLength)
+        {
+            return BadRequest($"Message exceeds {MessageMaxLength} characters.");
+        }
+
+        var n = await _ctx.Notifications.FirstOrDefaultAsync(
+            x => x.Id == Notification.SingletonId, ct);
+
+        if (n is null)
+        {
+            n = new Notification { Id = Notification.SingletonId };
+            _ctx.Notifications.Add(n);
+        }
+
+        n.Enabled = request.Enabled;
+        n.Message = message;
+        n.UpdatedOn = DateTime.UtcNow;
+        n.UpdatedBy = User.Identity?.Name;
+
+        await _ctx.SaveChangesAsync(ct);
+
+        return Ok(new NotificationResponse(n.Enabled, n.Message, n.UpdatedOn));
+    }
+}

--- a/web/tests/server.tests/Controllers/NotificationControllerTests.cs
+++ b/web/tests/server.tests/Controllers/NotificationControllerTests.cs
@@ -1,0 +1,110 @@
+using System.Security.Claims;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Server.Controllers;
+using Server.Tests;
+using server.core.Data;
+using server.core.Domain;
+
+namespace server.tests.Controllers;
+
+public sealed class NotificationControllerTests
+{
+    [Fact]
+    public async Task Get_returns_seeded_singleton_disabled_by_default()
+    {
+        using AppDbContext ctx = TestDbContextFactory.CreateInMemory();
+
+        var controller = new NotificationController(ctx);
+
+        var result = await controller.Get(CancellationToken.None);
+
+        var payload = result.Result.Should().BeOfType<OkObjectResult>().Which.Value
+            .Should().BeOfType<NotificationController.NotificationResponse>().Which;
+
+        payload.Enabled.Should().BeFalse();
+        payload.Message.Should().Be("");
+    }
+
+    [Fact]
+    public async Task Get_returns_persisted_message()
+    {
+        using AppDbContext ctx = TestDbContextFactory.CreateInMemory();
+
+        var seed = await ctx.Notifications.SingleAsync(n => n.Id == Notification.SingletonId);
+        seed.Enabled = true;
+        seed.Message = "Heads up";
+        seed.UpdatedOn = new DateTime(2026, 4, 1, 12, 0, 0, DateTimeKind.Utc);
+        await ctx.SaveChangesAsync();
+
+        var controller = new NotificationController(ctx);
+
+        var result = await controller.Get(CancellationToken.None);
+
+        var payload = result.Result.Should().BeOfType<OkObjectResult>().Which.Value
+            .Should().BeOfType<NotificationController.NotificationResponse>().Which;
+
+        payload.Enabled.Should().BeTrue();
+        payload.Message.Should().Be("Heads up");
+        payload.UpdatedOn.Should().Be(new DateTime(2026, 4, 1, 12, 0, 0, DateTimeKind.Utc));
+    }
+
+    [Fact]
+    public async Task Update_persists_message_and_stamps_audit_fields()
+    {
+        using AppDbContext ctx = TestDbContextFactory.CreateInMemory();
+
+        var controller = CreateController(ctx, identityName: "admin@ucdavis.edu");
+
+        var before = DateTime.UtcNow;
+
+        var result = await controller.Update(
+            new NotificationController.UpdateNotificationRequest(true, "Hello world"),
+            CancellationToken.None);
+
+        var payload = result.Result.Should().BeOfType<OkObjectResult>().Which.Value
+            .Should().BeOfType<NotificationController.NotificationResponse>().Which;
+
+        payload.Enabled.Should().BeTrue();
+        payload.Message.Should().Be("Hello world");
+
+        var saved = ctx.Notifications.Single(n => n.Id == Notification.SingletonId);
+        saved.Enabled.Should().BeTrue();
+        saved.Message.Should().Be("Hello world");
+        saved.UpdatedBy.Should().Be("admin@ucdavis.edu");
+        saved.UpdatedOn.Should().BeOnOrAfter(before);
+    }
+
+    [Fact]
+    public async Task Update_rejects_message_above_max_length()
+    {
+        using AppDbContext ctx = TestDbContextFactory.CreateInMemory();
+
+        var controller = CreateController(ctx, identityName: "admin@ucdavis.edu");
+
+        var result = await controller.Update(
+            new NotificationController.UpdateNotificationRequest(true, new string('x', 2001)),
+            CancellationToken.None);
+
+        result.Result.Should().BeOfType<BadRequestObjectResult>();
+
+        var saved = ctx.Notifications.Single(n => n.Id == Notification.SingletonId);
+        saved.Enabled.Should().BeFalse();
+        saved.Message.Should().Be("");
+    }
+
+    private static NotificationController CreateController(AppDbContext ctx, string identityName)
+    {
+        var controller = new NotificationController(ctx);
+        var identity = new ClaimsIdentity(
+            new[] { new Claim(ClaimTypes.Name, identityName) },
+            authenticationType: "Test");
+        controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext { User = new ClaimsPrincipal(identity) },
+        };
+        return controller;
+    }
+}


### PR DESCRIPTION
## Summary
- New `Notification` singleton table + `/api/notification` (GET anon, PUT Admin) for storing one site-wide message with an enabled toggle
- `NotificationBanner` renders the message as a full-bleed soft-gold strip flush under the header on `/about` (unauthenticated landing) and `/` (authenticated home); hidden when disabled or empty
- New `/admin/notification` page (Admin-only) with toggle + 2000-char message textarea + Save; the home banner reflects edits immediately via query cache update

🤖 Generated with [Claude Code](https://claude.com/claude-code)