### PR TITLE
Include Apr-24 UCD Conversion balance adjustments in GL queries

### DIFF
--- a/datamart/StoredProcedures/usp_GetGLPPMReconciliation.sql
+++ b/datamart/StoredProcedures/usp_GetGLPPMReconciliation.sql
@@ -34,8 +34,9 @@ BEGIN
     EXEC dbo.usp_ParseProjectIdFilter @ProjectIds, @ProjectIdFilter OUTPUT;
 
     -- Build Redshift query for GL data (transactional_listing_report is still remote).
-    -- Exclude carryforward 3XXXXXX activity except the one-time Jul-23 UCD conversion ASNs
-    -- (initial rollover from the legacy financial system).
+    -- Exclude carryforward 3XXXXXX activity with two exceptions:
+    --   1. Jul-23 one-time UCD conversion ASNs (initial rollover from legacy financial system)
+    --   2. Apr-24 UCD Conversion journal entries (balance correction adjustments)
     SET @RedshiftQuery = '
         SELECT
             tlr.FINANCIAL_DEPARTMENT,
@@ -55,6 +56,7 @@ BEGIN
           AND (
               acc.parent_level_0_code NOT LIKE ''3%''
               OR (tlr.PERIOD_NAME = ''Jul-23'' AND tlr.ACCOUNTING_SEQUENCE_NUMBER IN (''100009'',''100010'',''100307'',''103283'',''103284''))
+              OR (tlr.PERIOD_NAME = ''Apr-24'' AND tlr.JOURNAL_SOURCE = ''UCD Conversion'' AND tlr.JOURNAL_CATEGORY = ''UCD Conversion'')
           )
         GROUP BY tlr.FINANCIAL_DEPARTMENT, tlr.PROJECT, tlr.PROJECT_DESCRIPTION, tlr.FUND, tlr.FUND_DESCRIPTION, tlr.PROGRAM, tlr.PROGRAM_DESCRIPTION, tlr.ACTIVITY, tlr.ACTIVITY_DESCRIPTION';
 

--- a/datamart/StoredProcedures/usp_GetGLTransactionListings.sql
+++ b/datamart/StoredProcedures/usp_GetGLTransactionListings.sql
@@ -73,11 +73,14 @@ BEGIN
     IF @EndDate IS NOT NULL
         SET @FilterClause = @FilterClause + ' AND tlr.journal_acct_date <= ''' + CONVERT(VARCHAR(10), @EndDate, 120) + '''';
 
-    -- Exclude carryforward 3XXXXXX activity except the one-time Jul-23 UCD conversion ASNs
-    -- (initial rollover from the legacy financial system). Same exclusion as usp_GetGLPPMReconciliation.
+    -- Exclude carryforward 3XXXXXX activity with two exceptions:
+    --   1. Jul-23 one-time UCD conversion ASNs (initial rollover from legacy financial system)
+    --   2. Apr-24 UCD Conversion journal entries (balance correction adjustments)
+    -- Same exclusion logic as usp_GetGLPPMReconciliation.
     SET @FilterClause = @FilterClause + ' AND (
             acc.parent_level_0_code NOT LIKE ''3%''
             OR (tlr.PERIOD_NAME = ''Jul-23'' AND tlr.ACCOUNTING_SEQUENCE_NUMBER IN (''100009'',''100010'',''100307'',''103283'',''103284''))
+            OR (tlr.PERIOD_NAME = ''Apr-24'' AND tlr.JOURNAL_SOURCE = ''UCD Conversion'' AND tlr.JOURNAL_CATEGORY = ''UCD Conversion'')
         )';
 
     SET @FilterClause = @FilterClause + ' AND tlr.PERIOD_NAME <> ''Jun-23''';


### PR DESCRIPTION
## Summary

- Apr-24 journal entries with `JOURNAL_SOURCE = 'UCD Conversion'` and `JOURNAL_CATEGORY = 'UCD Conversion'` were being incorrectly excluded from both GL sprocs by the `3XXXXXX` account filter
- These are one-time balance correction adjustments (e.g. doc 148455 for VetMed), not carryforward activity
- Added an OR exception for `PERIOD_NAME = 'Apr-24'` + UCD Conversion source/category, mirroring the existing Jul-23 rollover exception
- Applies to both `usp_GetGLTransactionListings` and `usp_GetGLPPMReconciliation`

## Test plan

- [ ] Verify FPVVMB1622 GL balance in Walter shows ~$2,177.22 overdraft (not $4,442.79) after deploy to test
- [ ] Shannon and Melissa to review other projects for similar correction across VetMed and other units
- [ ] Confirm no unintended rows appear for projects with no Apr-24 UCD Conversion activity

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved General Ledger reconciliation logic to properly handle UCD conversion entries from April 2024 in carryforward activity exclusions, ensuring accurate reporting in reconciliation and transaction listing queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->