### PR TITLE
Fix usp_GetPositionBudgets 8000-char query limit (OPENQUERY → EXEC ... AT)

### DIFF
--- a/datamart/StoredProcedures/usp_GetPositionBudgets.sql
+++ b/datamart/StoredProcedures/usp_GetPositionBudgets.sql
@@ -18,7 +18,6 @@ BEGIN
     DECLARE @OracleQuery NVARCHAR(MAX);
     DECLARE @RedshiftQuery NVARCHAR(MAX);
     DECLARE @TSQLCommand NVARCHAR(MAX);
-    DECLARE @LinkedServerName SYSNAME = '[AIT_BISTG_PRD-CAES_HCMODS_APPUSER]';
     DECLARE @RedshiftLinkedServer SYSNAME = '[AE_Redshift_PROD]';
     DECLARE @StartTime DATETIME2 = SYSDATETIME();
     DECLARE @RowCount INT;
@@ -40,12 +39,15 @@ BEGIN
     DECLARE @ProjectIdFilter NVARCHAR(MAX);
     EXEC dbo.usp_ParseProjectIdFilter @ProjectIds, @ProjectIdFilter OUTPUT;
 
-    -- Build Oracle query joining budget and position data
+    -- Build Oracle query joining budget and position data.
     -- Use two-stage approach for performance:
     --   1. CandidatePositions: Fast lookup to find positions with ANY budget entry for the project.
     --      This limits the number of records pulled in subsequent CTEs to improve performance
     --   2. RankedBudget: Get all budget entries for just those positions and rank them
     --   3. LatestBudget: Filter to positions whose LATEST entry is still in the project
+    -- CandidatePositions stays an in-Oracle subquery (IN (SELECT ...)) so large position sets do
+    -- not hit Oracle's 1000-item IN-list limit (ORA-01795). The query is executed via EXEC ... AT
+    -- (see below) so it is not subject to OPENQUERY's 8000-character string-literal limit.
     SET @OracleQuery = '
         WITH CandidatePositions AS (
             SELECT DISTINCT budget.POSITION_NBR
@@ -208,7 +210,6 @@ BEGIN
         FOR JSON PATH, WITHOUT_ARRAY_WRAPPER
     );
 
-    -- Execute via OPENQUERY, join with CompositeBenefitRates and Redshift project names
     BEGIN TRY
         -- Create temp table for Oracle results
         CREATE TABLE #PositionBudgets (
@@ -241,13 +242,12 @@ BEGIN
             JOBCODE VARCHAR(6)
         );
 
-        -- Insert Oracle data into temp table
-        SET @TSQLCommand =
-            'INSERT INTO #PositionBudgets
-             SELECT oq.*
-             FROM OPENQUERY(' + @LinkedServerName + ', ''' + REPLACE(@OracleQuery, '''', '''''') + ''') oq';
-
-        EXEC sp_executesql @TSQLCommand;
+        -- Insert Oracle data into temp table via EXEC ... AT. Unlike OPENQUERY, the query text is
+        -- sent to the linked server as an RPC parameter, so it is NOT capped at 8000 characters --
+        -- which is what broke this proc for large project sets. Requires 'rpc out' = true on the
+        -- linked server (sp_serveroption '...','rpc out','true').
+        INSERT INTO #PositionBudgets
+        EXEC (@OracleQuery) AT [AIT_BISTG_PRD-CAES_HCMODS_APPUSER];
 
         -- TODO: Replace this temp table approach with a local Projects table populated via ETL
         -- Create temp table for project names from Redshift


### PR DESCRIPTION
## Problem

`usp_GetPositionBudgets` builds its position-budget query dynamically and runs it against the Oracle linked server. The query was embedded as a **string literal inside `OPENQUERY`**, which caps the query text at **8000 characters**. For large project sets — e.g. a faculty portfolio of ~600 projects — the generated literal exceeded 8000 chars and the proc failed:

> The character string that starts with `'WITH CandidatePositions AS ( SELECT DISTINCT budget.POSITION_NBR FROM caes_hcmods.PS_DEPT_BUDGET...'` is too long. Maximum length is 8000.

The two-stage optimization added in `54b89754` (the `CandidatePositions` CTE) duplicated the budget/account join and added a second `@ProjectIdFilter` interpolation, which pushed the literal over the limit.

## Fix

Switch the Oracle call from `OPENQUERY(...)` to:

```sql
INSERT INTO #PositionBudgets
EXEC (@OracleQuery) AT [AIT_BISTG_PRD-CAES_HCMODS_APPUSER];
```

`EXEC ... AT` sends the query to the linked server as an **RPC parameter**, so it's not subject to the 8000-char literal cap (and the quote-doubling `REPLACE` is no longer needed).

- **Query body is byte-for-byte unchanged** → identical results, no logic change.
- `CandidatePositions` stays an **in-Oracle subquery** (`IN (SELECT ...)`), so large position sets don't hit Oracle's 1000-item IN-list limit (**ORA-01795**) — which an alternative "re-inject positions as a literal list" approach did hit during testing.
- The small Redshift project-names lookup stays on `OPENQUERY` (tiny static query, different server).

Net diff: **11 insertions / 11 deletions**.

## ⚠️ Deployment prerequisite

`EXEC ... AT` requires **`rpc out = true`** on the linked server (`OPENQUERY` only needs `data access`). This is server-level config **outside the DACPAC**, so it must be set per-environment:

```sql
EXEC sp_serveroption '[AIT_BISTG_PRD-CAES_HCMODS_APPUSER]', 'rpc out', 'true';
```

Check with:
```sql
SELECT name, is_rpc_out_enabled FROM sys.servers WHERE name = 'AIT_BISTG_PRD-CAES_HCMODS_APPUSER';
```

**Please enable `rpc out` in Test and Prod before/at deploy** (it's already enabled in Dev).

## Testing

Validated live against Dev with a ~600-project faculty portfolio that previously triggered the 8000-char error — the proc now executes and returns rows. (Couldn't run `dotnet build` locally due to an unrelated SDK/`NuGet.Build.Tasks.Pack.targets` environment issue.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)