### PR TITLE
Re-include 8 CA&ES carryforward journals in GL/PPM recon

### DIFF
--- a/datamart/StoredProcedures/usp_GetGLPPMReconciliation.sql
+++ b/datamart/StoredProcedures/usp_GetGLPPMReconciliation.sql
@@ -34,9 +34,11 @@ BEGIN
     EXEC dbo.usp_ParseProjectIdFilter @ProjectIds, @ProjectIdFilter OUTPUT;
 
     -- Build Redshift query for GL data (transactional_listing_report is still remote).
-    -- Exclude carryforward 3XXXXXX activity with two exceptions:
+    -- Exclude carryforward 3XXXXXX activity with three exceptions:
     --   1. Jul-23 one-time UCD conversion ASNs (initial rollover from legacy financial system)
     --   2. Apr-24 UCD Conversion journal entries (balance correction adjustments)
+    --   3. CA&ES carryforward journals re-included per Melissa Estes (2025-05).
+    --      Interim hardcoded ASN list; replace with a reference table later.
     SET @RedshiftQuery = '
         SELECT
             tlr.FINANCIAL_DEPARTMENT,
@@ -57,6 +59,7 @@ BEGIN
               acc.parent_level_0_code NOT LIKE ''3%''
               OR (tlr.PERIOD_NAME = ''Jul-23'' AND tlr.ACCOUNTING_SEQUENCE_NUMBER IN (''100009'',''100010'',''100307'',''103283'',''103284''))
               OR (tlr.PERIOD_NAME = ''Apr-24'' AND tlr.JOURNAL_SOURCE = ''UCD Conversion'' AND tlr.JOURNAL_CATEGORY = ''UCD Conversion'')
+              OR tlr.ACCOUNTING_SEQUENCE_NUMBER IN (''292363'',''338926'',''341705'',''341722'',''398465'',''413247'',''419608'',''434173'')
           )
         GROUP BY tlr.FINANCIAL_DEPARTMENT, tlr.PROJECT, tlr.PROJECT_DESCRIPTION, tlr.FUND, tlr.FUND_DESCRIPTION, tlr.PROGRAM, tlr.PROGRAM_DESCRIPTION, tlr.ACTIVITY, tlr.ACTIVITY_DESCRIPTION';
 

--- a/datamart/StoredProcedures/usp_GetGLTransactionListings.sql
+++ b/datamart/StoredProcedures/usp_GetGLTransactionListings.sql
@@ -73,14 +73,17 @@ BEGIN
     IF @EndDate IS NOT NULL
         SET @FilterClause = @FilterClause + ' AND tlr.journal_acct_date <= ''' + CONVERT(VARCHAR(10), @EndDate, 120) + '''';
 
-    -- Exclude carryforward 3XXXXXX activity with two exceptions:
+    -- Exclude carryforward 3XXXXXX activity with three exceptions:
     --   1. Jul-23 one-time UCD conversion ASNs (initial rollover from legacy financial system)
     --   2. Apr-24 UCD Conversion journal entries (balance correction adjustments)
+    --   3. CA&ES carryforward journals re-included per Melissa Estes (2025-05).
+    --      Interim hardcoded ASN list; replace with a reference table later.
     -- Same exclusion logic as usp_GetGLPPMReconciliation.
     SET @FilterClause = @FilterClause + ' AND (
             acc.parent_level_0_code NOT LIKE ''3%''
             OR (tlr.PERIOD_NAME = ''Jul-23'' AND tlr.ACCOUNTING_SEQUENCE_NUMBER IN (''100009'',''100010'',''100307'',''103283'',''103284''))
             OR (tlr.PERIOD_NAME = ''Apr-24'' AND tlr.JOURNAL_SOURCE = ''UCD Conversion'' AND tlr.JOURNAL_CATEGORY = ''UCD Conversion'')
+            OR tlr.ACCOUNTING_SEQUENCE_NUMBER IN (''292363'',''338926'',''341705'',''341722'',''398465'',''413247'',''419608'',''434173'')
         )';
 
     SET @FilterClause = @FilterClause + ' AND tlr.PERIOD_NAME <> ''Jun-23''';


### PR DESCRIPTION
## What

Re-includes 8 natural-account-300001 carryforward journals that should appear in the GL/PPM reconciliation but are currently excluded by the 3XXXXXX carve-out logic.

Identified by Melissa Estes (CA&ES analysis): ASNs `292363, 338926, 341705, 341722, 398465, 413247, 419608, 434173`.

## Change

Adds a third exception to the existing 3XXXXXX exclusion block in **both** sprocs, keeping them consistent (the listing must reconcile to the summary):

- `usp_GetGLPPMReconciliation.sql` — recon summary (`SUM(ACTUAL_AMOUNT)`)
- `usp_GetGLTransactionListings.sql` — line-level drill-down

```sql
OR tlr.ACCOUNTING_SEQUENCE_NUMBER IN ('292363','338926','341705','341722','398465','413247','419608','434173')
```

The new clause is a flat, unscoped `ACCOUNTING_SEQUENCE_NUMBER IN (...)` list (no `PERIOD_NAME` scoping, since the periods weren't provided). Because it's `OR`'d into a "keep if NOT a 3-account OR a carve-out" block, it only ever adds rows — never removes any.

## Notes

- **Interim hardcoded list**, per request. The longer-term fix is a reference table of re-included ASNs.
- Explanatory comments are kept in the host T-SQL, **not** inside the dynamic SQL — the Oracle linked server rejects `--` inside the OPENQUERY string.
- Small theoretical risk of the flat list: if one of these 8 ASN values also appears in a different period for an unrelated 3-account row, it would be pulled in too. Acceptable for the interim fix.

## Verification

Local `dotnet build` is currently blocked by an unrelated toolchain issue (`Microsoft.Build.Sql` SDK vs. installed .NET SDK 10.0.101). The SQL change itself is a single added `OR` line per file; CI build/deploy will validate compilation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated General Ledger reconciliation and transaction reports to correctly handle carryforward journal entries, including new exceptions for CA&ES accounts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ucdavis/Walter/pull/280?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->