### PR TITLE
Add TransactionalListing table and chart-string-grain incremental pipeline objects

### DIFF
--- a/datamart/Scripts/Script.PostDeployment.sql
+++ b/datamart/Scripts/Script.PostDeployment.sql
@@ -36,6 +36,7 @@ GRANT EXECUTE ON [dbo].[usp_ValidateFinancialDept] TO [WalterAppRole];
 GRANT SELECT ON [dbo].[FacultyDeptPortfolio] TO [WalterAppRole];
 GRANT SELECT ON [dbo].[EmployeeAccrualBalances] TO [WalterAppRole];
 GRANT SELECT ON [dbo].[PositionBudgets] TO [WalterAppRole];
+GRANT SELECT ON [dbo].[TransactionalListing] TO [WalterAppRole];
 
 -- Grant pipeline role permissions
 GRANT INSERT, SELECT, UPDATE, DELETE ON [dbo].[FacultyDeptPortfolio] TO [WalterPipelineRole];
@@ -43,6 +44,10 @@ GRANT INSERT, SELECT, UPDATE ON [dbo].[EmployeeAccrualBalances] TO [WalterPipeli
 GRANT INSERT, SELECT, UPDATE, DELETE ON [dbo].[PositionBudgets] TO [WalterPipelineRole];
 GRANT INSERT, SELECT, UPDATE, DELETE ON [dbo].[PositionBudgets_Staging] TO [WalterPipelineRole];
 GRANT EXECUTE ON [dbo].[usp_SwapPositionBudgets] TO [WalterPipelineRole];
+GRANT INSERT, SELECT, UPDATE, DELETE ON [dbo].[TransactionalListing] TO [WalterPipelineRole];
+GRANT INSERT, SELECT, UPDATE, DELETE ON [dbo].[TransactionalListing_Staging] TO [WalterPipelineRole];
+GRANT EXECUTE ON [dbo].[usp_DiffTransactionalListing] TO [WalterPipelineRole];
+GRANT EXECUTE ON [dbo].[usp_SwapTransactionalListing] TO [WalterPipelineRole];
 
 
 

--- a/datamart/StoredProcedures/usp_DiffTransactionalListing.sql
+++ b/datamart/StoredProcedures/usp_DiffTransactionalListing.sql
@@ -1,0 +1,85 @@
+-- <summary>
+-- Computes the set of document numbers that differ between Walter's current
+-- TransactionalListing and the live source on Redshift. Emits both a count and
+-- a quoted IN-list string for use as a Fabric pipeline parameter.
+--
+-- The full-outer-join below classifies a document as changed if:
+--   - it exists in source but not in Walter (new)
+--   - row count or any of the three amount sums differ (modified)
+--   - it exists in Walter but not in source (deleted)
+--
+-- Source aggregates are pulled via OPENQUERY against [AE_Redshift_PROD]. This
+-- is a static, small aggregate query (one row per document); it is well under
+-- the 8000-byte OPENQUERY literal limit. The row-level changed-rows query
+-- (with the potentially large dynamic IN-list) is executed by the Fabric Copy
+-- activity using the IR's direct Redshift connection, not via OPENQUERY here.
+--
+-- Initial bulk load of dbo.TransactionalListing is performed offline. This
+-- sproc does no first-run handling: if Walter is empty, every source document
+-- will be flagged "new" and the pipeline will attempt a full pull.
+-- </summary>
+create procedure dbo.usp_DiffTransactionalListing
+    @ChangedDocCount   int           output,
+    @ChangedDocsInList nvarchar(max) output
+as
+begin
+    set nocount on;
+    set xact_abort on;
+
+    set @ChangedDocCount   = 0;
+    set @ChangedDocsInList = N'';
+
+    declare @SourceAggs table
+    (
+        DocumentNumber  nvarchar(50)   not null primary key,
+        DocRowCount     bigint         not null,
+        SumActual       decimal(18, 2) not null,
+        SumCommitment   decimal(18, 2) not null,
+        SumObligation   decimal(18, 2) not null
+    );
+
+    insert into @SourceAggs (DocumentNumber, DocRowCount, SumActual, SumCommitment, SumObligation)
+    select document_number, doc_row_count, sum_actual, sum_commitment, sum_obligation
+    from openquery([AE_Redshift_PROD], '
+        select
+            document_number,
+            count(*)                            as doc_row_count,
+            coalesce(sum(actual_amount), 0)     as sum_actual,
+            coalesce(sum(commitment_amount), 0) as sum_commitment,
+            coalesce(sum(obligation_amount), 0) as sum_obligation
+        from ae_dwh.transactional_listing_report
+        group by document_number
+    ');
+
+    with WalterAggs as
+    (
+        select
+            DocumentNumber,
+            count_big(*)          as DocRowCount,
+            sum(ActualAmount)     as SumActual,
+            sum(CommitmentAmount) as SumCommitment,
+            sum(ObligationAmount) as SumObligation
+        from dbo.TransactionalListing
+        group by DocumentNumber
+    ),
+    Changed as
+    (
+        select coalesce(s.DocumentNumber, w.DocumentNumber) as DocumentNumber
+        from @SourceAggs s
+        full outer join WalterAggs w on w.DocumentNumber = s.DocumentNumber
+        where s.DocumentNumber is null               -- deleted (in Walter, missing from source)
+           or w.DocumentNumber is null               -- new (in source, missing from Walter)
+           or w.DocRowCount    <> s.DocRowCount      -- modified
+           or w.SumActual      <> s.SumActual
+           or w.SumCommitment  <> s.SumCommitment
+           or w.SumObligation  <> s.SumObligation
+    )
+    select
+        @ChangedDocCount   = count(*),
+        @ChangedDocsInList = string_agg(quotename(DocumentNumber, ''''), ',')
+    from Changed;
+
+    if @ChangedDocsInList is null
+        set @ChangedDocsInList = N'';
+end
+go

--- a/datamart/StoredProcedures/usp_DiffTransactionalListing.sql
+++ b/datamart/StoredProcedures/usp_DiffTransactionalListing.sql
@@ -1,85 +1,91 @@
 -- <summary>
--- Computes the set of document numbers that differ between Walter's current
--- TransactionalListing and the live source on Redshift. Emits both a count and
--- a quoted IN-list string for use as a Fabric pipeline parameter.
+-- Computes the set of chart strings whose aggregates (row count + amount sums)
+-- differ between Walter's current TransactionalListing and the live source on
+-- Redshift. Emits a count and a quoted IN-list string for use as a Fabric
+-- pipeline parameter. The full-outer-join classifies a chart string as
+-- changed if it is new in source, missing from source (deleted), or has any
+-- aggregate divergence.
 --
--- The full-outer-join below classifies a document as changed if:
---   - it exists in source but not in Walter (new)
---   - row count or any of the three amount sums differ (modified)
---   - it exists in Walter but not in source (deleted)
---
--- Source aggregates are pulled via OPENQUERY against [AE_Redshift_PROD]. This
--- is a static, small aggregate query (one row per document); it is well under
--- the 8000-byte OPENQUERY literal limit. The row-level changed-rows query
--- (with the potentially large dynamic IN-list) is executed by the Fabric Copy
--- activity using the IR's direct Redshift connection, not via OPENQUERY here.
+-- Source aggregates are pulled via OPENQUERY against [AE_Redshift_PROD]. The
+-- query is static and produces one row per chart string (~98K rows for ~2.2M
+-- source rows), well under any OPENQUERY size limit. The row-level changed-
+-- rows query (with the potentially large dynamic IN-list) is executed by the
+-- Fabric Copy activity using the IR's direct Redshift connection.
 --
 -- Initial bulk load of dbo.TransactionalListing is performed offline. This
--- sproc does no first-run handling: if Walter is empty, every source document
--- will be flagged "new" and the pipeline will attempt a full pull.
+-- sproc does no first-run handling.
 -- </summary>
 create procedure dbo.usp_DiffTransactionalListing
-    @ChangedDocCount   int           output,
-    @ChangedDocsInList nvarchar(max) output
+    @ChangedChartStringCount   int           output,
+    @ChangedChartStringsInList nvarchar(max) output
 as
 begin
     set nocount on;
     set xact_abort on;
 
-    set @ChangedDocCount   = 0;
-    set @ChangedDocsInList = N'';
+    set @ChangedChartStringCount   = 0;
+    set @ChangedChartStringsInList = N'';
 
     declare @SourceAggs table
     (
-        DocumentNumber  nvarchar(50)   not null primary key,
-        DocRowCount     bigint         not null,
-        SumActual       decimal(18, 2) not null,
-        SumCommitment   decimal(18, 2) not null,
-        SumObligation   decimal(18, 2) not null
+        ChartStringKey   nvarchar(200)  not null primary key,
+        ChartRowCount    bigint         not null,
+        SumActual        decimal(18, 2) not null,
+        SumCommitment    decimal(18, 2) not null,
+        SumObligation    decimal(18, 2) not null
     );
 
-    insert into @SourceAggs (DocumentNumber, DocRowCount, SumActual, SumCommitment, SumObligation)
-    select document_number, doc_row_count, sum_actual, sum_commitment, sum_obligation
+    -- COALESCE segments must match TransactionalListing.ChartStringKey so
+    -- source and Walter aggregates align on identical keys.
+    insert into @SourceAggs (ChartStringKey, ChartRowCount, SumActual, SumCommitment, SumObligation)
+    select chart_string_key, chart_row_count, sum_actual, sum_commitment, sum_obligation
     from openquery([AE_Redshift_PROD], '
         select
-            document_number,
-            count(*)                            as doc_row_count,
-            coalesce(sum(actual_amount), 0)     as sum_actual,
-            coalesce(sum(commitment_amount), 0) as sum_commitment,
-            coalesce(sum(obligation_amount), 0) as sum_obligation
+            coalesce(entity, '''')               || ''-'' ||
+            coalesce(fund, '''')                 || ''-'' ||
+            coalesce(financial_department, '''') || ''-'' ||
+            coalesce(account, '''')              || ''-'' ||
+            coalesce(purpose, '''')              || ''-'' ||
+            coalesce(program, '''')              || ''-'' ||
+            coalesce(project, '''')              || ''-'' ||
+            coalesce(activity, '''')             as chart_string_key,
+            count(*)                             as chart_row_count,
+            coalesce(sum(actual_amount), 0)      as sum_actual,
+            coalesce(sum(commitment_amount), 0)  as sum_commitment,
+            coalesce(sum(obligation_amount), 0)  as sum_obligation
         from ae_dwh.transactional_listing_report
-        group by document_number
+        group by 1
     ');
 
     with WalterAggs as
     (
         select
-            DocumentNumber,
-            count_big(*)          as DocRowCount,
+            ChartStringKey,
+            count_big(*)          as ChartRowCount,
             sum(ActualAmount)     as SumActual,
             sum(CommitmentAmount) as SumCommitment,
             sum(ObligationAmount) as SumObligation
         from dbo.TransactionalListing
-        group by DocumentNumber
+        group by ChartStringKey
     ),
     Changed as
     (
-        select coalesce(s.DocumentNumber, w.DocumentNumber) as DocumentNumber
+        select coalesce(s.ChartStringKey, w.ChartStringKey) as ChartStringKey
         from @SourceAggs s
-        full outer join WalterAggs w on w.DocumentNumber = s.DocumentNumber
-        where s.DocumentNumber is null               -- deleted (in Walter, missing from source)
-           or w.DocumentNumber is null               -- new (in source, missing from Walter)
-           or w.DocRowCount    <> s.DocRowCount      -- modified
-           or w.SumActual      <> s.SumActual
-           or w.SumCommitment  <> s.SumCommitment
-           or w.SumObligation  <> s.SumObligation
+        full outer join WalterAggs w on w.ChartStringKey = s.ChartStringKey
+        where s.ChartStringKey is null               -- deleted (in Walter, missing from source)
+           or w.ChartStringKey is null               -- new (in source, missing from Walter)
+           or w.ChartRowCount   <> s.ChartRowCount   -- modified
+           or w.SumActual       <> s.SumActual
+           or w.SumCommitment   <> s.SumCommitment
+           or w.SumObligation   <> s.SumObligation
     )
     select
-        @ChangedDocCount   = count(*),
-        @ChangedDocsInList = string_agg(quotename(DocumentNumber, ''''), ',')
+        @ChangedChartStringCount   = count(*),
+        @ChangedChartStringsInList = string_agg(quotename(ChartStringKey, ''''), ',')
     from Changed;
 
-    if @ChangedDocsInList is null
-        set @ChangedDocsInList = N'';
+    if @ChangedChartStringsInList is null
+        set @ChangedChartStringsInList = N'';
 end
 go

--- a/datamart/StoredProcedures/usp_SwapTransactionalListing.sql
+++ b/datamart/StoredProcedures/usp_SwapTransactionalListing.sql
@@ -1,47 +1,45 @@
 -- <summary>
--- Atomically replaces all rows for the given document numbers in
+-- Atomically replaces all rows for the given chart strings in
 -- dbo.TransactionalListing with the rows currently in
 -- dbo.TransactionalListing_Staging.
 --
--- @ChangedDocsInList carries the same quoted, comma-separated string emitted
--- by usp_DiffTransactionalListing (format: 'doc1','doc2','doc3'). The list
--- is parsed back to a relation via STRING_SPLIT so we can DELETE by an
--- indexed join rather than a literal IN-clause that could exceed parser
--- limits at high cardinality.
+-- @ChangedChartStringsInList carries the same quoted, comma-separated string
+-- emitted by usp_DiffTransactionalListing (format: 'cs1','cs2','cs3'). The list
+-- is parsed back to a relation via STRING_SPLIT so we can DELETE by an indexed
+-- join rather than a literal IN-clause that could exceed parser limits at
+-- high cardinality.
 --
--- Deleted documents (present in @ChangedDocsInList but absent from staging,
--- because the source no longer has any rows for them) are removed by the
--- DELETE step. The INSERT step naturally skips them because staging contains
--- no rows for those doc numbers. Atomicity is enforced by SET XACT_ABORT ON
--- and a single explicit transaction.
+-- Deleted chart strings (present in the list but absent from staging, because
+-- the source no longer has any rows for them) are removed by the DELETE step.
+-- The INSERT step naturally skips them because staging contains no rows for
+-- those chart strings. Atomicity is enforced by SET XACT_ABORT ON and a
+-- single explicit transaction.
 -- </summary>
 create procedure dbo.usp_SwapTransactionalListing
-    @ChangedDocsInList nvarchar(max)
+    @ChangedChartStringsInList nvarchar(max)
 as
 begin
     set nocount on;
     set xact_abort on;
 
-    if @ChangedDocsInList is null or len(@ChangedDocsInList) = 0
+    if @ChangedChartStringsInList is null or len(@ChangedChartStringsInList) = 0
         return;
 
-    -- Parse the QUOTENAME-built list back to a relation. Each token from
-    -- STRING_SPLIT looks like 'docN'; strip the wrapping single quotes.
-    declare @DocsToReplace table
+    declare @ChartStringsToReplace table
     (
-        DocumentNumber nvarchar(50) not null primary key
+        ChartStringKey nvarchar(200) not null primary key
     );
 
-    insert into @DocsToReplace (DocumentNumber)
+    insert into @ChartStringsToReplace (ChartStringKey)
     select trim('''' from value)
-    from string_split(@ChangedDocsInList, ',')
+    from string_split(@ChangedChartStringsInList, ',')
     where len(value) > 0;
 
     begin transaction;
 
     delete tl
     from dbo.TransactionalListing tl
-    inner join @DocsToReplace d on d.DocumentNumber = tl.DocumentNumber;
+    inner join @ChartStringsToReplace c on c.ChartStringKey = tl.ChartStringKey;
 
     insert into dbo.TransactionalListing
     (
@@ -50,7 +48,7 @@ begin
         Account, AccountDescription, Purpose, PurposeDescription,
         Program, ProgramDescription, Project, ProjectDescription,
         Activity, ActivityDescription,
-        DocumentType, DocumentNumber, AccountingSequenceNumber,
+        DocumentType, AccountingSequenceNumber,
         TrackingNo, Reference,
         JournalLineDescription, JournalAcctDate, JournalName, JournalReference,
         PeriodName, JournalBatchName, JournalSource, JournalCategory,
@@ -64,7 +62,7 @@ begin
         Account, AccountDescription, Purpose, PurposeDescription,
         Program, ProgramDescription, Project, ProjectDescription,
         Activity, ActivityDescription,
-        DocumentType, DocumentNumber, AccountingSequenceNumber,
+        DocumentType, AccountingSequenceNumber,
         TrackingNo, Reference,
         JournalLineDescription, JournalAcctDate, JournalName, JournalReference,
         PeriodName, JournalBatchName, JournalSource, JournalCategory,

--- a/datamart/StoredProcedures/usp_SwapTransactionalListing.sql
+++ b/datamart/StoredProcedures/usp_SwapTransactionalListing.sql
@@ -1,0 +1,78 @@
+-- <summary>
+-- Atomically replaces all rows for the given document numbers in
+-- dbo.TransactionalListing with the rows currently in
+-- dbo.TransactionalListing_Staging.
+--
+-- @ChangedDocsInList carries the same quoted, comma-separated string emitted
+-- by usp_DiffTransactionalListing (format: 'doc1','doc2','doc3'). The list
+-- is parsed back to a relation via STRING_SPLIT so we can DELETE by an
+-- indexed join rather than a literal IN-clause that could exceed parser
+-- limits at high cardinality.
+--
+-- Deleted documents (present in @ChangedDocsInList but absent from staging,
+-- because the source no longer has any rows for them) are removed by the
+-- DELETE step. The INSERT step naturally skips them because staging contains
+-- no rows for those doc numbers. Atomicity is enforced by SET XACT_ABORT ON
+-- and a single explicit transaction.
+-- </summary>
+create procedure dbo.usp_SwapTransactionalListing
+    @ChangedDocsInList nvarchar(max)
+as
+begin
+    set nocount on;
+    set xact_abort on;
+
+    if @ChangedDocsInList is null or len(@ChangedDocsInList) = 0
+        return;
+
+    -- Parse the QUOTENAME-built list back to a relation. Each token from
+    -- STRING_SPLIT looks like 'docN'; strip the wrapping single quotes.
+    declare @DocsToReplace table
+    (
+        DocumentNumber nvarchar(50) not null primary key
+    );
+
+    insert into @DocsToReplace (DocumentNumber)
+    select trim('''' from value)
+    from string_split(@ChangedDocsInList, ',')
+    where len(value) > 0;
+
+    begin transaction;
+
+    delete tl
+    from dbo.TransactionalListing tl
+    inner join @DocsToReplace d on d.DocumentNumber = tl.DocumentNumber;
+
+    insert into dbo.TransactionalListing
+    (
+        Entity, EntityDescription, Fund, FundDescription,
+        FinancialDepartment, FinancialDepartmentDescription,
+        Account, AccountDescription, Purpose, PurposeDescription,
+        Program, ProgramDescription, Project, ProjectDescription,
+        Activity, ActivityDescription,
+        DocumentType, DocumentNumber, AccountingSequenceNumber,
+        TrackingNo, Reference,
+        JournalLineDescription, JournalAcctDate, JournalName, JournalReference,
+        PeriodName, JournalBatchName, JournalSource, JournalCategory,
+        BatchStatus, ActualFlag, EncumbranceTypeCode,
+        ActualAmount, CommitmentAmount, ObligationAmount,
+        LoadedAt
+    )
+    select
+        Entity, EntityDescription, Fund, FundDescription,
+        FinancialDepartment, FinancialDepartmentDescription,
+        Account, AccountDescription, Purpose, PurposeDescription,
+        Program, ProgramDescription, Project, ProjectDescription,
+        Activity, ActivityDescription,
+        DocumentType, DocumentNumber, AccountingSequenceNumber,
+        TrackingNo, Reference,
+        JournalLineDescription, JournalAcctDate, JournalName, JournalReference,
+        PeriodName, JournalBatchName, JournalSource, JournalCategory,
+        BatchStatus, ActualFlag, EncumbranceTypeCode,
+        ActualAmount, CommitmentAmount, ObligationAmount,
+        LoadedAt
+    from dbo.TransactionalListing_Staging;
+
+    commit transaction;
+end
+go

--- a/datamart/Tables/Staging/TransactionalListing_Staging.sql
+++ b/datamart/Tables/Staging/TransactionalListing_Staging.sql
@@ -17,7 +17,6 @@ CREATE TABLE dbo.TransactionalListing_Staging
     Activity                        NVARCHAR(20),
     ActivityDescription             NVARCHAR(200),
     DocumentType                    NVARCHAR(50),
-    DocumentNumber                  NVARCHAR(50)                          NOT NULL,
     AccountingSequenceNumber        NVARCHAR(50),
     TrackingNo                      NVARCHAR(100),
     Reference                       NVARCHAR(200),
@@ -32,16 +31,9 @@ CREATE TABLE dbo.TransactionalListing_Staging
     BatchStatus                     NVARCHAR(50),
     ActualFlag                      NVARCHAR(10),
     EncumbranceTypeCode             NVARCHAR(50),
-    ActualAmount                    DECIMAL(18, 2)                        NOT NULL DEFAULT 0,
-    CommitmentAmount                DECIMAL(18, 2)                        NOT NULL DEFAULT 0,
-    ObligationAmount                DECIMAL(18, 2)                        NOT NULL DEFAULT 0,
-    LoadedAt                        DATETIME2(3)                          NOT NULL
+    ActualAmount                    DECIMAL(18, 2)  NOT NULL DEFAULT 0,
+    CommitmentAmount                DECIMAL(18, 2)  NOT NULL DEFAULT 0,
+    ObligationAmount                DECIMAL(18, 2)  NOT NULL DEFAULT 0,
+    LoadedAt                        DATETIME2(3)    NOT NULL
 );
-GO
-
--- Clustered index on DocumentNumber matches the production table so the
--- swap's "DELETE WHERE DocumentNumber IN (SELECT DocumentNumber FROM Staging)"
--- and "INSERT ... FROM Staging" both scan efficiently.
-CREATE CLUSTERED INDEX IX_TransactionalListing_Staging_DocumentNumber
-    ON dbo.TransactionalListing_Staging (DocumentNumber);
 GO

--- a/datamart/Tables/Staging/TransactionalListing_Staging.sql
+++ b/datamart/Tables/Staging/TransactionalListing_Staging.sql
@@ -1,0 +1,47 @@
+CREATE TABLE dbo.TransactionalListing_Staging
+(
+    Entity                          NVARCHAR(20),
+    EntityDescription               NVARCHAR(200),
+    Fund                            NVARCHAR(20),
+    FundDescription                 NVARCHAR(200),
+    FinancialDepartment             NVARCHAR(20),
+    FinancialDepartmentDescription  NVARCHAR(200),
+    Account                         NVARCHAR(20),
+    AccountDescription              NVARCHAR(200),
+    Purpose                         NVARCHAR(20),
+    PurposeDescription              NVARCHAR(200),
+    Program                         NVARCHAR(20),
+    ProgramDescription              NVARCHAR(200),
+    Project                         NVARCHAR(30),
+    ProjectDescription              NVARCHAR(400),
+    Activity                        NVARCHAR(20),
+    ActivityDescription             NVARCHAR(200),
+    DocumentType                    NVARCHAR(50),
+    DocumentNumber                  NVARCHAR(50)                          NOT NULL,
+    AccountingSequenceNumber        NVARCHAR(50),
+    TrackingNo                      NVARCHAR(100),
+    Reference                       NVARCHAR(200),
+    JournalLineDescription          NVARCHAR(400),
+    JournalAcctDate                 DATE,
+    JournalName                     NVARCHAR(200),
+    JournalReference                NVARCHAR(200),
+    PeriodName                      NVARCHAR(20),
+    JournalBatchName                NVARCHAR(200),
+    JournalSource                   NVARCHAR(100),
+    JournalCategory                 NVARCHAR(100),
+    BatchStatus                     NVARCHAR(50),
+    ActualFlag                      NVARCHAR(10),
+    EncumbranceTypeCode             NVARCHAR(50),
+    ActualAmount                    DECIMAL(18, 2)                        NOT NULL DEFAULT 0,
+    CommitmentAmount                DECIMAL(18, 2)                        NOT NULL DEFAULT 0,
+    ObligationAmount                DECIMAL(18, 2)                        NOT NULL DEFAULT 0,
+    LoadedAt                        DATETIME2(3)                          NOT NULL
+);
+GO
+
+-- Clustered index on DocumentNumber matches the production table so the
+-- swap's "DELETE WHERE DocumentNumber IN (SELECT DocumentNumber FROM Staging)"
+-- and "INSERT ... FROM Staging" both scan efficiently.
+CREATE CLUSTERED INDEX IX_TransactionalListing_Staging_DocumentNumber
+    ON dbo.TransactionalListing_Staging (DocumentNumber);
+GO

--- a/datamart/Tables/TransactionalListing.sql
+++ b/datamart/Tables/TransactionalListing.sql
@@ -1,5 +1,6 @@
 CREATE TABLE dbo.TransactionalListing
 (
+    TransactionalListingId          BIGINT          IDENTITY(1, 1) NOT NULL,
     Entity                          NVARCHAR(20),
     EntityDescription               NVARCHAR(200),
     Fund                            NVARCHAR(20),
@@ -17,7 +18,6 @@ CREATE TABLE dbo.TransactionalListing
     Activity                        NVARCHAR(20),
     ActivityDescription             NVARCHAR(200),
     DocumentType                    NVARCHAR(50),
-    DocumentNumber                  NVARCHAR(50)                          NOT NULL,
     AccountingSequenceNumber        NVARCHAR(50),
     TrackingNo                      NVARCHAR(100),
     Reference                       NVARCHAR(200),
@@ -32,15 +32,42 @@ CREATE TABLE dbo.TransactionalListing
     BatchStatus                     NVARCHAR(50),
     ActualFlag                      NVARCHAR(10),
     EncumbranceTypeCode             NVARCHAR(50),
-    ActualAmount                    DECIMAL(18, 2)                        NOT NULL DEFAULT 0,
-    CommitmentAmount                DECIMAL(18, 2)                        NOT NULL DEFAULT 0,
-    ObligationAmount                DECIMAL(18, 2)                        NOT NULL DEFAULT 0,
-    LoadedAt                        DATETIME2(3)                          NOT NULL
+    ActualAmount                    DECIMAL(18, 2)  NOT NULL DEFAULT 0,
+    CommitmentAmount                DECIMAL(18, 2)  NOT NULL DEFAULT 0,
+    ObligationAmount                DECIMAL(18, 2)  NOT NULL DEFAULT 0,
+    LoadedAt                        DATETIME2(3)    NOT NULL,
+    -- ChartStringKey is the diff grain. AE source rows often have null
+    -- AccountingSequenceNumber (encumbrances/POs), so we can't key off that.
+    -- The 8-column chart string is always populated and gives us stable
+    -- buckets to aggregate, diff, and replace by. COALESCE keeps NULL
+    -- segments from producing NULL keys.
+    ChartStringKey AS
+    (
+        CONCAT(
+            COALESCE(Entity, ''),               N'-',
+            COALESCE(Fund, ''),                 N'-',
+            COALESCE(FinancialDepartment, ''),  N'-',
+            COALESCE(Account, ''),              N'-',
+            COALESCE(Purpose, ''),              N'-',
+            COALESCE(Program, ''),              N'-',
+            COALESCE(Project, ''),              N'-',
+            COALESCE(Activity, '')
+        )
+    ) PERSISTED,
+    CONSTRAINT PK_TransactionalListing
+        PRIMARY KEY CLUSTERED (TransactionalListingId)
 );
 GO
 
--- Clustered index on DocumentNumber: supports the live-aggregate GROUP BY in
--- usp_DiffTransactionalListing and the doc-level DELETE in usp_SwapTransactionalListing.
-CREATE CLUSTERED INDEX IX_TransactionalListing_DocumentNumber
-    ON dbo.TransactionalListing (DocumentNumber);
+-- Diff and swap path: aggregate / DELETE / scan-from-staging all hit ChartStringKey.
+-- INCLUDE the three amount columns so the diff's per-chart-string aggregate
+-- query is satisfied entirely by this index.
+CREATE NONCLUSTERED INDEX IX_TransactionalListing_ChartStringKey
+    ON dbo.TransactionalListing (ChartStringKey)
+    INCLUDE (ActualAmount, CommitmentAmount, ObligationAmount);
+GO
+
+-- Consumer reads: every TL consumer sproc filters by Project.
+CREATE NONCLUSTERED INDEX IX_TransactionalListing_Project
+    ON dbo.TransactionalListing (Project);
 GO

--- a/datamart/Tables/TransactionalListing.sql
+++ b/datamart/Tables/TransactionalListing.sql
@@ -1,0 +1,46 @@
+CREATE TABLE dbo.TransactionalListing
+(
+    Entity                          NVARCHAR(20),
+    EntityDescription               NVARCHAR(200),
+    Fund                            NVARCHAR(20),
+    FundDescription                 NVARCHAR(200),
+    FinancialDepartment             NVARCHAR(20),
+    FinancialDepartmentDescription  NVARCHAR(200),
+    Account                         NVARCHAR(20),
+    AccountDescription              NVARCHAR(200),
+    Purpose                         NVARCHAR(20),
+    PurposeDescription              NVARCHAR(200),
+    Program                         NVARCHAR(20),
+    ProgramDescription              NVARCHAR(200),
+    Project                         NVARCHAR(30),
+    ProjectDescription              NVARCHAR(400),
+    Activity                        NVARCHAR(20),
+    ActivityDescription             NVARCHAR(200),
+    DocumentType                    NVARCHAR(50),
+    DocumentNumber                  NVARCHAR(50)                          NOT NULL,
+    AccountingSequenceNumber        NVARCHAR(50),
+    TrackingNo                      NVARCHAR(100),
+    Reference                       NVARCHAR(200),
+    JournalLineDescription          NVARCHAR(400),
+    JournalAcctDate                 DATE,
+    JournalName                     NVARCHAR(200),
+    JournalReference                NVARCHAR(200),
+    PeriodName                      NVARCHAR(20),
+    JournalBatchName                NVARCHAR(200),
+    JournalSource                   NVARCHAR(100),
+    JournalCategory                 NVARCHAR(100),
+    BatchStatus                     NVARCHAR(50),
+    ActualFlag                      NVARCHAR(10),
+    EncumbranceTypeCode             NVARCHAR(50),
+    ActualAmount                    DECIMAL(18, 2)                        NOT NULL DEFAULT 0,
+    CommitmentAmount                DECIMAL(18, 2)                        NOT NULL DEFAULT 0,
+    ObligationAmount                DECIMAL(18, 2)                        NOT NULL DEFAULT 0,
+    LoadedAt                        DATETIME2(3)                          NOT NULL
+);
+GO
+
+-- Clustered index on DocumentNumber: supports the live-aggregate GROUP BY in
+-- usp_DiffTransactionalListing and the doc-level DELETE in usp_SwapTransactionalListing.
+CREATE CLUSTERED INDEX IX_TransactionalListing_DocumentNumber
+    ON dbo.TransactionalListing (DocumentNumber);
+GO


### PR DESCRIPTION
## Summary
- New persistent `dbo.TransactionalListing` table with surrogate `BIGINT IDENTITY` PK and a `ChartStringKey` PERSISTED computed column (8-column `CONCAT(COALESCE(...), '-', ...)`). Indexed for diff/swap (`ChartStringKey` INCLUDE amounts) and for consumer reads (`Project`).
- `dbo.TransactionalListing_Staging` mirror schema for the per-run Copy from Redshift.
- `usp_DiffTransactionalListing` — pulls source aggregates via OPENQUERY against `[AE_Redshift_PROD]` aggregating by chart string into a table variable, full-outer-joins to live Walter aggregates by `ChartStringKey`, outputs `@ChangedChartStringCount` and `@ChangedChartStringsInList` (covers new + modified + deleted buckets).
- `usp_SwapTransactionalListing` — accepts `@ChangedChartStringsInList` as input, parses with `STRING_SPLIT`, atomically deletes all rows for those chart strings and re-inserts from staging (deleted chart strings naturally fall out — no rows in staging for them).
- Post-deployment grants: `WalterAppRole` SELECT on the table; `WalterPipelineRole` INSERT/SELECT/UPDATE/DELETE on both tables and EXECUTE on both sprocs.

## Diff grain choice
`AccountingSequenceNumber` (the source field "document_number" is an alias for it) is NULL on ~2.2M encumbrance/PO rows in `ae_dwh.transactional_listing_report`. Chart string is always populated and gives stable buckets (~98K distinct, avg ~22 rows each; 86% of buckets have ≤25 rows) covering both actuals and encumbrances.

## Pairs with
A companion PR against `ucdavis/Datamart` will add the Fabric pipeline activities (Diff → If → Copy changed rows → Copy staging to bronze → Swap) to `pl_AEDatamartLoader`.

## Notes
- Initial bulk load of `dbo.TransactionalListing` is performed offline (not via this pipeline). The diff sproc has no first-run handling — if Walter is empty, every source chart string is flagged "new" and the pipeline will attempt a full pull.
- Column lengths in `TransactionalListing` are best-guess against the existing `usp_GetGLTransactionListings` column list; may need adjustment after the offline load surfaces real value lengths.
- Bronze sink in the Fabric pipeline (`lh_bronze.dbo.transactional_listing`) follows the same append + `loaded_at` pattern as the other three AE bronze tables.