### PR TITLE
Restore PM access to GL/PPM reconciliation

### DIFF
--- a/web/server/Controllers/ProjectController.cs
+++ b/web/server/Controllers/ProjectController.cs
@@ -189,7 +189,6 @@ public sealed class ProjectController : ApiControllerBase
         return Ok(transactions);
     }
 
-    [Authorize(Policy = AuthorizationHelper.Policies.CanViewFinancials)]
     [HttpGet("gl-ppm-reconciliation")]
     public async Task<IActionResult> GetGLPPMReconciliationAsync(
         CancellationToken cancellationToken,
@@ -199,6 +198,29 @@ public sealed class ProjectController : ApiControllerBase
             return Ok(Array.Empty<GLPPMReconciliationRecord>());
 
         var codes = projectCodes.Split(',', StringSplitOptions.RemoveEmptyEntries);
+
+        var hasFinancialAccess = (await _authorizationService.AuthorizeAsync(
+            User,
+            resource: null,
+            policyName: AuthorizationHelper.Policies.CanViewFinancials)).Succeeded;
+
+        if (!hasFinancialAccess)
+        {
+            var currentEmployeeId = await GetCurrentEmployeeIdAsync(cancellationToken);
+            if (string.IsNullOrWhiteSpace(currentEmployeeId))
+            {
+                return Forbid();
+            }
+
+            var accessibleProjectNumbers = await GetAccessibleProjectNumbersForEmployeeAsync(currentEmployeeId, cancellationToken);
+            var requestedProjectNumbers = new HashSet<string>(codes, StringComparer.OrdinalIgnoreCase);
+
+            if (!requestedProjectNumbers.IsSubsetOf(accessibleProjectNumbers))
+            {
+                return Forbid();
+            }
+        }
+
         var applicationUser = User.GetUserIdentifier();
         var emulatingUser = User.GetEmulatingUser();
         var reconciliation = await _datamartService.GetGLPPMReconciliationAsync(codes, applicationUser, emulatingUser, cancellationToken);
@@ -335,11 +357,18 @@ public sealed class ProjectController : ApiControllerBase
     {
         var client = _financialApiService.GetClient();
 
-        var piResult = await client.PpmProjectByProjectTeamMemberEmployeeId.ExecuteAsync(
+        var piResultTask = client.PpmProjectByProjectTeamMemberEmployeeId.ExecuteAsync(
             employeeId, PpmRole.PrincipalInvestigator, cancellationToken);
-        var piData = piResult.ReadData();
+        var pmResultTask = client.PpmProjectByProjectTeamMemberEmployeeId.ExecuteAsync(
+            employeeId, PpmRole.ProjectManager, cancellationToken);
+
+        await Task.WhenAll(piResultTask, pmResultTask);
+
+        var piData = (await piResultTask).ReadData();
+        var pmData = (await pmResultTask).ReadData();
 
         return piData.PpmProjectByProjectTeamMemberEmployeeId
+            .Concat(pmData.PpmProjectByProjectTeamMemberEmployeeId)
             .Select(p => p.ProjectNumber?.Trim())
             .Where(p => !string.IsNullOrWhiteSpace(p))
             .Select(p => p!)


### PR DESCRIPTION
## Summary
- Drop the hard `CanViewFinancials` gate added to `/api/project/gl-ppm-reconciliation` in 6e18d706 and reinstate the soft check it had before — callers without financial access must be PI or PM on every requested project
- Restore the PI ∪ PM union in `GetAccessibleProjectNumbersForEmployeeAsync` (narrowed to PI-only in the same commit) so it works for the caller-side check; the personnel endpoint still passes a PI's emplid and is unaffected

## Why
Without this, PMs viewing a PI's project list or detail page lost the GL/PPM reconciliation discrepancy badges and the discrepancy alert (`useProjectDiscrepancies` returns an empty Set on 403, so the UI silently dropped the indicators), and clicking through to `/reports/reconciliation/$projectNumber` returned 403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced access control for financial data endpoints with improved permission validation.
  
* **Improvements**
  * Refined project accessibility checks to properly recognize users in Principal Investigator and Project Manager roles, ensuring users can access projects appropriate to their assigned role.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->