### PR TITLE
Return diff results via SELECT instead of OUTPUT params

### DIFF
--- a/datamart/StoredProcedures/usp_DiffTransactionalListing.sql
+++ b/datamart/StoredProcedures/usp_DiffTransactionalListing.sql
@@ -1,10 +1,10 @@
 -- <summary>
 -- Computes the set of chart strings whose aggregates (row count + amount sums)
 -- differ between Walter's current TransactionalListing and the live source on
--- Redshift. Emits a count and a quoted IN-list string for use as a Fabric
--- pipeline parameter. The full-outer-join classifies a chart string as
--- changed if it is new in source, missing from source (deleted), or has any
--- aggregate divergence.
+-- Redshift. Returns a single-row result set with the count and a quoted
+-- IN-list string -- consumed by a Fabric Lookup activity. The full-outer-join
+-- classifies a chart string as changed if it is new in source, missing from
+-- source (deleted), or has any aggregate divergence.
 --
 -- Source aggregates are pulled via OPENQUERY against [AE_Redshift_PROD]. The
 -- query is static and produces one row per chart string (~98K rows for ~2.2M
@@ -16,15 +16,13 @@
 -- sproc does no first-run handling.
 -- </summary>
 create procedure dbo.usp_DiffTransactionalListing
-    @ChangedChartStringCount   int           output,
-    @ChangedChartStringsInList nvarchar(max) output
 as
 begin
     set nocount on;
     set xact_abort on;
 
-    set @ChangedChartStringCount   = 0;
-    set @ChangedChartStringsInList = N'';
+    declare @ChangedChartStringCount   int           = 0;
+    declare @ChangedChartStringsInList nvarchar(max) = N'';
 
     declare @SourceAggs table
     (
@@ -87,5 +85,9 @@ begin
 
     if @ChangedChartStringsInList is null
         set @ChangedChartStringsInList = N'';
+
+    select
+        @ChangedChartStringCount   as ChangedChartStringCount,
+        @ChangedChartStringsInList as ChangedChartStringsInList;
 end
 go


### PR DESCRIPTION
## Summary
- Replaces `usp_DiffTransactionalListing`'s `@ChangedChartStringCount` / `@ChangedChartStringsInList` OUTPUT params with a single-row SELECT result set.
- The values are unchanged; only the calling convention changes.

## Why
The companion Fabric pipeline reads these values via a Lookup activity (`output.firstRow.ChangedChartStringCount`, `.ChangedChartStringsInList`). Lookup is the documented pattern for capturing query/sproc results in Fabric; the SqlServerStoredProcedure activity's OUTPUT-param handling is inconsistent across versions and wasn't safe to depend on.

## Pairs with
The forthcoming PR against `ucdavis/Datamart` adds the `Lookup TL Diff WalterDev` activity that consumes this SELECT.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized the transactional listing comparison procedure to use a standardized result-set approach, enhancing data consistency and system reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ucdavis/Walter/pull/285?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->