### PR TITLE
Add project burndown by personnel costs

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -44,6 +44,14 @@ _Avoid_: Admin report, manager report
 A user role whose members can inspect accrual reporting and receive the monthly **Accrual Viewer Report**.
 _Avoid_: Admin, viewer
 
+**Project Burndown**:
+A forward-looking projection of a project's remaining balance through a selected horizon, reduced by expected future costs.
+_Avoid_: Historical spend report, transaction history
+
+**Projected Personnel Cost**:
+The expected monthly project cost for a personnel funding distribution, including distributed salary and composite benefit rate costs.
+_Avoid_: Salary only, headcount cost
+
 ## Relationships
 
 - An **Accrual Snapshot** classifies each employee as active, **Approaching Cap**, or **At Cap**
@@ -55,6 +63,11 @@ _Avoid_: Admin, viewer
 - An active **Accrual Viewer** receives the monthly **Accrual Viewer Report**
 - A scheduled notification run does not create new **Accrual Notifications** when the latest **Accrual Snapshot** has already been notified
 - Employees with unmapped classifications receive the **Generic** employee-group variant
+- A **Project Burndown** starts from the latest reported project balance
+- A **Project Burndown** may use historical costs to estimate future costs, but it does not report historical spend as its purpose
+- A **Project Burndown** includes **Projected Personnel Cost** when personnel are expected to remain funded by the project during the projected month
+- **Projected Personnel Cost** is counted for a full projected month when the personnel funding and job windows overlap any part of that month
+- **Projected Personnel Cost** includes active funded open positions even when no employee is assigned
 
 ## Example dialogue
 
@@ -69,3 +82,5 @@ _Avoid_: Admin, viewer
 - "At cap" can sound like exactly 100% of the cap; resolved: **At Cap** follows the report threshold and starts at 96%.
 - Multiple accrual rows for the same employee can carry different emails; resolved: use the most recent non-empty employee email.
 - "Faculty" can exclude academic researchers or coordinators; resolved: **Faculty Academic** includes fiscal-year academic appointee classifications used by the accrual report.
+- "Burndown" can sound like historical spend; resolved: **Project Burndown** is a forecast of remaining balance, even when historical actuals inform the forecast.
+- Partial-month personnel funding can imply daily proration; resolved: **Projected Personnel Cost** counts the full projected month when funding and job windows overlap any part of that month.

--- a/docs/prds/project-burndown.md
+++ b/docs/prds/project-burndown.md
@@ -1,0 +1,105 @@
+# Project Burndown PRD
+
+## Problem Statement
+
+Project users can see the current reported balance and the personnel currently funded on a project, but they cannot see whether the available balance is likely to last through the next several months. The project page forces users to manually combine the project balance, award end date, funding dates, job dates, FTE, distribution percentage, salary, and composite benefit rate to understand when a project may run out of funds.
+
+Users need a forward-looking **Project Burndown** that starts from the latest reported project balance and projects the remaining balance over time using expected future costs. For the first version, that forecast should use **Projected Personnel Cost** only, while leaving the data model ready for later non-personnel forecast components.
+
+## Solution
+
+Add a **Project Burndown** section to the project detail page after the financial baseline and before the deeper task/personnel details. The section displays a monthly line chart beginning at the current reported project balance. Each following monthly point subtracts the projected personnel costs active during that month. The forecast runs through the earlier of the project end date or the default 12-month horizon. If the project has no end date, the default 12-month horizon is used.
+
+The chart should make risk obvious: balances continue below zero rather than being clamped, a dashed zero reference line marks the deficit threshold, and the balance line/data points turn red after the projected balance falls below zero. Hovering a monthly data point shows the remaining balance, total projected spend for that month, and the personnel cost breakdown that caused that month's movement.
+
+## User Stories
+
+1. As a project viewer, I want to see a projected balance trend on a project page, so that I can understand whether the project is likely to run out of funds.
+2. As a project viewer, I want the forecast to start from the current reported project balance, so that I can tie the projection back to the financial baseline I already trust.
+3. As a project viewer, I want the first chart point to show the starting balance before future projected costs are subtracted, so that the forecast baseline is clear.
+4. As a project viewer, I want each later monthly point to show the balance after that month's projected personnel costs, so that I can see the trend month by month.
+5. As a project viewer, I want the chart to stop at the project end date when one exists, so that the forecast does not imply spending beyond the project's relevant period.
+6. As a project viewer, I want projects without an end date to still show a useful default projection, so that missing end-date data does not block planning.
+7. As a project viewer, I want the default projection to cover up to 12 monthly periods, so that I get enough forward-looking signal without an overly long chart.
+8. As a project viewer, I want projected personnel costs to match the Monthly Total currently displayed in the personnel table, so that the chart agrees with the detailed personnel data.
+9. As a project viewer, I want salary, FTE, distribution percent, and composite benefit costs to be reflected in projected personnel cost, so that personnel costs are not understated.
+10. As a project viewer, I want personnel costs to apply only in months where the funding and job windows overlap the month, so that ended or not-yet-started assignments do not distort the forecast.
+11. As a project viewer, I want partial-month funding to count as a full projected monthly cost, so that the monthly chart remains easy to interpret.
+12. As a project viewer, I want future-dated funding rows to start costing in the first projected month they overlap, so that upcoming planned personnel costs are included at the right time.
+13. As a project viewer, I want ended funding rows to stop costing after their final overlapping month, so that costs do not continue indefinitely.
+14. As a project viewer, I want open funded positions to count in the forecast, so that planned staffing costs are not hidden just because an employee is not currently assigned.
+15. As a project viewer, I want open positions labeled clearly in the tooltip, so that I can distinguish assigned employees from funded vacancies.
+16. As a project viewer, I want balances to continue below zero when projected costs exceed available balance, so that I can see the size of the projected deficit.
+17. As a project viewer, I want a zero reference line, so that I can quickly see when the project crosses into deficit.
+18. As a project viewer, I want the chart to turn red after projected balance goes below zero, so that the risk is visually obvious.
+19. As a project viewer, I want hover details for each monthly point, so that I can understand what caused that month's balance change.
+20. As a project viewer, I want the hover details to include remaining balance and total projected spend, so that I can understand both position and movement.
+21. As a project viewer, I want the hover details to include a personnel breakdown by employee or open position, so that I can identify the cost drivers.
+22. As a project viewer, I want the hover breakdown to include salary, composite benefit cost, and total for each contributor, so that the monthly total is explainable.
+23. As a project viewer, I want people or positions that do not contribute cost in a month excluded from that month's tooltip, so that the tooltip explains only that month's movement.
+24. As a project viewer, I want the chart to wait for personnel data before rendering, so that I am not shown a misleading personnel-only forecast.
+25. As a project viewer, I want a local loading state while personnel data is loading, so that I know the forecast is being prepared.
+26. As a project viewer, I want a local error state if personnel data fails to load, so that I know why the forecast is unavailable.
+27. As a project viewer, I want the burndown located near the current financial details, so that the baseline and forecast are read together.
+28. As a future maintainer, I want the projection rules isolated from chart rendering, so that date and cost behavior can be tested without brittle UI tests.
+29. As a future maintainer, I want the projection data shape to support future non-personnel components, so that average historical costs can be added later without replacing the chart contract.
+
+## Implementation Decisions
+
+- Build a deep projection module that accepts a starting balance, a projection start month, an optional project end date, a default maximum month count, and personnel records. It returns monthly projection points with remaining balance, total monthly spend, and cost components.
+- The projection module should not depend on chart rendering. Its interface should be stable enough for future non-personnel forecast components to be added alongside personnel components.
+- Use the current project summary balance as the starting balance.
+- Use the project award end date as the project end cap when present.
+- Use a default maximum horizon of 12 monthly periods when no earlier project end date applies.
+- If no project end date is present, use the default 12-month horizon.
+- If the project end date is before the projection start, render only the starting point or an explanatory empty state rather than inventing future months.
+- Use the same projected personnel cost behavior as the existing personnel table Monthly Total: distributed monthly salary plus composite benefit cost.
+- Treat missing nullable numeric personnel fields the same way the current displayed Monthly Total behavior does; do not add extra explanatory messaging for missing composite benefit rates.
+- A personnel funding distribution contributes to a projected month when both the funding window and the job window overlap any part of that month.
+- Null funding end dates and null job end dates are treated as open-ended.
+- Future-dated funding contributes only starting with the first projected month that overlaps the funding effective date.
+- Partial-month overlap counts as a full projected monthly cost for that month.
+- Include active funded open positions even when no employee is assigned.
+- Use all rows returned by the project personnel query for the burndown cost basis, even if the personnel table hides open positions by default.
+- Add a project-page section for **Project Burndown** after the financial details and before the additional/task/personnel sections.
+- Reuse the existing personnel query already performed on the project detail page rather than issuing a duplicate request for the same project data.
+- Show a local loading state while personnel data is pending.
+- Show a local error state if personnel data fails to load.
+- Use Recharts for the v1 chart, consistent with existing chart components.
+- The chart should include a dashed zero reference line.
+- The chart should allow negative projected balances and visually distinguish the below-zero portion in red.
+- The chart tooltip should show the month, remaining balance, total projected spend, and a personnel breakdown for contributors in that month.
+- The tooltip should label unassigned funded positions as open positions with their position description.
+- V1 is chart-first. Do not add a separate monthly breakdown table or tabs yet.
+- No server API or database changes are required for v1 if the existing project and personnel data remain sufficient.
+
+## Testing Decisions
+
+- Tests should focus on externally observable behavior: generated monthly projection points, included/excluded personnel contributors, rendered chart states, and tooltip contents.
+- The projection module should have focused unit tests because it encodes the most important domain rules and can be tested without React or chart rendering.
+- Projection tests should cover the starting balance point, default 12-month horizon, project-end-date cap, no-end-date behavior, negative balances, future funding starts, funding ends, job ends, null end dates, partial-month full-cost behavior, and open funded positions.
+- Projection tests should cover the same monthly total cost basis used by the personnel table: distributed salary plus composite benefit cost.
+- Component tests should verify that the project detail page shows the burndown section in the intended location once personnel data is available.
+- Component tests should verify loading and error states for the burndown section.
+- Component tests should verify that the chart exposes the key labels or accessible content needed to confirm the forecast is present without over-testing Recharts internals.
+- Tooltip tests should verify the presence of remaining balance, total projected spend, and personnel/open-position breakdown for a representative month.
+- Existing personnel table tests provide prior art for monthly salary, composite benefit, distribution percentage, and open-position behavior.
+- Existing project chart and project funding chart tests provide prior art for chart component rendering and Recharts-based components.
+
+## Out of Scope
+
+- Non-personnel forecast costs based on historical average spend.
+- User-selectable horizon controls.
+- Fiscal-period-specific horizon rules beyond the default 12-month cap and project end date cap.
+- A monthly breakdown table or tabbed view.
+- New backend endpoints, stored procedures, or schema changes.
+- Historical spend reporting as a primary purpose of the chart.
+- Daily proration for partial-month funding.
+- Exporting burndown data.
+- Alerts, notifications, or automated warnings based on the projected deficit.
+
+## Further Notes
+
+- The domain glossary now defines **Project Burndown** as a forward-looking projection and **Projected Personnel Cost** as expected monthly project cost for a personnel funding distribution, including distributed salary and composite benefit rate costs.
+- The first implementation should keep future non-personnel forecast components in mind by using a monthly cost-component model, but only personnel costs should be populated in v1.
+- The visual direction from the spike is accepted: a zero reference line, negative balances below zero, and red styling after the projected balance crosses below zero.

--- a/web/client/src/components/project/ProjectBurndownChart.tsx
+++ b/web/client/src/components/project/ProjectBurndownChart.tsx
@@ -1,0 +1,225 @@
+import { useMemo } from 'react';
+import {
+  CartesianGrid,
+  Line,
+  LineChart,
+  ReferenceLine,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import { formatCurrency } from '@/lib/currency.ts';
+import {
+  createProjectBurndown,
+  type ProjectBurndownPoint,
+} from '@/lib/projectBurndown.ts';
+import type { ProjectSummary } from '@/lib/projectSummary.ts';
+import type { PersonnelRecord } from '@/queries/personnel.ts';
+
+interface ProjectBurndownSectionProps {
+  isError: boolean;
+  isLoading: boolean;
+  personnel: PersonnelRecord[] | undefined;
+  summary: ProjectSummary;
+}
+
+interface BurndownTooltipProps {
+  active?: boolean;
+  payload?: Array<{ payload?: ProjectBurndownPoint }>;
+}
+
+const BALANCE_COLOR = 'var(--color-primary)';
+const DEFICIT_COLOR = 'var(--color-error)';
+const GRID_COLOR = 'var(--color-main-border)';
+
+function BurndownTooltip({ active, payload }: BurndownTooltipProps) {
+  const point = payload?.find((item) => item.payload)?.payload;
+
+  if (!active || !point) {
+    return null;
+  }
+
+  return (
+    <div className="rounded-md border border-main-border bg-base-100 p-4 text-sm shadow-lg">
+      <p className="font-proxima-bold text-base mb-3">{point.label}</p>
+      <dl className="space-y-2">
+        <div className="flex justify-between gap-8">
+          <dt className="text-base-content/70">Remaining Balance</dt>
+          <dd className="font-medium">
+            {formatCurrency(point.remainingBalance)}
+          </dd>
+        </div>
+        <div className="flex justify-between gap-8">
+          <dt className="text-base-content/70">Projected Spend</dt>
+          <dd className="font-medium">{formatCurrency(point.totalSpend)}</dd>
+        </div>
+      </dl>
+
+      {!point.isStartingBalance && point.personnel.length > 0 && (
+        <div className="mt-3 border-t border-main-border pt-3">
+          <p className="font-proxima-bold mb-2">Personnel</p>
+          <div className="space-y-2">
+            {point.personnel.map((person) => (
+              <div
+                className="grid grid-cols-[minmax(0,1fr)_auto] gap-x-4"
+                key={person.id}
+              >
+                <span className="truncate" title={person.label}>
+                  {person.label}
+                </span>
+                <span className="font-medium">
+                  {formatCurrency(person.total)}
+                </span>
+                <span className="text-xs text-base-content/60">
+                  Salary {formatCurrency(person.salary)}
+                </span>
+                <span className="text-xs text-base-content/60">
+                  CBR {formatCurrency(person.fringe)}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function buildChartData(points: ProjectBurndownPoint[]) {
+  const firstNegativeIndex = points.findIndex(
+    (point) => point.remainingBalance < 0
+  );
+
+  return points.map((point, index) => ({
+    ...point,
+    negativeLineBalance:
+      firstNegativeIndex >= 0 && index >= Math.max(firstNegativeIndex - 1, 0)
+        ? point.remainingBalance
+        : null,
+    positiveLineBalance:
+      firstNegativeIndex >= 0 && index >= firstNegativeIndex
+        ? null
+        : point.remainingBalance,
+  }));
+}
+
+export function ProjectBurndownSection({
+  isError,
+  isLoading,
+  personnel,
+  summary,
+}: ProjectBurndownSectionProps) {
+  const points = useMemo(
+    () =>
+      createProjectBurndown({
+        personnel: personnel ?? [],
+        projectEndDate: summary.awardEndDate,
+        startingBalance: summary.totals.balance,
+      }),
+    [personnel, summary.awardEndDate, summary.totals.balance]
+  );
+  const chartData = useMemo(() => buildChartData(points), [points]);
+  const balances = points.map((point) => point.remainingBalance);
+  const minBalance = Math.min(0, ...balances);
+  const maxBalance = Math.max(0, ...balances);
+  const padding = Math.max((maxBalance - minBalance) * 0.1, 1000);
+  const projectedEnd =
+    points.at(-1)?.remainingBalance ?? summary.totals.balance;
+
+  return (
+    <section className="section-margin">
+      <h2 className="h2">Project Burndown</h2>
+
+      {isLoading && (
+        <div className="fancy-data min-h-64 flex items-center justify-center text-base-content/70">
+          Loading project burndown...
+        </div>
+      )}
+
+      {isError && (
+        <div className="fancy-data text-error">
+          Error loading project burndown.
+        </div>
+      )}
+
+      {!isLoading && !isError && (
+        <div className="fancy-data">
+          <div className="h-80" data-testid="project-burndown-chart">
+            <ResponsiveContainer height="100%" width="100%">
+              <LineChart
+                data={chartData}
+                margin={{ bottom: 8, left: 8, right: 24, top: 16 }}
+              >
+                <CartesianGrid stroke={GRID_COLOR} strokeDasharray="3 3" />
+                <XAxis
+                  dataKey="label"
+                  tick={{ fill: 'currentColor', fontSize: 12 }}
+                />
+                <YAxis
+                  domain={[minBalance - padding, maxBalance + padding]}
+                  tick={{ fill: 'currentColor', fontSize: 12 }}
+                  tickFormatter={(value: number) =>
+                    `$${(value / 1000).toFixed(0)}k`
+                  }
+                />
+                <ReferenceLine
+                  ifOverflow="extendDomain"
+                  stroke={DEFICIT_COLOR}
+                  strokeDasharray="5 5"
+                  y={0}
+                />
+                <Tooltip content={<BurndownTooltip />} />
+                <Line
+                  activeDot={{ r: 6 }}
+                  connectNulls={false}
+                  dataKey="positiveLineBalance"
+                  dot={{ fill: BALANCE_COLOR, r: 4 }}
+                  isAnimationActive={false}
+                  name="Remaining Balance"
+                  stroke={BALANCE_COLOR}
+                  strokeWidth={3}
+                  type="monotone"
+                />
+                <Line
+                  activeDot={{ r: 6 }}
+                  connectNulls={false}
+                  dataKey="negativeLineBalance"
+                  dot={{ fill: DEFICIT_COLOR, r: 4 }}
+                  isAnimationActive={false}
+                  name="Projected Deficit"
+                  stroke={DEFICIT_COLOR}
+                  strokeWidth={3}
+                  type="monotone"
+                />
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
+
+          <div className="mt-4 grid gap-4 text-sm md:grid-cols-3">
+            <div>
+              <p className="stat-label">Starting Balance</p>
+              <p className="stat-value">
+                {formatCurrency(summary.totals.balance)}
+              </p>
+            </div>
+            <div>
+              <p className="stat-label">Projected End</p>
+              <p
+                className={
+                  projectedEnd < 0 ? 'stat-value text-error' : 'stat-value'
+                }
+              >
+                {formatCurrency(projectedEnd)}
+              </p>
+            </div>
+            <div>
+              <p className="stat-label">Projection</p>
+              <p className="stat-value">{points.length - 1} months</p>
+            </div>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/web/client/src/components/project/ProjectBurndownChart.tsx
+++ b/web/client/src/components/project/ProjectBurndownChart.tsx
@@ -47,17 +47,13 @@ function BurndownTooltip({ active, payload }: BurndownTooltipProps) {
       <p className="font-proxima-bold text-base mb-3">{point.label}</p>
       <dl className="space-y-2">
         <div className="flex justify-between gap-8">
-          <dt className="font-proxima-bold text-base-content/70">
-            Remaining Balance
-          </dt>
+          <dt className="font-proxima-bold">Remaining Balance</dt>
           <dd className="font-medium">
             {formatCurrency(point.remainingBalance)}
           </dd>
         </div>
         <div className="flex justify-between gap-8">
-          <dt className="font-proxima-bold text-base-content/70">
-            Projected Spend
-          </dt>
+          <dt className="font-proxima-bold">Projected Spend</dt>
           <dd className="font-medium">{formatCurrency(point.totalSpend)}</dd>
         </div>
       </dl>

--- a/web/client/src/components/project/ProjectBurndownChart.tsx
+++ b/web/client/src/components/project/ProjectBurndownChart.tsx
@@ -16,6 +16,8 @@ import {
 } from '@/lib/projectBurndown.ts';
 import type { ProjectSummary } from '@/lib/projectSummary.ts';
 import type { PersonnelRecord } from '@/queries/personnel.ts';
+import { TooltipLabel } from '@/shared/TooltipLabel.tsx';
+import { tooltipDefinitions } from '@/shared/tooltips.ts';
 
 interface ProjectBurndownSectionProps {
   isError: boolean;
@@ -45,13 +47,17 @@ function BurndownTooltip({ active, payload }: BurndownTooltipProps) {
       <p className="font-proxima-bold text-base mb-3">{point.label}</p>
       <dl className="space-y-2">
         <div className="flex justify-between gap-8">
-          <dt className="text-base-content/70">Remaining Balance</dt>
+          <dt className="font-proxima-bold text-base-content/70">
+            Remaining Balance
+          </dt>
           <dd className="font-medium">
             {formatCurrency(point.remainingBalance)}
           </dd>
         </div>
         <div className="flex justify-between gap-8">
-          <dt className="text-base-content/70">Projected Spend</dt>
+          <dt className="font-proxima-bold text-base-content/70">
+            Projected Spend
+          </dt>
           <dd className="font-medium">{formatCurrency(point.totalSpend)}</dd>
         </div>
       </dl>
@@ -126,10 +132,22 @@ export function ProjectBurndownSection({
   const padding = Math.max((maxBalance - minBalance) * 0.1, 1000);
   const projectedEnd =
     points.at(-1)?.remainingBalance ?? summary.totals.balance;
+  const hasApplicablePersonnelCosts = points.some(
+    (point) => point.personnel.length > 0
+  );
+
+  if (!isLoading && !isError && !hasApplicablePersonnelCosts) {
+    return null;
+  }
 
   return (
     <section className="section-margin">
-      <h2 className="h2">Project Burndown</h2>
+      <h2 className="h2">
+        <TooltipLabel
+          label="Project Burndown by Personnel Costs"
+          tooltip={tooltipDefinitions.projectBurndownPersonnelCosts}
+        />
+      </h2>
 
       {isLoading && (
         <div className="fancy-data min-h-64 flex items-center justify-center text-base-content/70">

--- a/web/client/src/lib/projectBurndown.ts
+++ b/web/client/src/lib/projectBurndown.ts
@@ -1,0 +1,184 @@
+import {
+  addMonths,
+  endOfMonth,
+  format,
+  isAfter,
+  isBefore,
+  isEqual,
+  parseISO,
+  startOfMonth,
+} from 'date-fns';
+import type { PersonnelRecord } from '@/queries/personnel.ts';
+
+export interface ProjectBurndownPersonnelCost {
+  fringe: number;
+  id: string;
+  label: string;
+  salary: number;
+  total: number;
+}
+
+export interface ProjectBurndownPoint {
+  isStartingBalance: boolean;
+  label: string;
+  month: string;
+  monthLabel: string;
+  personnel: ProjectBurndownPersonnelCost[];
+  remainingBalance: number;
+  totalSpend: number;
+}
+
+interface CreateProjectBurndownOptions {
+  maxMonths?: number;
+  personnel: PersonnelRecord[];
+  projectEndDate: string | null;
+  startDate?: Date | string;
+  startingBalance: number;
+}
+
+const DEFAULT_MAX_MONTHS = 12;
+
+function parseDate(value: Date | string | null | undefined): Date | null {
+  if (!value) {
+    return null;
+  }
+
+  if (typeof value === 'object') {
+    const time = value.getTime();
+    return Number.isNaN(time) ? null : value;
+  }
+
+  try {
+    const parsed = parseISO(value);
+    return Number.isNaN(parsed.getTime()) ? null : parsed;
+  } catch {
+    return null;
+  }
+}
+
+function isSameOrBefore(left: Date, right: Date) {
+  return isBefore(left, right) || isEqual(left, right);
+}
+
+function isSameOrAfter(left: Date, right: Date) {
+  return isAfter(left, right) || isEqual(left, right);
+}
+
+function overlapsMonth(
+  monthStart: Date,
+  windowStartValue: string | null,
+  windowEndValue: string | null
+) {
+  const monthEnd = endOfMonth(monthStart);
+  const windowStart = parseDate(windowStartValue);
+  const windowEnd = parseDate(windowEndValue);
+
+  return (
+    (!windowStart || isSameOrBefore(windowStart, monthEnd)) &&
+    (!windowEnd || isSameOrAfter(windowEnd, monthStart))
+  );
+}
+
+function toNumber(value: number | null | undefined) {
+  const parsed = Number(value ?? 0);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function getPersonnelCost(
+  record: PersonnelRecord
+): ProjectBurndownPersonnelCost {
+  const salary =
+    toNumber(record.monthlyRate) *
+    toNumber(record.fte) *
+    (toNumber(record.distributionPercent) / 100);
+  const fringe = salary * toNumber(record.compositeBenefitRate);
+  const label = record.name
+    ? `${record.name} - ${record.positionDescription}`
+    : `Open position - ${record.positionDescription || record.positionNumber}`;
+
+  return {
+    fringe,
+    id: [
+      record.employeeId || 'open',
+      record.positionNumber,
+      record.projectId,
+      record.fundingEffectiveDate ?? '',
+      record.fundingEndDate ?? '',
+    ].join(':'),
+    label,
+    salary,
+    total: salary + fringe,
+  };
+}
+
+function contributesInMonth(record: PersonnelRecord, monthStart: Date) {
+  return (
+    overlapsMonth(
+      monthStart,
+      record.fundingEffectiveDate,
+      record.fundingEndDate
+    ) && overlapsMonth(monthStart, record.jobEffectiveDate, record.jobEndDate)
+  );
+}
+
+function buildPoint(
+  monthStart: Date,
+  remainingBalance: number,
+  totalSpend: number,
+  personnel: ProjectBurndownPersonnelCost[],
+  isStartingBalance: boolean
+): ProjectBurndownPoint {
+  return {
+    isStartingBalance,
+    label: isStartingBalance ? 'Start' : format(monthStart, 'MMM yyyy'),
+    month: format(monthStart, 'yyyy-MM-dd'),
+    monthLabel: format(monthStart, 'MMMM yyyy'),
+    personnel,
+    remainingBalance,
+    totalSpend,
+  };
+}
+
+export function createProjectBurndown({
+  maxMonths = DEFAULT_MAX_MONTHS,
+  personnel,
+  projectEndDate,
+  startDate = new Date(),
+  startingBalance,
+}: CreateProjectBurndownOptions): ProjectBurndownPoint[] {
+  const start = startOfMonth(parseDate(startDate) ?? new Date());
+  const end = parseDate(projectEndDate);
+  const endMonth = end ? startOfMonth(end) : null;
+  const points = [buildPoint(start, startingBalance, 0, [], true)];
+  let remainingBalance = startingBalance;
+
+  for (let offset = 1; offset <= maxMonths; offset += 1) {
+    const monthStart = addMonths(start, offset);
+
+    if (endMonth && isAfter(monthStart, endMonth)) {
+      break;
+    }
+
+    const monthPersonnel = personnel
+      .filter((record) => contributesInMonth(record, monthStart))
+      .map(getPersonnelCost)
+      .filter((cost) => cost.total !== 0);
+    const totalSpend = monthPersonnel.reduce(
+      (sum, cost) => sum + cost.total,
+      0
+    );
+
+    remainingBalance -= totalSpend;
+    points.push(
+      buildPoint(
+        monthStart,
+        remainingBalance,
+        totalSpend,
+        monthPersonnel,
+        false
+      )
+    );
+  }
+
+  return points;
+}

--- a/web/client/src/routes/(authenticated)/projects/$employeeId/$projectNumber/index.tsx
+++ b/web/client/src/routes/(authenticated)/projects/$employeeId/$projectNumber/index.tsx
@@ -2,6 +2,7 @@ import { ProjectAlerts } from '@/components/alerts/ProjectAlerts.tsx';
 import { TaskBreakdown } from '@/components/project/TaskBreakdown.tsx';
 import { ProjectDetails } from '@/components/project/ProjectDetails.tsx';
 import { FinancialDetails } from '@/components/project/FinancialDetails.tsx';
+import { ProjectBurndownSection } from '@/components/project/ProjectBurndownChart.tsx';
 import { PersonnelTable } from '@/components/project/PersonnelTable.tsx';
 import { usePersonnelQuery } from '@/queries/personnel.ts';
 import {
@@ -87,6 +88,12 @@ function ProjectContent({
 
       <ProjectDetails summary={summary} />
       <FinancialDetails summary={summary} />
+      <ProjectBurndownSection
+        isError={personnelQuery.isError}
+        isLoading={personnelQuery.isPending}
+        personnel={personnelQuery.data}
+        summary={summary}
+      />
       <ProjectAdditionalInfo summary={summary} />
 
       <section className="section-margin">
@@ -97,7 +104,11 @@ function ProjectContent({
           />
         </h2>
         <div className="mt-4">
-          <TaskBreakdown employeeId={employeeId} projectNumber={summary.projectNumber} records={projectRecords} />
+          <TaskBreakdown
+            employeeId={employeeId}
+            projectNumber={summary.projectNumber}
+            records={projectRecords}
+          />
         </div>
       </section>
 

--- a/web/client/src/shared/tooltips.ts
+++ b/web/client/src/shared/tooltips.ts
@@ -2,19 +2,12 @@ export const tooltipDefinitions = {
   awardCloseDate:
     'Final closeout date after which charges can no longer be posted to the award.',
   balance: 'Balance is your total budget minus expenses and commitments',
-  billingCycle:
-    'How often the system is set to generate sponsor billing.',
+  billingCycle: 'How often the system is set to generate sponsor billing.',
   burdenScheduleRate:
     'Indirect cost rate setup used to calculate burden on eligible expenses.',
   burdenStructure:
     'Rule set that determines which costs receive indirect cost charges and how they are calculated.',
   cbr: 'Monthly composite benefit rate cost, including fringe/benefit burden.',
-  taskBreakdown:
-    'Summary of how project costs are organized by financial coding segments.',
-  totalBudget:
-    'Total PPM budget across all active and expired projects. Closed projects are excluded.',
-  totalBalance:
-    'Total remaining balance (budget minus expenses and commitments) across all active and expired projects. Closed projects are excluded.',
   commitment:
     'Commitment / Encumbrance are funds set aside when a requisition is fully approved; it is automatically released when the associated purchase order is created (or when an approved requisition is canceled before PO creation).',
   contractAdministrator:
@@ -32,6 +25,14 @@ export const tooltipDefinitions = {
     'Monthly composite benefit rate cost, including fringe/benefit burden.',
   postReportingPeriod:
     'Number of days after the award end date allowed for reporting and closeout activity.',
+  projectBurndownPersonnelCosts:
+    'Projects the current balance forward by subtracting projected monthly personnel costs through the earlier of 12 months or the project end date.',
+  taskBreakdown:
+    'Summary of how project costs are organized by financial coding segments.',
+  totalBalance:
+    'Total remaining balance (budget minus expenses and commitments) across all active and expired projects. Closed projects are excluded.',
+  totalBudget:
+    'Total PPM budget across all active and expired projects. Closed projects are excluded.',
 } as const;
 
 export type TooltipDefinitionKey = keyof typeof tooltipDefinitions;

--- a/web/client/src/test/lib/projectBurndown.test.ts
+++ b/web/client/src/test/lib/projectBurndown.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createProjectBurndown,
+  type ProjectBurndownPoint,
+} from '@/lib/projectBurndown.ts';
+import type { PersonnelRecord } from '@/queries/personnel.ts';
+
+const createRecord = (
+  overrides: Partial<PersonnelRecord> = {}
+): PersonnelRecord => ({
+  compositeBenefitRate: 0.4,
+  distributionPercent: 50,
+  employeeId: '1001',
+  fte: 1,
+  fundingEffectiveDate: '2026-01-01',
+  fundingEndDate: null,
+  jobCode: '001234',
+  jobEffectiveDate: '2025-01-01',
+  jobEndDate: null,
+  monthlyRate: 10_000,
+  name: 'Smith, Jane',
+  positionDescription: 'Researcher',
+  positionNumber: '40001234',
+  projectDescription: 'Test Project',
+  projectId: 'P1',
+  ...overrides,
+});
+
+const pointByLabel = (points: ProjectBurndownPoint[], label: string) => {
+  const point = points.find((candidate) => candidate.label === label);
+  expect(point).toBeDefined();
+  return point as ProjectBurndownPoint;
+};
+
+describe('createProjectBurndown', () => {
+  it('starts with the current balance before subtracting projected cost', () => {
+    const points = createProjectBurndown({
+      personnel: [createRecord()],
+      projectEndDate: null,
+      startDate: '2026-05-22',
+      startingBalance: 100_000,
+    });
+
+    expect(points[0]).toMatchObject({
+      isStartingBalance: true,
+      label: 'Start',
+      remainingBalance: 100_000,
+      totalSpend: 0,
+    });
+    expect(points[1]).toMatchObject({
+      label: 'Jun 2026',
+      remainingBalance: 93_000,
+      totalSpend: 7000,
+    });
+  });
+
+  it('uses the default 12-month horizon when no project end date exists', () => {
+    const points = createProjectBurndown({
+      personnel: [],
+      projectEndDate: null,
+      startDate: '2026-05-22',
+      startingBalance: 100_000,
+    });
+
+    expect(points).toHaveLength(13);
+    expect(points.at(-1)?.label).toBe('May 2027');
+  });
+
+  it('caps the projection at the project end month', () => {
+    const points = createProjectBurndown({
+      personnel: [],
+      projectEndDate: '2026-07-15',
+      startDate: '2026-05-22',
+      startingBalance: 100_000,
+    });
+
+    expect(points.map((point) => point.label)).toEqual([
+      'Start',
+      'Jun 2026',
+      'Jul 2026',
+    ]);
+  });
+
+  it('counts future-dated funding only once the month overlaps', () => {
+    const points = createProjectBurndown({
+      personnel: [
+        createRecord({
+          fundingEffectiveDate: '2026-07-20',
+        }),
+      ],
+      projectEndDate: '2026-08-31',
+      startDate: '2026-05-22',
+      startingBalance: 100_000,
+    });
+
+    expect(pointByLabel(points, 'Jun 2026').totalSpend).toBe(0);
+    expect(pointByLabel(points, 'Jul 2026').totalSpend).toBe(7000);
+  });
+
+  it('counts a partial-month funding end as a full projected month', () => {
+    const points = createProjectBurndown({
+      personnel: [
+        createRecord({
+          fundingEndDate: '2026-06-10',
+        }),
+      ],
+      projectEndDate: '2026-07-31',
+      startDate: '2026-05-22',
+      startingBalance: 100_000,
+    });
+
+    expect(pointByLabel(points, 'Jun 2026').totalSpend).toBe(7000);
+    expect(pointByLabel(points, 'Jul 2026').totalSpend).toBe(0);
+  });
+
+  it('stops personnel cost after the job window ends', () => {
+    const points = createProjectBurndown({
+      personnel: [
+        createRecord({
+          jobEndDate: '2026-06-30',
+        }),
+      ],
+      projectEndDate: '2026-07-31',
+      startDate: '2026-05-22',
+      startingBalance: 100_000,
+    });
+
+    expect(pointByLabel(points, 'Jun 2026').totalSpend).toBe(7000);
+    expect(pointByLabel(points, 'Jul 2026').totalSpend).toBe(0);
+  });
+
+  it('includes active funded open positions', () => {
+    const points = createProjectBurndown({
+      personnel: [
+        createRecord({
+          employeeId: '',
+          name: '',
+          positionDescription: 'Open Analyst',
+        }),
+      ],
+      projectEndDate: '2026-06-30',
+      startDate: '2026-05-22',
+      startingBalance: 100_000,
+    });
+
+    const june = pointByLabel(points, 'Jun 2026');
+
+    expect(june.totalSpend).toBe(7000);
+    expect(june.personnel[0].label).toBe('Open position - Open Analyst');
+  });
+
+  it('continues below zero instead of clamping projected balance', () => {
+    const points = createProjectBurndown({
+      personnel: [createRecord()],
+      projectEndDate: '2026-06-30',
+      startDate: '2026-05-22',
+      startingBalance: 5000,
+    });
+
+    expect(pointByLabel(points, 'Jun 2026').remainingBalance).toBe(-2000);
+  });
+});

--- a/web/client/src/test/routes/(authenticated)/project-detail.test.tsx
+++ b/web/client/src/test/routes/(authenticated)/project-detail.test.tsx
@@ -87,8 +87,8 @@ const setupHandlers = (
     http.get('/api/project/managed/:employeeId', () =>
       HttpResponse.json({ pis: [], projectManager: null })
     ),
-    http.get('/api/project/:employeeId', () => HttpResponse.json(projects)),
     http.get('/api/project/personnel', () => HttpResponse.json(personnel)),
+    http.get('/api/project/:employeeId', () => HttpResponse.json(projects)),
     http.get('/api/project/gl-ppm-reconciliation', () => HttpResponse.json([]))
   );
 };
@@ -149,6 +149,7 @@ describe('project detail page', () => {
       http.get('/api/project/managed/:employeeId', () =>
         HttpResponse.json({ pis: [], projectManager: null })
       ),
+      http.get('/api/project/personnel', () => HttpResponse.json([])),
       http.get('/api/project/:employeeId', ({ params }) => {
         if (params.employeeId === '10212674') {
           return HttpResponse.json(
@@ -159,7 +160,6 @@ describe('project detail page', () => {
 
         return HttpResponse.json([]);
       }),
-      http.get('/api/project/personnel', () => HttpResponse.json([])),
       http.get('/api/project/gl-ppm-reconciliation', () =>
         HttpResponse.json([])
       )
@@ -195,8 +195,13 @@ describe('project detail page', () => {
   });
 
   it('shows the project burndown after personnel data loads', async () => {
+    const user = userEvent.setup();
     const projects = [
-      createProject({ balance: 100_000, pmEmployeeId: '2000' }),
+      createProject({
+        balance: 100_000,
+        pmEmployeeId: '2000',
+        projectNumber: 'P-BURNDOWN',
+      }),
     ];
     const personnel: PersonnelRecord[] = [
       {
@@ -204,30 +209,63 @@ describe('project detail page', () => {
         distributionPercent: 50,
         employeeId: '1001',
         fte: 1,
-        fundingEffectiveDate: '2026-01-01',
+        fundingEffectiveDate: null,
         fundingEndDate: null,
         jobCode: '001234',
-        jobEffectiveDate: '2025-01-01',
+        jobEffectiveDate: null,
         jobEndDate: null,
         monthlyRate: 10_000,
         name: 'Smith, Jane',
         positionDescription: 'Researcher',
         positionNumber: '40001234',
         projectDescription: 'Test Project',
-        projectId: 'P1',
+        projectId: 'P-BURNDOWN',
       },
     ];
     setupHandlers({ employeeId: '1000', name: 'PI User' }, projects, personnel);
 
     const { cleanup } = renderRoute({
-      initialPath: '/projects/1000/P1',
+      initialPath: '/projects/1000/P-BURNDOWN',
     });
 
     try {
-      expect(await screen.findByText('Project Burndown')).toBeInTheDocument();
+      const headingLabel = await screen.findByText(
+        'Project Burndown by Personnel Costs'
+      );
+      expect(headingLabel).toBeInTheDocument();
       expect(await screen.findByText('Starting Balance')).toBeInTheDocument();
       expect(screen.getByTestId('project-burndown-chart')).toBeInTheDocument();
       expect(screen.getByText('Projection')).toBeInTheDocument();
+
+      await user.hover(headingLabel.parentElement as HTMLElement);
+
+      expect(await screen.findByRole('tooltip')).toHaveTextContent(
+        tooltipDefinitions.projectBurndownPersonnelCosts
+      );
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('hides the project burndown when no personnel costs apply', async () => {
+    const projects = [
+      createProject({
+        balance: 100_000,
+        pmEmployeeId: '2000',
+        projectNumber: 'P-NO-PERSONNEL',
+      }),
+    ];
+    setupHandlers({ employeeId: '1000', name: 'PI User' }, projects);
+
+    const { cleanup } = renderRoute({
+      initialPath: '/projects/1000/P-NO-PERSONNEL',
+    });
+
+    try {
+      await screen.findByText('No personnel found.');
+      expect(
+        screen.queryByText('Project Burndown by Personnel Costs')
+      ).not.toBeInTheDocument();
     } finally {
       cleanup();
     }

--- a/web/client/src/test/routes/(authenticated)/project-detail.test.tsx
+++ b/web/client/src/test/routes/(authenticated)/project-detail.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { screen } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
+import type { PersonnelRecord } from '@/queries/personnel.ts';
 import type { ProjectRecord } from '@/queries/project.ts';
 import { server } from '@/test/mswUtils.ts';
 import { renderRoute } from '@/test/routerUtils.tsx';
@@ -69,7 +70,8 @@ const createProject = (
 
 const setupHandlers = (
   user: { employeeId: string; name: string },
-  projects: ProjectRecord[]
+  projects: ProjectRecord[],
+  personnel: PersonnelRecord[] = []
 ) => {
   server.use(
     http.get('/api/user/me', () =>
@@ -82,9 +84,11 @@ const setupHandlers = (
         roles: [],
       })
     ),
-    http.get('/api/project/managed/:employeeId', () => HttpResponse.json({ pis: [], projectManager: null })),
+    http.get('/api/project/managed/:employeeId', () =>
+      HttpResponse.json({ pis: [], projectManager: null })
+    ),
     http.get('/api/project/:employeeId', () => HttpResponse.json(projects)),
-    http.get('/api/project/personnel', () => HttpResponse.json([])),
+    http.get('/api/project/personnel', () => HttpResponse.json(personnel)),
     http.get('/api/project/gl-ppm-reconciliation', () => HttpResponse.json([]))
   );
 };
@@ -142,7 +146,9 @@ describe('project detail page', () => {
           roles: [],
         })
       ),
-      http.get('/api/project/managed/:employeeId', () => HttpResponse.json({ pis: [], projectManager: null })),
+      http.get('/api/project/managed/:employeeId', () =>
+        HttpResponse.json({ pis: [], projectManager: null })
+      ),
       http.get('/api/project/:employeeId', ({ params }) => {
         if (params.employeeId === '10212674') {
           return HttpResponse.json(
@@ -183,6 +189,45 @@ describe('project detail page', () => {
       expect(
         screen.queryByText('We could not reach the server')
       ).not.toBeInTheDocument();
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('shows the project burndown after personnel data loads', async () => {
+    const projects = [
+      createProject({ balance: 100_000, pmEmployeeId: '2000' }),
+    ];
+    const personnel: PersonnelRecord[] = [
+      {
+        compositeBenefitRate: 0.4,
+        distributionPercent: 50,
+        employeeId: '1001',
+        fte: 1,
+        fundingEffectiveDate: '2026-01-01',
+        fundingEndDate: null,
+        jobCode: '001234',
+        jobEffectiveDate: '2025-01-01',
+        jobEndDate: null,
+        monthlyRate: 10_000,
+        name: 'Smith, Jane',
+        positionDescription: 'Researcher',
+        positionNumber: '40001234',
+        projectDescription: 'Test Project',
+        projectId: 'P1',
+      },
+    ];
+    setupHandlers({ employeeId: '1000', name: 'PI User' }, projects, personnel);
+
+    const { cleanup } = renderRoute({
+      initialPath: '/projects/1000/P1',
+    });
+
+    try {
+      expect(await screen.findByText('Project Burndown')).toBeInTheDocument();
+      expect(await screen.findByText('Starting Balance')).toBeInTheDocument();
+      expect(screen.getByTestId('project-burndown-chart')).toBeInTheDocument();
+      expect(screen.getByText('Projection')).toBeInTheDocument();
     } finally {
       cleanup();
     }


### PR DESCRIPTION
## Summary
- Add a project burndown chart that projects current balance forward using monthly personnel costs
- Show monthly tooltip breakdowns, zero reference line, and negative-balance styling
- Hide the burndown section when no applicable personnel costs are available
- Document Project Burndown and Projected Personnel Cost language in CONTEXT.md and add a local PRD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Project Burndown chart on the project detail page forecasting remaining balance month-by-month based on projected personnel costs, capped at the project award end date or 12 months.

* **Documentation**
  * Updated domain documentation to define Project Burndown and Projected Personnel Cost concepts, including relationship rules and clarifications on forecasting behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ucdavis/Walter/pull/275?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->