### PR TITLE
Add admin email preview

### DIFF
--- a/web/client/src/queries/emailPreview.ts
+++ b/web/client/src/queries/emailPreview.ts
@@ -1,0 +1,25 @@
+import { fetchJson } from '@/lib/api.ts';
+
+export type EmailPreviewRequest = {
+  notificationType: string;
+  payloadJson: string;
+  payloadVersion: number;
+  recipientName: string;
+  templateKey: string;
+  templateVersion: number;
+};
+
+export type EmailPreviewResponse = {
+  htmlBody: string;
+  subject: string;
+  textBody: string;
+};
+
+export async function renderEmailPreview(
+  input: EmailPreviewRequest
+): Promise<EmailPreviewResponse> {
+  return await fetchJson<EmailPreviewResponse>('/api/admin/email-preview/render', {
+    body: JSON.stringify(input),
+    method: 'POST',
+  });
+}

--- a/web/client/src/routeTree.gen.ts
+++ b/web/client/src/routeTree.gen.ts
@@ -27,6 +27,7 @@ import { Route as authenticatedAccrualsIndexRouteImport } from './routes/(authen
 import { Route as authenticatedPrincipalInvestigatorsEmplidRouteImport } from './routes/(authenticated)/principalInvestigators/$emplid'
 import { Route as authenticatedAdminUsersRouteImport } from './routes/(authenticated)/admin/users'
 import { Route as authenticatedAdminNotificationRouteImport } from './routes/(authenticated)/admin/notification'
+import { Route as authenticatedAdminEmailPreviewRouteImport } from './routes/(authenticated)/admin/email-preview'
 import { Route as authenticatedAccrualsAboutRouteImport } from './routes/(authenticated)/accruals/about'
 import { Route as authenticatedProjectsEmployeeIdRouteRouteImport } from './routes/(authenticated)/projects/$employeeId/route'
 import { Route as authenticatedProjectsEmployeeIdIndexRouteImport } from './routes/(authenticated)/projects/$employeeId/index'
@@ -132,6 +133,12 @@ const authenticatedAdminNotificationRoute =
     path: '/notification',
     getParentRoute: () => authenticatedAdminRouteRoute,
   } as any)
+const authenticatedAdminEmailPreviewRoute =
+  authenticatedAdminEmailPreviewRouteImport.update({
+    id: '/email-preview',
+    path: '/email-preview',
+    getParentRoute: () => authenticatedAdminRouteRoute,
+  } as any)
 const authenticatedAccrualsAboutRoute =
   authenticatedAccrualsAboutRouteImport.update({
     id: '/accruals/about',
@@ -202,6 +209,7 @@ export interface FileRoutesByFullPath {
   '/': typeof authenticatedIndexRoute
   '/projects/$employeeId': typeof authenticatedProjectsEmployeeIdRouteRouteWithChildren
   '/accruals/about': typeof authenticatedAccrualsAboutRoute
+  '/admin/email-preview': typeof authenticatedAdminEmailPreviewRoute
   '/admin/notification': typeof authenticatedAdminNotificationRoute
   '/admin/users': typeof authenticatedAdminUsersRoute
   '/principalInvestigators/$emplid': typeof authenticatedPrincipalInvestigatorsEmplidRoute
@@ -227,6 +235,7 @@ export interface FileRoutesByTo {
   '/styles': typeof authenticatedStylesRoute
   '/': typeof authenticatedIndexRoute
   '/accruals/about': typeof authenticatedAccrualsAboutRoute
+  '/admin/email-preview': typeof authenticatedAdminEmailPreviewRoute
   '/admin/notification': typeof authenticatedAdminNotificationRoute
   '/admin/users': typeof authenticatedAdminUsersRoute
   '/principalInvestigators/$emplid': typeof authenticatedPrincipalInvestigatorsEmplidRoute
@@ -257,6 +266,7 @@ export interface FileRoutesById {
   '/(authenticated)/': typeof authenticatedIndexRoute
   '/(authenticated)/projects/$employeeId': typeof authenticatedProjectsEmployeeIdRouteRouteWithChildren
   '/(authenticated)/accruals/about': typeof authenticatedAccrualsAboutRoute
+  '/(authenticated)/admin/email-preview': typeof authenticatedAdminEmailPreviewRoute
   '/(authenticated)/admin/notification': typeof authenticatedAdminNotificationRoute
   '/(authenticated)/admin/users': typeof authenticatedAdminUsersRoute
   '/(authenticated)/principalInvestigators/$emplid': typeof authenticatedPrincipalInvestigatorsEmplidRoute
@@ -287,6 +297,7 @@ export interface FileRouteTypes {
     | '/'
     | '/projects/$employeeId'
     | '/accruals/about'
+    | '/admin/email-preview'
     | '/admin/notification'
     | '/admin/users'
     | '/principalInvestigators/$emplid'
@@ -312,6 +323,7 @@ export interface FileRouteTypes {
     | '/styles'
     | '/'
     | '/accruals/about'
+    | '/admin/email-preview'
     | '/admin/notification'
     | '/admin/users'
     | '/principalInvestigators/$emplid'
@@ -341,6 +353,7 @@ export interface FileRouteTypes {
     | '/(authenticated)/'
     | '/(authenticated)/projects/$employeeId'
     | '/(authenticated)/accruals/about'
+    | '/(authenticated)/admin/email-preview'
     | '/(authenticated)/admin/notification'
     | '/(authenticated)/admin/users'
     | '/(authenticated)/principalInvestigators/$emplid'
@@ -490,6 +503,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof authenticatedAdminNotificationRouteImport
       parentRoute: typeof authenticatedAdminRouteRoute
     }
+    '/(authenticated)/admin/email-preview': {
+      id: '/(authenticated)/admin/email-preview'
+      path: '/email-preview'
+      fullPath: '/admin/email-preview'
+      preLoaderRoute: typeof authenticatedAdminEmailPreviewRouteImport
+      parentRoute: typeof authenticatedAdminRouteRoute
+    }
     '/(authenticated)/accruals/about': {
       id: '/(authenticated)/accruals/about'
       path: '/accruals/about'
@@ -557,6 +577,7 @@ declare module '@tanstack/react-router' {
 }
 
 interface authenticatedAdminRouteRouteChildren {
+  authenticatedAdminEmailPreviewRoute: typeof authenticatedAdminEmailPreviewRoute
   authenticatedAdminNotificationRoute: typeof authenticatedAdminNotificationRoute
   authenticatedAdminUsersRoute: typeof authenticatedAdminUsersRoute
   authenticatedAdminIndexRoute: typeof authenticatedAdminIndexRoute
@@ -564,6 +585,7 @@ interface authenticatedAdminRouteRouteChildren {
 
 const authenticatedAdminRouteRouteChildren: authenticatedAdminRouteRouteChildren =
   {
+    authenticatedAdminEmailPreviewRoute: authenticatedAdminEmailPreviewRoute,
     authenticatedAdminNotificationRoute: authenticatedAdminNotificationRoute,
     authenticatedAdminUsersRoute: authenticatedAdminUsersRoute,
     authenticatedAdminIndexRoute: authenticatedAdminIndexRoute,

--- a/web/client/src/routes/(authenticated)/admin/email-preview.tsx
+++ b/web/client/src/routes/(authenticated)/admin/email-preview.tsx
@@ -1,0 +1,360 @@
+import { HttpError } from '@/lib/api.ts';
+import {
+  EmailPreviewResponse,
+  renderEmailPreview,
+} from '@/queries/emailPreview.ts';
+import { meQueryOptions } from '@/queries/user.ts';
+import { RouterContext } from '@/main.tsx';
+import { hasAdminRole } from '@/shared/auth/roleAccess.ts';
+import {
+  ArrowLeftIcon,
+  EnvelopeIcon,
+  EyeIcon,
+} from '@heroicons/react/24/outline';
+import { useMutation } from '@tanstack/react-query';
+import { createFileRoute, Link, redirect } from '@tanstack/react-router';
+import { useState } from 'react';
+
+type EmailPreviewPreset = {
+  id: string;
+  label: string;
+  notificationType: string;
+  payloadJson: string;
+  payloadVersion: number;
+  recipientName: string;
+  templateKey: string;
+  templateVersion: number;
+};
+
+const formatJson = (value: unknown) => JSON.stringify(value, null, 2);
+
+const createEmployeePayload = (
+  employeeGroup: string,
+  employeeName: string,
+  pctOfCap: number
+) =>
+  formatJson({
+    accrualHoursPerMonth: 10,
+    balanceHours: 240,
+    capHours: 240,
+    classification: employeeGroup,
+    department: 'PLANT SCIENCES',
+    departmentCode: '030003',
+    employeeAsOfDate: '2026-04-30T00:00:00',
+    employeeGroup,
+    employeeId: 'E001',
+    employeeName,
+    lastVacationDate: '2026-02-28T00:00:00',
+    monthsToCap: 0,
+    pctOfCap,
+    snapshotAsOfDate: '2026-04-30T00:00:00',
+    status: 'AtCap',
+  });
+
+const presets: EmailPreviewPreset[] = [
+  {
+    id: 'employee-staff',
+    label: 'Accrual employee: staff',
+    notificationType: 'accrual.employee',
+    payloadJson: createEmployeePayload('Staff', 'Staff Member', 100),
+    payloadVersion: 1,
+    recipientName: 'Staff Member',
+    templateKey: 'accrual.employee.staff.v1',
+    templateVersion: 1,
+  },
+  {
+    id: 'employee-faculty',
+    label: 'Accrual employee: faculty',
+    notificationType: 'accrual.employee',
+    payloadJson: createEmployeePayload(
+      'FacultyAcademic',
+      'Faculty Member',
+      91.7
+    ),
+    payloadVersion: 1,
+    recipientName: 'Faculty Member',
+    templateKey: 'accrual.employee.faculty-academic.v1',
+    templateVersion: 1,
+  },
+  {
+    id: 'employee-generic',
+    label: 'Accrual employee: generic',
+    notificationType: 'accrual.employee',
+    payloadJson: createEmployeePayload('Generic', 'Employee One', 83.3),
+    payloadVersion: 1,
+    recipientName: 'Employee One',
+    templateKey: 'accrual.employee.generic.v1',
+    templateVersion: 1,
+  },
+];
+
+const firstPreset = presets[0];
+
+export const Route = createFileRoute(
+  '/(authenticated)/admin/email-preview'
+)({
+  beforeLoad: async ({ context }: { context: RouterContext }) => {
+    const user = await context.queryClient.ensureQueryData(meQueryOptions());
+
+    if (!hasAdminRole(user.roles)) {
+      throw redirect({ to: '/admin' });
+    }
+  },
+  component: RouteComponent,
+});
+
+function RouteComponent() {
+  const [selectedPresetId, setSelectedPresetId] = useState(firstPreset.id);
+  const [notificationType, setNotificationType] = useState(
+    firstPreset.notificationType
+  );
+  const [templateKey, setTemplateKey] = useState(firstPreset.templateKey);
+  const [templateVersion, setTemplateVersion] = useState(
+    firstPreset.templateVersion.toString()
+  );
+  const [payloadVersion, setPayloadVersion] = useState(
+    firstPreset.payloadVersion.toString()
+  );
+  const [recipientName, setRecipientName] = useState(
+    firstPreset.recipientName
+  );
+  const [payloadJson, setPayloadJson] = useState(firstPreset.payloadJson);
+  const [preview, setPreview] = useState<EmailPreviewResponse | null>(null);
+
+  const renderMutation = useMutation({
+    mutationFn: renderEmailPreview,
+    onSuccess: (data) => {
+      setPreview(data);
+    },
+  });
+
+  const loadPreset = (presetId: string) => {
+    const preset = presets.find((item) => item.id === presetId);
+    if (!preset) {
+      return;
+    }
+
+    setSelectedPresetId(preset.id);
+    setNotificationType(preset.notificationType);
+    setTemplateKey(preset.templateKey);
+    setTemplateVersion(preset.templateVersion.toString());
+    setPayloadVersion(preset.payloadVersion.toString());
+    setRecipientName(preset.recipientName);
+    setPayloadJson(preset.payloadJson);
+    renderMutation.reset();
+  };
+
+  const renderError = renderMutation.error
+    ? getPreviewErrorMessage(renderMutation.error)
+    : null;
+
+  return (
+    <main className="mt-8">
+      <div className="container">
+        <Link className="btn btn-sm mb-4" to="/admin">
+          <ArrowLeftIcon className="h-4 w-4" />
+          Back to Admin Dashboard
+        </Link>
+        <EnvelopeIcon className="h-6 w-6" />
+        <h1 className="h1">Email Preview</h1>
+        <p className="subtitle">
+          Render an email using the production notification renderer.
+        </p>
+        <hr className="border-main-border my-4" />
+
+        <form
+          className="grid gap-6 xl:grid-cols-[minmax(360px,520px)_1fr]"
+          onSubmit={(event) => {
+            event.preventDefault();
+            renderMutation.mutate({
+              notificationType,
+              payloadJson,
+              payloadVersion: Number(payloadVersion),
+              recipientName,
+              templateKey,
+              templateVersion: Number(templateVersion),
+            });
+          }}
+        >
+          <section className="flex flex-col gap-4">
+            <div>
+              <label className="label" htmlFor="email-preview-preset">
+                <span className="label-text">Load preset</span>
+              </label>
+              <select
+                className="select select-bordered w-full"
+                id="email-preview-preset"
+                onChange={(event) => loadPreset(event.target.value)}
+                value={selectedPresetId}
+              >
+                {presets.map((preset) => (
+                  <option key={preset.id} value={preset.id}>
+                    {preset.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div>
+              <label className="label" htmlFor="email-preview-notification">
+                <span className="label-text">NotificationType</span>
+              </label>
+              <input
+                className="input input-bordered w-full"
+                id="email-preview-notification"
+                onChange={(event) => setNotificationType(event.target.value)}
+                type="text"
+                value={notificationType}
+              />
+            </div>
+
+            <div>
+              <label className="label" htmlFor="email-preview-template">
+                <span className="label-text">TemplateKey</span>
+              </label>
+              <input
+                className="input input-bordered w-full"
+                id="email-preview-template"
+                onChange={(event) => setTemplateKey(event.target.value)}
+                type="text"
+                value={templateKey}
+              />
+            </div>
+
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div>
+                <label className="label" htmlFor="email-preview-template-version">
+                  <span className="label-text">TemplateVersion</span>
+                </label>
+                <input
+                  className="input input-bordered w-full"
+                  id="email-preview-template-version"
+                  min={1}
+                  onChange={(event) => setTemplateVersion(event.target.value)}
+                  type="number"
+                  value={templateVersion}
+                />
+              </div>
+
+              <div>
+                <label className="label" htmlFor="email-preview-payload-version">
+                  <span className="label-text">PayloadVersion</span>
+                </label>
+                <input
+                  className="input input-bordered w-full"
+                  id="email-preview-payload-version"
+                  min={1}
+                  onChange={(event) => setPayloadVersion(event.target.value)}
+                  type="number"
+                  value={payloadVersion}
+                />
+              </div>
+            </div>
+
+            <div>
+              <label className="label" htmlFor="email-preview-recipient">
+                <span className="label-text">RecipientName</span>
+              </label>
+              <input
+                className="input input-bordered w-full"
+                id="email-preview-recipient"
+                onChange={(event) => setRecipientName(event.target.value)}
+                type="text"
+                value={recipientName}
+              />
+            </div>
+
+            <div>
+              <label className="label" htmlFor="email-preview-payload">
+                <span className="label-text">PayloadJson</span>
+              </label>
+              <textarea
+                className="textarea textarea-bordered min-h-96 w-full font-mono text-sm"
+                id="email-preview-payload"
+                onChange={(event) => setPayloadJson(event.target.value)}
+                spellCheck={false}
+                value={payloadJson}
+              />
+            </div>
+
+            <button
+              className="btn btn-primary w-fit"
+              disabled={renderMutation.isPending}
+              type="submit"
+            >
+              {renderMutation.isPending ? (
+                <>
+                  <span className="loading loading-spinner loading-sm" />
+                  Rendering...
+                </>
+              ) : (
+                <>
+                  <EyeIcon className="h-4 w-4" />
+                  Preview
+                </>
+              )}
+            </button>
+
+            {renderError ? (
+              <div className="alert alert-error">
+                <span>{renderError}</span>
+              </div>
+            ) : null}
+          </section>
+
+          <section className="flex min-w-0 flex-col gap-4">
+            <div>
+              <h2 className="text-lg font-semibold">Subject</h2>
+              <div className="mt-2 rounded border border-main-border bg-base-100 p-3">
+                {preview?.subject ?? 'No preview rendered yet.'}
+              </div>
+            </div>
+
+            <div>
+              <h2 className="text-lg font-semibold">HTML</h2>
+              <iframe
+                className="mt-2 h-[640px] w-full rounded border border-main-border bg-white"
+                sandbox=""
+                srcDoc={preview?.htmlBody ?? ''}
+                title="Email HTML preview"
+              />
+            </div>
+
+            <div>
+              <h2 className="text-lg font-semibold">Text</h2>
+              <pre className="mt-2 max-h-96 overflow-auto whitespace-pre-wrap rounded border border-main-border bg-base-100 p-3 text-sm">
+                {preview?.textBody ?? 'No preview rendered yet.'}
+              </pre>
+            </div>
+          </section>
+        </form>
+      </div>
+    </main>
+  );
+}
+
+function getPreviewErrorMessage(error: unknown) {
+  if (error instanceof HttpError) {
+    const body = error.body;
+    if (typeof body === 'string' && body.trim()) {
+      return body;
+    }
+
+    if (isEmailPreviewError(body)) {
+      return body.error;
+    }
+
+    return `Render failed with HTTP ${error.status}.`;
+  }
+
+  return error instanceof Error ? error.message : 'Render failed.';
+}
+
+function isEmailPreviewError(value: unknown): value is { error: string } {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'error' in value &&
+    typeof value.error === 'string'
+  );
+}

--- a/web/client/src/routes/(authenticated)/admin/index.tsx
+++ b/web/client/src/routes/(authenticated)/admin/index.tsx
@@ -5,7 +5,11 @@ import {
   hasSystemRole,
 } from '@/shared/auth/roleAccess.ts';
 import { useUser } from '@/shared/auth/UserContext.tsx';
-import { MegaphoneIcon, UsersIcon } from '@heroicons/react/24/outline';
+import {
+  EnvelopeIcon,
+  MegaphoneIcon,
+  UsersIcon,
+} from '@heroicons/react/24/outline';
 
 export const Route = createFileRoute('/(authenticated)/admin/')({
   component: RouteComponent,
@@ -62,10 +66,16 @@ function RouteComponent() {
             </Link>
           ) : null}
           {isAdmin ? (
-            <Link className="btn btn-primary btn-lg" to="/admin/notification">
-              <MegaphoneIcon className="w-4 h-4" />
-              Site Notification
-            </Link>
+            <>
+              <Link className="btn btn-primary btn-lg" to="/admin/notification">
+                <MegaphoneIcon className="w-4 h-4" />
+                Site Notification
+              </Link>
+              <Link className="btn btn-primary btn-lg" to="/admin/email-preview">
+                <EnvelopeIcon className="w-4 h-4" />
+                Email Preview
+              </Link>
+            </>
           ) : null}
         </div>
       </div>

--- a/web/client/src/test/routes/(authenticated)/admin-email-preview.test.tsx
+++ b/web/client/src/test/routes/(authenticated)/admin-email-preview.test.tsx
@@ -1,0 +1,117 @@
+import { server } from '@/test/mswUtils.ts';
+import { renderRoute } from '@/test/routerUtils.tsx';
+import { screen, waitFor } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
+import { describe, expect, it } from 'vitest';
+
+const createUser = (roles: string[]) => ({
+  email: 'test@example.com',
+  employeeId: '1000',
+  id: 'user-1',
+  kerberos: 'testuser',
+  name: 'Test User',
+  roles,
+});
+
+const registerHomeApis = () => {
+  server.use(
+    http.get('/api/project/managed/:employeeId', () =>
+      HttpResponse.json({ pis: [], projectManager: null })
+    ),
+    http.get('/api/project/:employeeId', () => HttpResponse.json([])),
+    http.get('/api/project/personnel', () => HttpResponse.json([]))
+  );
+};
+
+describe('Admin email preview page', () => {
+  it('shows the Email Preview link on the admin index for Admin users', async () => {
+    server.use(
+      http.get('/api/user/me', () => HttpResponse.json(createUser(['Admin'])))
+    );
+    registerHomeApis();
+
+    const { cleanup } = renderRoute({ initialPath: '/admin' });
+
+    try {
+      expect(
+        await screen.findByRole('link', { name: 'Email Preview' })
+      ).toBeInTheDocument();
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('redirects Manager users from /admin/email-preview to /admin', async () => {
+    server.use(
+      http.get('/api/user/me', () => HttpResponse.json(createUser(['Manager'])))
+    );
+    registerHomeApis();
+
+    const { cleanup } = renderRoute({ initialPath: '/admin/email-preview' });
+
+    try {
+      await waitFor(() => {
+        expect(
+          screen.getByRole('heading', { name: 'Admin Dashboard' })
+        ).toBeInTheDocument();
+      });
+      expect(
+        screen.queryByRole('heading', { name: 'Email Preview' })
+      ).not.toBeInTheDocument();
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('renders the preview with editable envelope fields and payload JSON', async () => {
+    server.use(
+      http.get('/api/user/me', () => HttpResponse.json(createUser(['Admin'])))
+    );
+    registerHomeApis();
+
+    let postBody: unknown = null;
+    server.use(
+      http.post('/api/admin/email-preview/render', async ({ request }) => {
+        postBody = await request.json();
+        return HttpResponse.json({
+          htmlBody: '<html><body><p>Rendered HTML</p></body></html>',
+          subject: 'Action Needed: Your Vacation Accrual is at 100% of Maximum',
+          textBody: 'Rendered text',
+        });
+      })
+    );
+
+    const user = userEvent.setup();
+    const { cleanup } = renderRoute({ initialPath: '/admin/email-preview' });
+
+    try {
+      await screen.findByRole('heading', { name: 'Email Preview' });
+      await user.click(screen.getByRole('button', { name: 'Preview' }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(
+            'Action Needed: Your Vacation Accrual is at 100% of Maximum'
+          )
+        ).toBeInTheDocument();
+      });
+
+      expect(screen.getByText('Rendered text')).toBeInTheDocument();
+      expect(postBody).toMatchObject({
+        notificationType: 'accrual.employee',
+        payloadVersion: 1,
+        recipientName: 'Staff Member',
+        templateKey: 'accrual.employee.staff.v1',
+        templateVersion: 1,
+      });
+      expect(postBody).toEqual(
+        expect.objectContaining({
+          payloadJson: expect.stringContaining('"pctOfCap": 100'),
+        })
+      );
+    } finally {
+      cleanup();
+    }
+  });
+});

--- a/web/server.core/Services/NotificationTemplateModels.cs
+++ b/web/server.core/Services/NotificationTemplateModels.cs
@@ -4,9 +4,12 @@ namespace server.core.Services;
 
 public abstract class NotificationTemplateModelBase
 {
+    public static string DefaultLogoUrl => "/apple-touch-icon.png";
+
     public string AppName { get; init; } = "Walter";
     public string ButtonText { get; init; } = string.Empty;
     public string ButtonUrl { get; init; } = string.Empty;
+    public string? LogoUrl { get; init; } = DefaultLogoUrl;
     public string? LayoutWidth { get; init; }
 }
 

--- a/web/server.core/Services/OutboundMessageRendering.cs
+++ b/web/server.core/Services/OutboundMessageRendering.cs
@@ -209,6 +209,8 @@ public sealed class AccrualOutboundMessageRenderer : IOutboundMessageRenderer
         {
             AppName = _appOptions.Name,
             GreetingName = NormalizeDisplayName(message.RecipientName) ?? payload.EmployeeName,
+            LogoUrl = BuildAppAssetUrl(_appOptions.TryGetBaseUri(), "/apple-touch-icon.png")
+                ?? NotificationTemplateModelBase.DefaultLogoUrl,
             Payload = payload,
             Variant = variant,
         };
@@ -226,6 +228,8 @@ public sealed class AccrualOutboundMessageRenderer : IOutboundMessageRenderer
             ButtonText = string.IsNullOrWhiteSpace(reportUrl) ? string.Empty : "Open Accrual Report",
             ButtonUrl = reportUrl,
             LayoutWidth = "720px",
+            LogoUrl = BuildAppAssetUrl(appBaseUri, "/apple-touch-icon.png")
+                ?? NotificationTemplateModelBase.DefaultLogoUrl,
             Payload = payload,
         };
     }
@@ -235,6 +239,23 @@ public sealed class AccrualOutboundMessageRenderer : IOutboundMessageRenderer
         var builder = new UriBuilder(appBaseUri)
         {
             Path = $"{appBaseUri.AbsolutePath.TrimEnd('/')}/accruals",
+            Query = string.Empty,
+            Fragment = string.Empty,
+        };
+
+        return builder.Uri.ToString();
+    }
+
+    private static string? BuildAppAssetUrl(Uri? appBaseUri, string assetPath)
+    {
+        if (appBaseUri is null)
+        {
+            return null;
+        }
+
+        var builder = new UriBuilder(appBaseUri)
+        {
+            Path = $"{appBaseUri.AbsolutePath.TrimEnd('/')}/{assetPath.TrimStart('/')}",
             Query = string.Empty,
             Fragment = string.Empty,
         };

--- a/web/server.core/Services/OutboundMessageRendering.cs
+++ b/web/server.core/Services/OutboundMessageRendering.cs
@@ -77,7 +77,7 @@ public sealed class PlaceholderOutboundMessageRenderer : IOutboundMessageRendere
             var pctOfCap = TryReadDecimal(formattedPayload, "pctOfCap");
             return pctOfCap is null
                 ? "Action Needed: Your Vacation Accrual Balance"
-                : $"Action Needed: Your Vacation Accrual is at {pctOfCap.Value:0}% of Maximum";
+                : $"Action Needed: Your Vacation Accrual is at {AccrualEmailTemplateFormatting.Percent(pctOfCap.Value)} of Maximum";
         }
 
         if (message.NotificationType == AccrualNotificationMessageBuilder.ViewerReportNotificationType)
@@ -286,8 +286,6 @@ public sealed class AccrualOutboundMessageRenderer : IOutboundMessageRenderer
 
     private static string BuildEmployeeSubject(AccrualEmployeeNotificationPayload payload)
     {
-        return payload.PctOfCap > 0m
-            ? $"Action Needed: Your Vacation Accrual is at {AccrualEmailTemplateFormatting.Percent(payload.PctOfCap)} of Maximum"
-            : "Action Needed: Your Vacation Accrual Balance";
+        return $"Action Needed: Your Vacation Accrual is at {AccrualEmailTemplateFormatting.Percent(payload.PctOfCap)} of Maximum";
     }
 }

--- a/web/server.core/Views/Emails/AccrualEmployeeNotification_mjml.cshtml
+++ b/web/server.core/Views/Emails/AccrualEmployeeNotification_mjml.cshtml
@@ -1,102 +1,62 @@
-@using server.core.Models
 @using server.core.Services
 @model server.core.Services.AccrualEmployeeNotificationTemplateModel
 
 @{
     Layout = "/Views/Shared/_NotificationLayout_mjml.cshtml";
     var payload = Model.Payload;
-    var header = payload.Status switch
-    {
-        nameof(AccrualNotificationStatus.AtCap) => "Your vacation accrual balance is at the cap",
-        nameof(AccrualNotificationStatus.ApproachingCap) => "Your vacation accrual balance is approaching the cap",
-        _ => "Your vacation accrual balance needs review",
-    };
-    var primaryMessage = Model.Variant switch
-    {
-        AccrualEmployeeNotificationVariant.FacultyAcademic =>
-            "Faculty and academic appointees are expected to manage vacation usage so balances do not remain at or near the maximum accrual limit.",
-        AccrualEmployeeNotificationVariant.Staff =>
-            "Please work with your supervisor to plan vacation usage and keep your balance below the maximum accrual limit.",
-        _ =>
-            "Please review your vacation balance and plan usage as needed to keep your accruals below the maximum limit.",
-    };
-    var monthsToCap = payload.MonthsToCap switch
-    {
-        null => "Not projected",
-        <= 0 => "At cap now",
-        1 => "1 month",
-        var months => $"{months} months",
-    };
-    var lastVacationDate = payload.LastVacationDate is null
-        ? "No recent vacation date found"
-        : AccrualEmailTemplateFormatting.Date(payload.LastVacationDate.Value);
+    var balanceHours = AccrualEmailTemplateFormatting.Hours(payload.BalanceHours);
+    var capHours = AccrualEmailTemplateFormatting.Hours(payload.CapHours);
+    var pctOfCap = AccrualEmailTemplateFormatting.Percent(payload.PctOfCap);
+    const string trsUrl = "https://trs.ucdavis.edu/timesheet";
 }
 
-<mj-section padding="34px 36px 12px 36px">
+<mj-section padding="34px 36px 24px 36px">
   <mj-column>
-    <mj-text font-size="25px" font-weight="700" line-height="1.3" padding-bottom="12px">
-      @header
-    </mj-text>
     <mj-text padding="0px 0px 12px 0px">
-      Hello @Model.GreetingName,
+      Dear @Model.GreetingName,
     </mj-text>
-    <mj-text padding="0px 0px 16px 0px">
-      @primaryMessage
+    @if (Model.Variant == AccrualEmployeeNotificationVariant.FacultyAcademic)
+    {
+      <mj-text padding="0px 0px 16px 0px">
+        This is an automated notification from the CAES HR Office regarding your vacation accrual balance.
+      </mj-text>
+      <mj-text padding="0px 0px 16px 0px">
+        As a fiscal year academic appointee, your current vacation balance is @balanceHours, which is @pctOfCap of your maximum accrual cap of @capHours.
+      </mj-text>
+      <mj-text padding="0px 0px 16px 0px">
+        Per UC policy (PPSM 2.210), vacation accrual stops entirely once the cap is reached. We recognize that research and teaching commitments can make scheduling time away challenging, but we strongly encourage you to work with your department chair to identify windows for vacation before your balance reaches the maximum.
+      </mj-text>
+    }
+    else if (Model.Variant == AccrualEmployeeNotificationVariant.Staff)
+    {
+      <mj-text padding="0px 0px 16px 0px">
+        This is an automated notification from the CAES HR Office. Your current vacation accrual balance is @balanceHours, which is @pctOfCap of your maximum accrual cap of @capHours.
+      </mj-text>
+      <mj-text padding="0px 0px 16px 0px">
+        Per UC policy (PPSM 2.210), once your balance reaches the maximum, you will stop accruing vacation hours until your balance falls below the cap. We encourage you to plan and schedule vacation time to avoid losing accrual.
+      </mj-text>
+      <mj-text padding="0px 0px 16px 0px">
+        Please submit your leave request at your earliest convenience:
+      </mj-text>
+      <mj-button href="@trsUrl" padding="0px 0px 22px 0px" align="left">
+        Open TRS Time Reporting &rarr;
+      </mj-button>
+    }
+    else
+    {
+      <mj-text padding="0px 0px 16px 0px">
+        This is an automated notification from the CAES HR Office regarding your vacation accrual balance.
+      </mj-text>
+      <mj-text padding="0px 0px 16px 0px">
+        Your current vacation balance is @balanceHours, which is @pctOfCap of your maximum accrual cap of @capHours.
+      </mj-text>
+      <mj-text padding="0px 0px 16px 0px">
+        Per UC policy (PPSM 2.210), once your balance reaches the maximum, you will stop accruing vacation hours until your balance falls below the cap. We encourage you to plan and schedule vacation time to avoid losing accrual.
+      </mj-text>
+    }
+    <mj-text padding="0px">
+      Best regards,<br />
+      CAES Human Resources
     </mj-text>
-  </mj-column>
-</mj-section>
-
-<mj-section padding="0px 36px 28px 36px">
-  <mj-column>
-    <mj-table cellpadding="0" cellspacing="0" font-size="14px" line-height="1.5" role="presentation" padding="0px">
-      <tr style="border-bottom:1px solid #d8e1ec;">
-        <th align="left" style="padding:0 12px 10px 0;color:#5d6b82;font-size:12px;font-weight:700;text-transform:uppercase;">
-          Field
-        </th>
-        <th align="left" style="padding:0 0 10px 12px;color:#5d6b82;font-size:12px;font-weight:700;text-transform:uppercase;">
-          Value
-        </th>
-      </tr>
-      <tr style="border-bottom:1px solid #eef3f8;">
-        <td style="padding:12px 12px 12px 0;color:#5d6b82;">Snapshot date</td>
-        <td style="padding:12px 0 12px 12px;color:#172033;font-weight:600;">@AccrualEmailTemplateFormatting.Date(payload.SnapshotAsOfDate)</td>
-      </tr>
-      <tr style="border-bottom:1px solid #eef3f8;">
-        <td style="padding:12px 12px 12px 0;color:#5d6b82;">Vacation balance</td>
-        <td style="padding:12px 0 12px 12px;color:#172033;font-weight:600;">@AccrualEmailTemplateFormatting.Hours(payload.BalanceHours)</td>
-      </tr>
-      <tr style="border-bottom:1px solid #eef3f8;">
-        <td style="padding:12px 12px 12px 0;color:#5d6b82;">Accrual cap</td>
-        <td style="padding:12px 0 12px 12px;color:#172033;font-weight:600;">@AccrualEmailTemplateFormatting.Hours(payload.CapHours)</td>
-      </tr>
-      <tr style="border-bottom:1px solid #eef3f8;">
-        <td style="padding:12px 12px 12px 0;color:#5d6b82;">Percent of cap</td>
-        <td style="padding:12px 0 12px 12px;color:#172033;font-weight:600;">@AccrualEmailTemplateFormatting.Percent(payload.PctOfCap)</td>
-      </tr>
-      <tr style="border-bottom:1px solid #eef3f8;">
-        <td style="padding:12px 12px 12px 0;color:#5d6b82;">Status</td>
-        <td style="padding:12px 0 12px 12px;color:#172033;font-weight:600;">@AccrualEmailTemplateFormatting.Status(payload.Status)</td>
-      </tr>
-      <tr style="border-bottom:1px solid #eef3f8;">
-        <td style="padding:12px 12px 12px 0;color:#5d6b82;">Monthly accrual</td>
-        <td style="padding:12px 0 12px 12px;color:#172033;font-weight:600;">@AccrualEmailTemplateFormatting.Hours(payload.AccrualHoursPerMonth)</td>
-      </tr>
-      <tr style="border-bottom:1px solid #eef3f8;">
-        <td style="padding:12px 12px 12px 0;color:#5d6b82;">Projected time to cap</td>
-        <td style="padding:12px 0 12px 12px;color:#172033;font-weight:600;">@monthsToCap</td>
-      </tr>
-      <tr style="border-bottom:1px solid #eef3f8;">
-        <td style="padding:12px 12px 12px 0;color:#5d6b82;">Last vacation date</td>
-        <td style="padding:12px 0 12px 12px;color:#172033;font-weight:600;">@lastVacationDate</td>
-      </tr>
-      <tr style="border-bottom:1px solid #eef3f8;">
-        <td style="padding:12px 12px 12px 0;color:#5d6b82;">Department</td>
-        <td style="padding:12px 0 12px 12px;color:#172033;font-weight:600;">@payload.Department (@payload.DepartmentCode)</td>
-      </tr>
-      <tr>
-        <td style="padding:12px 12px 0 0;color:#5d6b82;">Classification</td>
-        <td style="padding:12px 0 0 12px;color:#172033;font-weight:600;">@payload.Classification</td>
-      </tr>
-    </mj-table>
   </mj-column>
 </mj-section>

--- a/web/server.core/Views/Emails/AccrualEmployeeNotification_text.cshtml
+++ b/web/server.core/Views/Emails/AccrualEmployeeNotification_text.cshtml
@@ -1,49 +1,44 @@
-@using server.core.Models
 @using server.core.Services
 @model server.core.Services.AccrualEmployeeNotificationTemplateModel
 @{
     var payload = Model.Payload;
-    var header = payload.Status switch
-    {
-        nameof(AccrualNotificationStatus.AtCap) => "Your vacation accrual balance is at the cap",
-        nameof(AccrualNotificationStatus.ApproachingCap) => "Your vacation accrual balance is approaching the cap",
-        _ => "Your vacation accrual balance needs review",
-    };
-    var primaryMessage = Model.Variant switch
-    {
-        AccrualEmployeeNotificationVariant.FacultyAcademic =>
-            "Faculty and academic appointees are expected to manage vacation usage so balances do not remain at or near the maximum accrual limit.",
-        AccrualEmployeeNotificationVariant.Staff =>
-            "Please work with your supervisor to plan vacation usage and keep your balance below the maximum accrual limit.",
-        _ =>
-            "Please review your vacation balance and plan usage as needed to keep your accruals below the maximum limit.",
-    };
-    var monthsToCap = payload.MonthsToCap switch
-    {
-        null => "Not projected",
-        <= 0 => "At cap now",
-        1 => "1 month",
-        var months => $"{months} months",
-    };
-    var lastVacationDate = payload.LastVacationDate is null
-        ? "No recent vacation date found"
-        : AccrualEmailTemplateFormatting.Date(payload.LastVacationDate.Value);
+    var balanceHours = AccrualEmailTemplateFormatting.Hours(payload.BalanceHours);
+    var capHours = AccrualEmailTemplateFormatting.Hours(payload.CapHours);
+    var pctOfCap = AccrualEmailTemplateFormatting.Percent(payload.PctOfCap);
+    const string trsUrl = "https://trs.ucdavis.edu/timesheet";
 }
-@header
+Dear @Html.Raw(Model.GreetingName),
 
-Hello @Html.Raw(Model.GreetingName),
+@if (Model.Variant == AccrualEmployeeNotificationVariant.FacultyAcademic)
+{
+<text>This is an automated notification from the CAES HR Office regarding your vacation accrual balance.
 
-@primaryMessage
+As a fiscal year academic appointee, your current vacation balance is @balanceHours, which is @pctOfCap of your maximum accrual cap of @capHours.
 
-Snapshot date: @AccrualEmailTemplateFormatting.Date(payload.SnapshotAsOfDate)
-Balance: @AccrualEmailTemplateFormatting.Hours(payload.BalanceHours)
-Cap: @AccrualEmailTemplateFormatting.Hours(payload.CapHours)
-Percent of cap: @AccrualEmailTemplateFormatting.Percent(payload.PctOfCap)
-Status: @AccrualEmailTemplateFormatting.Status(payload.Status)
-Monthly accrual: @AccrualEmailTemplateFormatting.Hours(payload.AccrualHoursPerMonth)
-Projected time to cap: @monthsToCap
-Last vacation date: @lastVacationDate
-Department: @Html.Raw(payload.Department) (@Html.Raw(payload.DepartmentCode))
-Classification: @Html.Raw(payload.Classification)
+Per UC policy (PPSM 2.210), vacation accrual stops entirely once the cap is reached. We recognize that research and teaching commitments can make scheduling time away challenging, but we strongly encourage you to work with your department chair to identify windows for vacation before your balance reaches the maximum.
+</text>
+}
+else if (Model.Variant == AccrualEmployeeNotificationVariant.Staff)
+{
+<text>This is an automated notification from the CAES HR Office. Your current vacation accrual balance is @balanceHours, which is @pctOfCap of your maximum accrual cap of @capHours.
 
-This email was automatically generated. Please do not reply to it.
+Per UC policy (PPSM 2.210), once your balance reaches the maximum, you will stop accruing vacation hours until your balance falls below the cap. We encourage you to plan and schedule vacation time to avoid losing accrual.
+
+Please submit your leave request at your earliest convenience:
+
+Open TRS Time Reporting →
+@trsUrl
+</text>
+}
+else
+{
+<text>This is an automated notification from the CAES HR Office regarding your vacation accrual balance.
+
+Your current vacation balance is @balanceHours, which is @pctOfCap of your maximum accrual cap of @capHours.
+
+Per UC policy (PPSM 2.210), once your balance reaches the maximum, you will stop accruing vacation hours until your balance falls below the cap. We encourage you to plan and schedule vacation time to avoid losing accrual.
+</text>
+}
+
+Best regards,
+CAES Human Resources

--- a/web/server.core/Views/Shared/_NotificationButton_mjml.cshtml
+++ b/web/server.core/Views/Shared/_NotificationButton_mjml.cshtml
@@ -2,7 +2,7 @@
 
 <mj-section background-color="#ffffff" padding="0px 0px 28px 0px">
   <mj-column>
-    <mj-divider border-color="#dfe7f1" padding="0px 28px 20px 28px" />
+    <mj-divider border-color="#e9e3ee" padding="0px 28px 20px 28px" />
     <mj-button href="@Model.Url" padding="0px 24px">
       @Model.Text
     </mj-button>

--- a/web/server.core/Views/Shared/_NotificationLayout_mjml.cshtml
+++ b/web/server.core/Views/Shared/_NotificationLayout_mjml.cshtml
@@ -4,39 +4,65 @@
   <mj-head>
     <mj-preview>@Model.AppName notification</mj-preview>
     <mj-attributes>
-      <mj-all font-family="Helvetica, Arial, sans-serif" />
-      <mj-text color="#172033" font-size="16px" line-height="1.65" />
+      <mj-all font-family="proxima-nova, Arial, Helvetica, sans-serif" />
+      <mj-text color="#2f2f2f" font-size="16px" line-height="1.65" />
       <mj-button background-color="#0047ba"
                  color="#ffffff"
-                 border-radius="6px"
+                 border-radius="4px"
                  font-size="16px"
                  font-weight="600"
-                 inner-padding="14px 28px" />
+                 inner-padding="13px 24px" />
     </mj-attributes>
   </mj-head>
-  <mj-body background-color="#eef3f8"
+  <mj-body background-color="#fafafa"
            width="@(string.IsNullOrWhiteSpace(Model.LayoutWidth) ? "640px" : Model.LayoutWidth)">
-    <mj-section padding-top="32px" padding-bottom="14px">
+    <mj-section padding="26px 24px 14px 24px">
       <mj-column>
-        <mj-text align="center"
-                 font-size="28px"
-                 font-weight="700"
-                 color="#172033"
-                 padding="0px">
-          @Model.AppName
-        </mj-text>
+        <mj-table cellpadding="0" cellspacing="0" role="presentation" padding="0px">
+          <tr>
+            <td style="height:48px;line-height:0;mso-line-height-rule:exactly;padding:0 10px 0 0;vertical-align:middle;width:48px;">
+              @if (!string.IsNullOrWhiteSpace(Model.LogoUrl))
+              {
+              <img alt="" height="46" src="@Model.LogoUrl" style="border:0;display:block;height:46px;line-height:0;max-height:46px;max-width:46px;width:46px;" width="46" />
+              }
+            </td>
+            <td style="height:48px;padding:0;vertical-align:middle;">
+              <div style="color:#2f2f2f;font-size:22px;font-weight:700;line-height:1.2;">
+                @Model.AppName
+              </div>
+              <div style="color:#7c7c7c;font-size:12px;font-weight:700;letter-spacing:1.8px;line-height:1.5;text-transform:uppercase;">
+                Notification
+              </div>
+            </td>
+          </tr>
+        </mj-table>
       </mj-column>
     </mj-section>
 
-    <mj-section background-color="#ffffff" border-radius="8px" padding="0px">
+    <mj-section background-color="#0047ba" padding="0px">
+      <mj-column width="72%">
+        <mj-spacer height="4px" />
+      </mj-column>
+      <mj-column width="18%" background-color="#ffbf00">
+        <mj-spacer height="4px" />
+      </mj-column>
+      <mj-column width="10%" background-color="#c10230">
+        <mj-spacer height="4px" />
+      </mj-column>
+    </mj-section>
+
+    <mj-section background-color="#ffffff"
+                border="1px solid #e9e3ee"
+                border-radius="0 0 4px 4px"
+                padding="0px">
       <mj-column padding="0px">
         @RenderBody()
       </mj-column>
     </mj-section>
 
-    <mj-section padding-top="16px" padding-bottom="32px">
+    <mj-section padding="16px 24px 30px 24px">
       <mj-column>
-        <mj-text align="center" font-size="12px" line-height="1.5" color="#5d6b82">
+        <mj-text align="center" font-size="12px" line-height="1.5" color="#7c7c7c" padding="0px">
           This email was automatically generated. Please do not reply to it.
         </mj-text>
       </mj-column>

--- a/web/server/Controllers/AdminEmailPreviewController.cs
+++ b/web/server/Controllers/AdminEmailPreviewController.cs
@@ -1,0 +1,88 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using server.core.Domain;
+using server.core.Services;
+
+namespace Server.Controllers;
+
+[ApiController]
+[Route("api/admin/email-preview")]
+[Authorize(Roles = Role.Names.Admin)]
+public sealed class AdminEmailPreviewController : ControllerBase
+{
+    private const int MaxPayloadJsonLength = 256 * 1024;
+
+    private readonly IOutboundMessageRenderer _renderer;
+
+    public AdminEmailPreviewController(IOutboundMessageRenderer renderer)
+    {
+        _renderer = renderer;
+    }
+
+    public sealed record EmailPreviewRequest(
+        [Required, MaxLength(100)] string NotificationType,
+        [Required, MaxLength(200)] string TemplateKey,
+        [Range(1, int.MaxValue)] int TemplateVersion,
+        [Range(1, int.MaxValue)] int PayloadVersion,
+        [MaxLength(200)] string? RecipientName,
+        [Required] string PayloadJson);
+
+    public sealed record EmailPreviewResponse(
+        string Subject,
+        string TextBody,
+        string HtmlBody);
+
+    public sealed record EmailPreviewErrorResponse(string Error);
+
+    [HttpPost("render")]
+    public async Task<ActionResult<EmailPreviewResponse>> Render(
+        [FromBody] EmailPreviewRequest request,
+        CancellationToken cancellationToken)
+    {
+        if (request is null)
+        {
+            return BadRequest(new EmailPreviewErrorResponse("Body is required."));
+        }
+
+        if (request.PayloadJson.Length > MaxPayloadJsonLength)
+        {
+            return BadRequest(new EmailPreviewErrorResponse(
+                $"PayloadJson exceeds {MaxPayloadJsonLength:N0} characters."));
+        }
+
+        var message = new OutboundMessage
+        {
+            Channel = OutboundMessage.Channels.Email,
+            CreatedUtc = DateTime.UtcNow,
+            DedupeKey = $"preview:{Guid.NewGuid():N}",
+            Id = 0,
+            NotBeforeUtc = DateTime.UtcNow,
+            NotificationType = request.NotificationType.Trim(),
+            PayloadJson = request.PayloadJson,
+            PayloadVersion = request.PayloadVersion,
+            RecipientEmail = "preview@example.edu",
+            RecipientName = string.IsNullOrWhiteSpace(request.RecipientName)
+                ? null
+                : request.RecipientName.Trim(),
+            RecipientType = "Preview",
+            RunId = Guid.NewGuid(),
+            Status = OutboundMessage.Statuses.Pending,
+            TemplateKey = request.TemplateKey.Trim(),
+            TemplateVersion = request.TemplateVersion,
+        };
+
+        try
+        {
+            var rendered = await _renderer.RenderAsync(message, cancellationToken);
+            return Ok(new EmailPreviewResponse(
+                rendered.Subject,
+                rendered.TextBody,
+                rendered.HtmlBody));
+        }
+        catch (InvalidOperationException ex)
+        {
+            return BadRequest(new EmailPreviewErrorResponse(ex.Message));
+        }
+    }
+}

--- a/web/server/Controllers/AdminEmailPreviewController.cs
+++ b/web/server/Controllers/AdminEmailPreviewController.cs
@@ -7,9 +7,10 @@ using server.core.Services;
 namespace Server.Controllers;
 
 [ApiController]
+[Route("api/[controller]")]
 [Route("api/admin/email-preview")]
 [Authorize(Roles = Role.Names.Admin)]
-public sealed class AdminEmailPreviewController : ControllerBase
+public sealed class AdminEmailPreviewController : ApiControllerBase
 {
     private const int MaxPayloadJsonLength = 256 * 1024;
 

--- a/web/server/Program.cs
+++ b/web/server/Program.cs
@@ -3,6 +3,8 @@ using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Mjml.Net;
+using Razor.Templating.Core;
 using server.core.Data;
 using server.HealthChecks;
 using server.Helpers;
@@ -53,6 +55,7 @@ builder.Services.AddAuthorizationPolicies();
 builder.Services.Configure<IamSettings>(builder.Configuration.GetSection("Iam"));
 builder.Services.Configure<FinancialSettings>(builder.Configuration.GetSection("Financial"));
 builder.Services.Configure<RumOptions>(builder.Configuration.GetSection("Rum"));
+builder.Services.Configure<AppOptions>(builder.Configuration.GetSection(AppOptions.SectionName));
 builder.Services.Configure<DatamartOptions>(options =>
 {
     options.ConnectionString = builder.Configuration["DM_CONNECTION"]
@@ -79,6 +82,10 @@ builder.Services.AddScoped<IEntraUserAttributeService, EntraUserAttributeService
 builder.Services.AddScoped<IGraphService, GraphService>();
 builder.Services.AddHttpClient<IIdentityService, IdentityService>();
 builder.Services.AddScoped<IUserProfileOrchestrator, UserProfileOrchestrator>();
+builder.Services.AddSingleton<MjmlRenderer>();
+builder.Services.AddRazorTemplating();
+builder.Services.AddScoped<INotificationRenderer, RazorMjmlNotificationRenderer>();
+builder.Services.AddScoped<IOutboundMessageRenderer, AccrualOutboundMessageRenderer>();
 // add auth policies here
 
 builder.Services.AddDbContextPool<AppDbContext>(o => o.UseSqlServer(conn, opt => opt.MigrationsAssembly("server.core")));

--- a/web/server/appsettings.json
+++ b/web/server/appsettings.json
@@ -7,7 +7,7 @@
   },
   "App": {
     "Name": "Walter",
-    "BaseUrl": ""
+    "BaseUrl": "https://walter.ucdavis.edu"
   },
   "Auth": {
     "Instance": "https://login.microsoftonline.com/",

--- a/web/tests/server.tests/Controllers/AdminEmailPreviewControllerTests.cs
+++ b/web/tests/server.tests/Controllers/AdminEmailPreviewControllerTests.cs
@@ -1,0 +1,102 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Server.Controllers;
+using server.core.Domain;
+using server.core.Services;
+
+namespace server.tests.Controllers;
+
+public sealed class AdminEmailPreviewControllerTests
+{
+    [Fact]
+    public async Task Render_builds_unsaved_outbound_message_and_returns_preview()
+    {
+        var renderer = new CapturingRenderer(new RenderedOutboundMessage(
+            "Action Needed: Your Vacation Accrual is at 100% of Maximum",
+            "Plain text body",
+            "<html><body>Email</body></html>"));
+        var controller = new AdminEmailPreviewController(renderer);
+
+        var result = await controller.Render(
+            new AdminEmailPreviewController.EmailPreviewRequest(
+                "accrual.employee",
+                "accrual.employee.staff.v1",
+                1,
+                1,
+                "Staff Member",
+                """{"pctOfCap":100}"""),
+            CancellationToken.None);
+
+        var payload = result.Result.Should().BeOfType<OkObjectResult>().Which.Value
+            .Should().BeOfType<AdminEmailPreviewController.EmailPreviewResponse>().Which;
+
+        payload.Subject.Should().Be("Action Needed: Your Vacation Accrual is at 100% of Maximum");
+        payload.TextBody.Should().Be("Plain text body");
+        payload.HtmlBody.Should().Be("<html><body>Email</body></html>");
+
+        renderer.Message.Should().NotBeNull();
+        renderer.Message!.Id.Should().Be(0);
+        renderer.Message.NotificationType.Should().Be("accrual.employee");
+        renderer.Message.TemplateKey.Should().Be("accrual.employee.staff.v1");
+        renderer.Message.TemplateVersion.Should().Be(1);
+        renderer.Message.PayloadVersion.Should().Be(1);
+        renderer.Message.RecipientName.Should().Be("Staff Member");
+        renderer.Message.RecipientEmail.Should().Be("preview@example.edu");
+        renderer.Message.RecipientType.Should().Be("Preview");
+        renderer.Message.Channel.Should().Be(OutboundMessage.Channels.Email);
+        renderer.Message.Status.Should().Be(OutboundMessage.Statuses.Pending);
+        renderer.Message.PayloadJson.Should().Be("""{"pctOfCap":100}""");
+    }
+
+    [Fact]
+    public async Task Render_returns_bad_request_when_renderer_rejects_input()
+    {
+        var controller = new AdminEmailPreviewController(new ThrowingRenderer());
+
+        var result = await controller.Render(
+            new AdminEmailPreviewController.EmailPreviewRequest(
+                "accrual.employee",
+                "unknown.template",
+                1,
+                1,
+                null,
+                "{}"),
+            CancellationToken.None);
+
+        var payload = result.Result.Should().BeOfType<BadRequestObjectResult>().Which.Value
+            .Should().BeOfType<AdminEmailPreviewController.EmailPreviewErrorResponse>().Which;
+
+        payload.Error.Should().Be("Unsupported outbound message template key 'unknown.template'.");
+    }
+
+    private sealed class CapturingRenderer : IOutboundMessageRenderer
+    {
+        private readonly RenderedOutboundMessage _response;
+
+        public CapturingRenderer(RenderedOutboundMessage response)
+        {
+            _response = response;
+        }
+
+        public OutboundMessage? Message { get; private set; }
+
+        public Task<RenderedOutboundMessage> RenderAsync(
+            OutboundMessage message,
+            CancellationToken cancellationToken = default)
+        {
+            Message = message;
+            return Task.FromResult(_response);
+        }
+    }
+
+    private sealed class ThrowingRenderer : IOutboundMessageRenderer
+    {
+        public Task<RenderedOutboundMessage> RenderAsync(
+            OutboundMessage message,
+            CancellationToken cancellationToken = default)
+        {
+            throw new InvalidOperationException(
+                $"Unsupported outbound message template key '{message.TemplateKey}'.");
+        }
+    }
+}

--- a/web/tests/server.tests/Services/AccrualOutboundMessageRendererTests.cs
+++ b/web/tests/server.tests/Services/AccrualOutboundMessageRendererTests.cs
@@ -43,11 +43,16 @@ public sealed class AccrualOutboundMessageRendererTests
         var rendered = await renderer.RenderAsync(message);
 
         rendered.Subject.Should().Be("Action Needed: Your Vacation Accrual is at 100% of Maximum");
-        rendered.TextBody.Should().Contain("Please work with your supervisor");
-        rendered.TextBody.Should().Contain("Balance: 240.0 hours");
+        rendered.TextBody.Should().Contain("Dear Staff Member,");
+        rendered.TextBody.Should().Contain("you will stop accruing vacation hours until your balance falls below the cap");
+        rendered.TextBody.Should().Contain("Open TRS Time Reporting");
+        rendered.TextBody.Should().Contain("https://trs.ucdavis.edu/timesheet");
+        rendered.TextBody.Should().Contain("240.0 hours");
         rendered.HtmlBody.Should().Contain("Walter");
-        rendered.HtmlBody.Should().Contain("Your vacation accrual balance is at the cap");
-        rendered.HtmlBody.Should().Contain("Please work with your supervisor");
+        rendered.HtmlBody.Should().Contain("Dear Staff Member,");
+        rendered.HtmlBody.Should().Contain("you will stop accruing vacation hours until your balance falls below the cap");
+        rendered.HtmlBody.Should().Contain("Open TRS Time Reporting");
+        rendered.HtmlBody.Should().Contain("https://trs.ucdavis.edu/timesheet");
         rendered.HtmlBody.Should().Contain("240.0 hours");
         rendered.HtmlBody.Should().NotContain("<mjml");
     }
@@ -79,8 +84,8 @@ public sealed class AccrualOutboundMessageRendererTests
         var rendered = await renderer.RenderAsync(message);
 
         rendered.HtmlBody.Should().Contain("Recipient &lt;Unsafe&gt;");
-        rendered.HtmlBody.Should().Contain("PLANT &lt;SCIENCES&gt;");
         rendered.HtmlBody.Should().NotContain("Recipient <Unsafe>");
+        rendered.HtmlBody.Should().NotContain("PLANT <SCIENCES>");
         rendered.HtmlBody.Should().NotContain("<script>alert('classification')</script>");
     }
 
@@ -88,15 +93,15 @@ public sealed class AccrualOutboundMessageRendererTests
     [InlineData(
         "accrual.employee.faculty-academic.v1",
         nameof(AccrualEmployeeGroup.FacultyAcademic),
-        "Faculty and academic appointees")]
+        "work with your department chair")]
     [InlineData(
         "accrual.employee.staff.v1",
         nameof(AccrualEmployeeGroup.Staff),
-        "Please work with your supervisor")]
+        "Please submit your leave request")]
     [InlineData(
         "accrual.employee.generic.v1",
         nameof(AccrualEmployeeGroup.Generic),
-        "Please review your vacation balance")]
+        "Your current vacation balance")]
     public async Task RenderAsync_renders_each_employee_template_key(
         string templateKey,
         string employeeGroup,

--- a/web/tests/server.tests/Services/AccrualOutboundMessageRendererTests.cs
+++ b/web/tests/server.tests/Services/AccrualOutboundMessageRendererTests.cs
@@ -131,6 +131,7 @@ public sealed class AccrualOutboundMessageRendererTests
 
         var rendered = await renderer.RenderAsync(message);
 
+        rendered.Subject.Should().Be("Action Needed: Your Vacation Accrual is at 91.7% of Maximum");
         rendered.HtmlBody.Should().Contain(expectedMessage);
         rendered.TextBody.Should().Contain(expectedMessage);
     }


### PR DESCRIPTION
## Summary
- add an Admin-only email preview endpoint that renders unsaved outbound messages with the production renderer
- add an /admin/email-preview page with preset payloads plus arbitrary notification/template/payload inputs
- link the preview page from the Admin dashboard and cover it with server/client tests

## Tests
- dotnet test web/tests/server.tests/server.tests.csproj
- npm run build
- npm run test -- --run
- npx eslint 'src/routes/(authenticated)/admin/email-preview.tsx' src/queries/emailPreview.ts 'src/routes/(authenticated)/admin/index.tsx' 'src/test/routes/(authenticated)/admin-email-preview.test.tsx'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin Email Preview tool: generate rendered email subject, HTML and text previews from the admin UI.

* **Updates**
  * Streamlined accrual notification copy and revamped email layout/styling.
  * Default app asset/logo URL set for email templates.
  * Admin dashboard includes Email Preview link.

* **Bug Fixes**
  * Consistent percentage formatting in accrual email subjects.

* **Tests**
  * Added server and UI tests for preview rendering and access controls.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ucdavis/Walter/pull/271?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->