### PR TITLE
Open byNumber and transactions to PMs on managed projects

### DIFF
--- a/web/server/Controllers/ProjectController.cs
+++ b/web/server/Controllers/ProjectController.cs
@@ -106,7 +106,6 @@ public sealed class ProjectController : ApiControllerBase
         return Ok(activeProjects);
     }
 
-    [Authorize(Policy = AuthorizationHelper.Policies.CanViewFinancials)]
     [HttpGet("byNumber")]
     public async Task<IActionResult> GetByProjectNumberAsync(
         CancellationToken cancellationToken,
@@ -116,6 +115,12 @@ public sealed class ProjectController : ApiControllerBase
             return Ok(Array.Empty<FacultyPortfolioRecord>());
 
         var codes = projectCodes.Split(',', StringSplitOptions.RemoveEmptyEntries);
+
+        if (!await CallerCanAccessProjectsAsync(codes, cancellationToken))
+        {
+            return Forbid();
+        }
+
         var applicationUser = User.GetUserIdentifier();
         var emulatingUser = User.GetEmulatingUser();
         var projects = await _datamartService.GetFacultyPortfolioAsync(codes, applicationUser, emulatingUser, cancellationToken);
@@ -172,7 +177,6 @@ public sealed class ProjectController : ApiControllerBase
         return Ok(personnel);
     }
 
-    [Authorize(Policy = AuthorizationHelper.Policies.CanViewFinancials)]
     [HttpGet("transactions")]
     public async Task<IActionResult> GetTransactionsForProjectsAsync(
         CancellationToken cancellationToken,
@@ -182,6 +186,12 @@ public sealed class ProjectController : ApiControllerBase
             return Ok(Array.Empty<GLTransactionRecord>());
 
         var codes = projectCodes.Split(',', StringSplitOptions.RemoveEmptyEntries);
+
+        if (!await CallerCanAccessProjectsAsync(codes, cancellationToken))
+        {
+            return Forbid();
+        }
+
         var applicationUser = User.GetUserIdentifier();
         var emulatingUser = User.GetEmulatingUser();
         var transactions = await _datamartService.GetGLTransactionListingsAsync(codes, applicationUser, emulatingUser, cancellationToken);
@@ -199,26 +209,9 @@ public sealed class ProjectController : ApiControllerBase
 
         var codes = projectCodes.Split(',', StringSplitOptions.RemoveEmptyEntries);
 
-        var hasFinancialAccess = (await _authorizationService.AuthorizeAsync(
-            User,
-            resource: null,
-            policyName: AuthorizationHelper.Policies.CanViewFinancials)).Succeeded;
-
-        if (!hasFinancialAccess)
+        if (!await CallerCanAccessProjectsAsync(codes, cancellationToken))
         {
-            var currentEmployeeId = await GetCurrentEmployeeIdAsync(cancellationToken);
-            if (string.IsNullOrWhiteSpace(currentEmployeeId))
-            {
-                return Forbid();
-            }
-
-            var accessibleProjectNumbers = await GetAccessibleProjectNumbersForEmployeeAsync(currentEmployeeId, cancellationToken);
-            var requestedProjectNumbers = new HashSet<string>(codes, StringComparer.OrdinalIgnoreCase);
-
-            if (!requestedProjectNumbers.IsSubsetOf(accessibleProjectNumbers))
-            {
-                return Forbid();
-            }
+            return Forbid();
         }
 
         var applicationUser = User.GetUserIdentifier();
@@ -349,6 +342,37 @@ public sealed class ProjectController : ApiControllerBase
 
         var currentUser = await _userService.GetByIdAsync(userId, cancellationToken);
         return currentUser?.EmployeeId;
+    }
+
+    /// <summary>
+    /// Returns true if the caller has CanViewFinancials, or if they are PI/PM
+    /// on every requested project. Used by endpoints that need to surface
+    /// project data to PMs viewing their PIs' projects.
+    /// </summary>
+    private async Task<bool> CallerCanAccessProjectsAsync(
+        string[] requestedProjectCodes,
+        CancellationToken cancellationToken)
+    {
+        var hasFinancialAccess = (await _authorizationService.AuthorizeAsync(
+            User,
+            resource: null,
+            policyName: AuthorizationHelper.Policies.CanViewFinancials)).Succeeded;
+
+        if (hasFinancialAccess)
+        {
+            return true;
+        }
+
+        var currentEmployeeId = await GetCurrentEmployeeIdAsync(cancellationToken);
+        if (string.IsNullOrWhiteSpace(currentEmployeeId))
+        {
+            return false;
+        }
+
+        var accessibleProjectNumbers = await GetAccessibleProjectNumbersForEmployeeAsync(currentEmployeeId, cancellationToken);
+        var requestedProjectNumbers = new HashSet<string>(requestedProjectCodes, StringComparer.OrdinalIgnoreCase);
+
+        return requestedProjectNumbers.IsSubsetOf(accessibleProjectNumbers);
     }
 
     private async Task<HashSet<string>> GetAccessibleProjectNumbersForEmployeeAsync(


### PR DESCRIPTION
## Summary
- Drop the `CanViewFinancials` gate from `/api/project/byNumber` and `/api/project/transactions`; replace with the same soft check used by `gl-ppm-reconciliation` (caller must be PI or PM on every requested project)
- Factor the soft check into a `CallerCanAccessProjectsAsync` helper that the three reconciliation-related endpoints share

## Why
The reconciliation detail page (`/reports/reconciliation/$projectNumber/detail`) needs all three endpoints — gl-ppm-reconciliation, byNumber, and transactions — to render the drill-down. After #251 only `gl-ppm-reconciliation` was opened to PMs, so the detail page still 403'd on the other two.

This intentionally relaxes the policy from 6e18d706 ("PMs cannot see transaction-level detail"). PMs now see transactions, but only for projects where they are PI or PM.


🤖 Generated with [Claude Code](https://claude.com/claude-code)