### PR TITLE
Exclude Jun-23 period from GL transaction listings

### DIFF
--- a/datamart/StoredProcedures/usp_GetGLTransactionListings.sql
+++ b/datamart/StoredProcedures/usp_GetGLTransactionListings.sql
@@ -81,6 +81,8 @@ BEGIN
     IF @ExcludedDocNumbers IS NOT NULL
         SET @FilterClause = @FilterClause + ' AND tlr.ACCOUNTING_SEQUENCE_NUMBER NOT IN (' + @ExcludedDocNumbers + ')';
 
+    SET @FilterClause = @FilterClause + ' AND tlr.PERIOD_NAME <> ''Jun-23''';
+
     -- Build Redshift query with explicit column list
     SET @RedshiftQuery = '
         SELECT


### PR DESCRIPTION
## Summary
- Adds `PERIOD_NAME <> 'Jun-23'` filter to `usp_GetGLTransactionListings`, matching the identical filter already present in `usp_GetGLPPMReconciliation`

## Test plan
- [ ] Run `usp_GetGLTransactionListings` with a project that has Jun-23 data and confirm those rows are excluded
- [ ] Confirm all other periods still return as expected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated GL transaction data filtering to exclude entries from June 2023.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->