### PR TITLE
Switch GL carryforward exclusion to account-based filter

### DIFF
--- a/datamart/StoredProcedures/usp_GetGLPPMReconciliation.sql
+++ b/datamart/StoredProcedures/usp_GetGLPPMReconciliation.sql
@@ -22,7 +22,6 @@ BEGIN
     DECLARE @Duration_MS INT;
     DECLARE @ErrorMsg NVARCHAR(MAX);
     DECLARE @ParametersJSON NVARCHAR(MAX);
-    DECLARE @ExcludedDocNumbers NVARCHAR(MAX);
 
     -- Sanitize ApplicationName for injection protection (whitelist: alphanumeric + spaces only)
     EXEC dbo.usp_SanitizeInputString @ApplicationName OUTPUT;
@@ -34,30 +33,30 @@ BEGIN
     DECLARE @ProjectIdFilter NVARCHAR(MAX);
     EXEC dbo.usp_ParseProjectIdFilter @ProjectIds, @ProjectIdFilter OUTPUT;
 
-    -- Build comma-separated list of excluded document numbers from local table
-    SELECT @ExcludedDocNumbers = STRING_AGG('''' + CAST(DocumentNumber AS VARCHAR(10)) + '''', ', ')
-    FROM dbo.CarryforwardDocumentNumbers;
-
-    -- Build Redshift query for GL data (transactional_listing_report is still remote)
+    -- Build Redshift query for GL data (transactional_listing_report is still remote).
+    -- Exclude carryforward 3XXXXXX activity except the one-time Jul-23 UCD conversion ASNs
+    -- (initial rollover from the legacy financial system).
     SET @RedshiftQuery = '
         SELECT
-            FINANCIAL_DEPARTMENT,
-            PROJECT,
-            PROJECT_DESCRIPTION,
-            FUND,
-            FUND_DESCRIPTION,
-            PROGRAM,
-            PROGRAM_DESCRIPTION,
-            ACTIVITY,
-            ACTIVITY_DESCRIPTION,
-            SUM(ACTUAL_AMOUNT) AS GL_ACTUAL_AMOUNT
-        FROM ae_dwh.transactional_listing_report
-        WHERE PROJECT IN (' + @ProjectIdFilter + ') AND PERIOD_NAME <> ''Jun-23'''
-        + CASE WHEN @ExcludedDocNumbers IS NOT NULL
-               THEN ' AND ACCOUNTING_SEQUENCE_NUMBER NOT IN (' + @ExcludedDocNumbers + ')'
-               ELSE ''
-          END + '
-        GROUP BY FINANCIAL_DEPARTMENT, PROJECT, PROJECT_DESCRIPTION, FUND, FUND_DESCRIPTION, PROGRAM, PROGRAM_DESCRIPTION, ACTIVITY, ACTIVITY_DESCRIPTION';
+            tlr.FINANCIAL_DEPARTMENT,
+            tlr.PROJECT,
+            tlr.PROJECT_DESCRIPTION,
+            tlr.FUND,
+            tlr.FUND_DESCRIPTION,
+            tlr.PROGRAM,
+            tlr.PROGRAM_DESCRIPTION,
+            tlr.ACTIVITY,
+            tlr.ACTIVITY_DESCRIPTION,
+            SUM(tlr.ACTUAL_AMOUNT) AS GL_ACTUAL_AMOUNT
+        FROM ae_dwh.transactional_listing_report tlr
+        LEFT JOIN ae_dwh.erp_account acc ON tlr.ACCOUNT = acc.code
+        WHERE tlr.PROJECT IN (' + @ProjectIdFilter + ')
+          AND tlr.PERIOD_NAME <> ''Jun-23''
+          AND (
+              acc.parent_level_0_code NOT LIKE ''3%''
+              OR (tlr.PERIOD_NAME = ''Jul-23'' AND tlr.ACCOUNTING_SEQUENCE_NUMBER IN (''100009'',''100010'',''100307'',''103283'',''103284''))
+          )
+        GROUP BY tlr.FINANCIAL_DEPARTMENT, tlr.PROJECT, tlr.PROJECT_DESCRIPTION, tlr.FUND, tlr.FUND_DESCRIPTION, tlr.PROGRAM, tlr.PROGRAM_DESCRIPTION, tlr.ACTIVITY, tlr.ACTIVITY_DESCRIPTION';
 
     -- Build parameters JSON for logging
     SET @ParametersJSON = (

--- a/datamart/StoredProcedures/usp_GetGLTransactionListings.sql
+++ b/datamart/StoredProcedures/usp_GetGLTransactionListings.sql
@@ -43,7 +43,6 @@ BEGIN
     DECLARE @Duration_MS INT;
     DECLARE @ErrorMsg NVARCHAR(MAX);
     DECLARE @ParametersJSON NVARCHAR(MAX);
-    DECLARE @ExcludedDocNumbers NVARCHAR(MAX);
 
     -- Sanitize ApplicationName for injection protection (whitelist: alphanumeric + spaces only)
     EXEC dbo.usp_SanitizeInputString @ApplicationName OUTPUT;
@@ -74,12 +73,12 @@ BEGIN
     IF @EndDate IS NOT NULL
         SET @FilterClause = @FilterClause + ' AND tlr.journal_acct_date <= ''' + CONVERT(VARCHAR(10), @EndDate, 120) + '''';
 
-    -- Exclude carryforward document numbers (same exclusion as usp_GetGLPPMReconciliation)
-    SELECT @ExcludedDocNumbers = STRING_AGG('''' + CAST(DocumentNumber AS VARCHAR(10)) + '''', ', ')
-    FROM dbo.CarryforwardDocumentNumbers;
-
-    IF @ExcludedDocNumbers IS NOT NULL
-        SET @FilterClause = @FilterClause + ' AND tlr.ACCOUNTING_SEQUENCE_NUMBER NOT IN (' + @ExcludedDocNumbers + ')';
+    -- Exclude carryforward 3XXXXXX activity except the one-time Jul-23 UCD conversion ASNs
+    -- (initial rollover from the legacy financial system). Same exclusion as usp_GetGLPPMReconciliation.
+    SET @FilterClause = @FilterClause + ' AND (
+            acc.parent_level_0_code NOT LIKE ''3%''
+            OR (tlr.PERIOD_NAME = ''Jul-23'' AND tlr.ACCOUNTING_SEQUENCE_NUMBER IN (''100009'',''100010'',''100307'',''103283'',''103284''))
+        )';
 
     -- Build Redshift query with explicit column list
     SET @RedshiftQuery = '


### PR DESCRIPTION
## Summary
- Replace the local `dbo.CarryforwardDocumentNumbers` lookup in `usp_GetGLPPMReconciliation` with a join to `ae_dwh.erp_account`, excluding rows where `parent_level_0_code LIKE '3%'` (carryforward 3XXXXXX activity).
- Preserve the one-time **Jul-23** UCD conversion ASNs (`100009, 100010, 100307, 103283, 103284`) — these are the legacy-system rollover entries needed for opening balances.
- Apply the same exclusion to `usp_GetGLTransactionListings` so the two procs report against an identical scope.

## Why
The doc-number lookup was a brittle workaround — every newly discovered carryforward ASN had to be hand-added to `CarryforwardDocumentNumbers`. Filtering by natural-account class (`parent_level_0_code`) catches all carryforward activity by definition while still letting the Jul-23 conversion entries through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GL reconciliation and transaction listing accuracy by refining account-level filtering logic.
  * Applied targeted data adjustments for July-23 transactions to ensure accurate reconciliation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->