### PR TITLE
Scope CI triggers to path-based changes

### DIFF
--- a/datamart/azure-pipelines.datamart.yml
+++ b/datamart/azure-pipelines.datamart.yml
@@ -11,6 +11,9 @@ pr:
   branches:
     include:
       - main
+  paths:
+    include:
+      - datamart/**
 
 pool:
   name: "Pazuzu Pool"

--- a/web/azure-pipelines.yml
+++ b/web/azure-pipelines.yml
@@ -4,6 +4,17 @@ trigger:
   branches:
     include:
       - main
+  paths:
+    include:
+      - web/**
+
+pr:
+  branches:
+    include:
+      - main
+  paths:
+    include:
+      - web/**
 
 variables:
   buildConfiguration: Release


### PR DESCRIPTION
## Summary
- Web pipeline now only triggers on `web/**` changes (both push to main and PRs)
- Datamart pipeline PR trigger now has the same `datamart/**` path filter its push trigger already had

## Effect
- PRs touching only `datamart/` won't trigger the web build, and vice versa
- ADF direct pushes to `main` (which only touch `pipelines/`) won't trigger either pipeline
- `infrastructure/`, `pipelines/`, and root-level files don't trigger any build (no CI runs on those today anyway)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Azure DevOps pipeline configurations to optimize when builds are triggered for code changes across different repository areas.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ucdavis/Walter/pull/263)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->