### PR TITLE
Fix wrong PI name on dashboard title

### DIFF
--- a/web/client/src/queries/project.ts
+++ b/web/client/src/queries/project.ts
@@ -39,6 +39,7 @@ export interface ProjectRecord {
   pi: string | null;
   pm: string | null;
   pmEmployeeId: string | null;
+  ownerName: string | null;
   postReportingPeriod: string | null;
   primarySponsorName: string | null;
   programCode: string | null;

--- a/web/client/src/routes/(authenticated)/projects/$employeeId/index.tsx
+++ b/web/client/src/routes/(authenticated)/projects/$employeeId/index.tsx
@@ -87,7 +87,9 @@ function RouteComponent() {
     <main className="flex-1 min-w-0">
       <section className="mt-8 mb-2">
         <h1 className="h1">
-          {projects[0].pi ? `${projects[0].pi}'s Dashboard` : 'Dashboard'}
+          {projects[0].ownerName
+            ? `${projects[0].ownerName}'s Dashboard`
+            : 'Dashboard'}
         </h1>
       </section>
       <section className="section-margin">

--- a/web/client/src/routes/(authenticated)/projects/$employeeId/index.tsx
+++ b/web/client/src/routes/(authenticated)/projects/$employeeId/index.tsx
@@ -83,13 +83,19 @@ function RouteComponent() {
     );
   }
 
+  // PPM gives the owner name as "Last, First"; show it as "First Last".
+  const ownerName = projects[0].ownerName;
+  const ownerDisplayName = ownerName?.includes(',')
+    ? `${ownerName.slice(ownerName.indexOf(',') + 1).trim()} ${ownerName
+        .slice(0, ownerName.indexOf(','))
+        .trim()}`
+    : ownerName;
+
   return (
     <main className="flex-1 min-w-0">
       <section className="mt-8 mb-2">
         <h1 className="h1">
-          {projects[0].ownerName
-            ? `${projects[0].ownerName}'s Dashboard`
-            : 'Dashboard'}
+          {ownerDisplayName ? `${ownerDisplayName}'s Dashboard` : 'Dashboard'}
         </h1>
       </section>
       <section className="section-margin">

--- a/web/client/src/test/components/project/ProjectFundingChart.test.tsx
+++ b/web/client/src/test/components/project/ProjectFundingChart.test.tsx
@@ -72,6 +72,7 @@ const createProject = (
   taskName: 'Task 1',
   taskNum: 'T001',
   taskStatus: 'Active',
+  ownerName: null,
   ...overrides,
 });
 

--- a/web/client/src/test/components/project/ProjectsTable.test.tsx
+++ b/web/client/src/test/components/project/ProjectsTable.test.tsx
@@ -79,6 +79,7 @@ const createProject = (
   taskName: 'Task 1',
   taskNum: 'T001',
   taskStatus: 'Active',
+  ownerName: null,
   ...overrides,
 });
 

--- a/web/client/src/test/components/project/SponsoredProjectsTable.test.tsx
+++ b/web/client/src/test/components/project/SponsoredProjectsTable.test.tsx
@@ -79,6 +79,7 @@ const createProject = (
   taskName: 'Task 1',
   taskNum: 'T001',
   taskStatus: 'Active',
+  ownerName: null,
   ...overrides,
 });
 

--- a/web/client/src/test/components/project/TaskBreakdown.test.tsx
+++ b/web/client/src/test/components/project/TaskBreakdown.test.tsx
@@ -81,6 +81,7 @@ const createProject = (
   taskName: 'Task 1',
   taskNum: 'T001',
   taskStatus: 'Active',
+  ownerName: null,
   ...overrides,
 });
 

--- a/web/client/src/test/routes/(authenticated)/project-detail.test.tsx
+++ b/web/client/src/test/routes/(authenticated)/project-detail.test.tsx
@@ -64,6 +64,7 @@ const createProject = (
   taskName: 'Task 1',
   taskNum: 'T001',
   taskStatus: 'Active',
+  ownerName: null,
   ...overrides,
 });
 

--- a/web/server.core/Models/FacultyPortfolioRecord.cs
+++ b/web/server.core/Models/FacultyPortfolioRecord.cs
@@ -194,4 +194,11 @@ public sealed class FacultyPortfolioRecord
     /// </summary>
     [JsonPropertyName("pmEmployeeId")]
     public string? PmEmployeeId { get; set; }
+
+    /// <summary>
+    /// Display name of the employee whose dashboard this record is being fetched for,
+    /// resolved from PPM team-member data rather than the faculty dept report.
+    /// </summary>
+    [JsonPropertyName("ownerName")]
+    public string? OwnerName { get; set; }
 }

--- a/web/server/Controllers/ProjectController.cs
+++ b/web/server/Controllers/ProjectController.cs
@@ -95,6 +95,13 @@ public sealed class ProjectController : ApiControllerBase
             .Where(p => p.ProjectStatus == "ACTIVE")
             .ToList();
 
+        // Resolve the dashboard owner's name from PPM team-member data
+        // (the URL employee is guaranteed to appear as a team member on at least one
+        // returned project since the GraphQL queries filtered on them).
+        var ownerName = graphProjects.Concat(orphanedProjects)
+            .SelectMany(p => p.TeamMembers)
+            .FirstOrDefault(m => m.EmployeeId == employeeId)?.Name;
+
         // Join PM employee ID from GraphQL data
         foreach (var project in activeProjects)
         {
@@ -102,6 +109,7 @@ public sealed class ProjectController : ApiControllerBase
             {
                 project.PmEmployeeId = pmEmployeeId;
             }
+            project.OwnerName = ownerName;
         }
 
         return Ok(activeProjects);


### PR DESCRIPTION
## Summary
- Resolve the dashboard owner's name from PPM team-member data so the title reflects the correct person (`ProjectController`, `FacultyPortfolioRecord`, `project.ts`).
- Render that name in natural order: PPM returns `"Last, First"`, so the title now shows **"First Last's Dashboard"** instead of **"Last, First's Dashboard"**.

## Behavior
- `"Doe, John"` → "John Doe's Dashboard"
- A name already in "First Last" order is shown unchanged.
- Missing owner name falls back to plain "Dashboard".

Addresses #258.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dashboard header now displays the owner's name in "First Last" format when available, showing personalized greeting like "${Name}'s Dashboard" instead of a generic "Dashboard".

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ucdavis/Walter/pull/276?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->