### PR TITLE
Fix usp_GetProjectSummary 8000-char query limit (OPENQUERY → EXEC ... AT)

### DIFF
--- a/datamart/StoredProcedures/usp_GetProjectSummary.sql
+++ b/datamart/StoredProcedures/usp_GetProjectSummary.sql
@@ -27,7 +27,6 @@ BEGIN
 
     DECLARE @RedshiftQuery NVARCHAR(MAX);
     DECLARE @TSQLCommand NVARCHAR(MAX);
-    DECLARE @RedshiftLinkedServer SYSNAME = '[AE_Redshift_PROD]';
     DECLARE @FilterClause NVARCHAR(MAX) = '';
     DECLARE @StartTime DATETIME2 = SYSDATETIME();
     DECLARE @RowCount INT;
@@ -72,16 +71,16 @@ BEGIN
         SELECT
             b.project_number, b.award_number,
             b.close_date AS award_close_date,
-            LISTAGG(DISTINCT a.principal_investigator_person_name, ''; '') WITHIN GROUP (ORDER BY 1) AS award_pi,
+            CAST(LISTAGG(DISTINCT a.principal_investigator_person_name, ''; '') WITHIN GROUP (ORDER BY 1) AS VARCHAR(4000)) AS award_pi,
             b.billing_cycle,
             b.project_burden_schedule_base,
             b.project_burden_cost_rate,
             b.cost_share_required_by_sponsor,
-            LISTAGG(DISTINCT a.grant_administrator, ''; '') WITHIN GROUP (ORDER BY 1) AS grant_administrator,
+            CAST(LISTAGG(DISTINCT a.grant_administrator, ''; '') WITHIN GROUP (ORDER BY 1) AS VARCHAR(4000)) AS grant_administrator,
             b.postrepperiod AS post_reporting_period,
             b.primary_sponsor_name,
-            '''' AS project_fund,
-            LISTAGG(DISTINCT a.contractadmin, ''; '') WITHIN GROUP (ORDER BY 1) AS contract_administrator,
+            CAST('''' AS VARCHAR(10)) AS project_fund,
+            CAST(LISTAGG(DISTINCT a.contractadmin, ''; '') WITHIN GROUP (ORDER BY 1) AS VARCHAR(4000)) AS contract_administrator,
             b.sponsor_award_number,
             b.flow_through_funds_primary_sponsor,
             b.flow_through_funds_reference_award_name,
@@ -111,10 +110,37 @@ BEGIN
     );
 
     BEGIN TRY
-        -- Fetch award metadata from Redshift into temp table, then join with local FacultyDeptPortfolio
-        SET @TSQLCommand = '
-            SELECT * INTO #pgm FROM OPENQUERY(' + @RedshiftLinkedServer + ', ''' + REPLACE(@RedshiftQuery, '''', '''''') + ''');
+        -- Fetch award metadata from Redshift into a temp table, then join with local FacultyDeptPortfolio.
+        -- #pgm is pre-created with an explicit column list because INSERT ... EXEC cannot use SELECT INTO.
+        -- The Redshift query is sent via EXEC ... AT (RPC), whose query text has no 8000-character limit.
+        -- [AE_Redshift_PROD] must have rpc out = true and remote proc transaction promotion = false.
+        CREATE TABLE #pgm (
+            project_number                          NVARCHAR(50),
+            award_number                            NVARCHAR(240),
+            award_close_date                        DATE,
+            award_pi                                NVARCHAR(4000),
+            billing_cycle                           NVARCHAR(100),
+            project_burden_schedule_base            NVARCHAR(60),
+            project_burden_cost_rate                NUMERIC(22, 5),
+            cost_share_required_by_sponsor          NVARCHAR(4),
+            grant_administrator                     NVARCHAR(4000),
+            post_reporting_period                   NVARCHAR(160),
+            primary_sponsor_name                    NVARCHAR(720),
+            project_fund                            NVARCHAR(10),
+            contract_administrator                  NVARCHAR(4000),
+            sponsor_award_number                    NVARCHAR(60),
+            flow_through_funds_primary_sponsor      NVARCHAR(720),
+            flow_through_funds_reference_award_name NVARCHAR(200),
+            flow_through_funds_start_date           DATE,
+            flow_through_funds_end_date             DATE,
+            flow_through_funds_amount               NUMERIC(38, 2)
+        );
 
+        INSERT INTO #pgm
+        EXEC (@RedshiftQuery) AT [AE_Redshift_PROD];
+
+        -- Join the Redshift award metadata with the local FacultyDeptPortfolio.
+        SET @TSQLCommand = '
             SELECT f.AwardNumber AS AWARD_NUMBER, f.AwardName AS AWARD_NAME, f.AwardType AS AWARD_TYPE,
                 f.AwardStartDate AS AWARD_START_DATE, f.AwardEndDate AS AWARD_END_DATE, f.AwardStatus AS AWARD_STATUS,
                 f.ProjectNumber AS PROJECT_NUMBER, f.ProjectName AS PROJECT_NAME,


### PR DESCRIPTION
## Problem

`usp_GetProjectSummary` builds its award-metadata query dynamically and runs it against the Redshift linked server (`[AE_Redshift_PROD]`). The query was embedded as a **string literal inside `OPENQUERY`**, which caps the query text at **8000 characters**. For large project sets — e.g. a ~600-project faculty portfolio — the interpolated `@ProjectIdFilter` pushed the literal over 8000 chars and the proc failed in Prod (audit log 2026-05-27):

> The character string that starts with `'WITH ranked AS ( SELECT *, ...'` is too long. Maximum length is 8000.

This is the same failure mode #281 fixed for `usp_GetPositionBudgets` — applied here to the **Redshift** path (#281 deliberately left Redshift on `OPENQUERY` because its query there was small; here the project filter makes it large).

## Fix

Switch the Redshift call from `OPENQUERY(...)` to:

```sql
INSERT INTO #pgm
EXEC (@RedshiftQuery) AT [AE_Redshift_PROD];
```

`EXEC ... AT` sends the query to the linked server as an **RPC parameter**, so it's not subject to the 8000-char literal cap.

- **Query body is unchanged** → identical results, no logic change.
- `#pgm` is now **pre-created with an explicit column list** because `INSERT ... EXEC` can't use `SELECT INTO`. Column types match those SQL Server inferred from the previous `OPENQUERY` (verified by inspecting `tempdb.sys.columns`).
- The three `LISTAGG` columns and the `project_fund` literal are `CAST` to **bounded `VARCHAR`** in Redshift. `INSERT ... EXEC` can't stream the unbounded (LOB/`ntext`) types the provider otherwise returns — that produced `Multiple-step OLE DB operation generated errors` via the `STREAM` provider. They're PI/admin **names**, comfortably under the 4000-char bound.

## ⚠️ Deployment prerequisite

Unlike #281 (Oracle, one option), the Redshift linked server needs **two** server-level options (config **outside the DACPAC**, so set per-environment):

```sql
EXEC sp_serveroption '[AE_Redshift_PROD]', 'rpc out', 'true';
EXEC sp_serveroption '[AE_Redshift_PROD]', 'remote proc transaction promotion', 'false';
```

`rpc out` allows `EXEC ... AT`. `remote proc transaction promotion = false` prevents SQL Server from promoting the RPC into an MS DTC distributed transaction, which the Redshift ODBC provider (`MSDASQL`) can't enlist in (`unable to begin a distributed transaction`).

Check with:
```sql
SELECT name, is_rpc_out_enabled FROM sys.servers WHERE name = 'AE_Redshift_PROD';
```


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data handling and formatting for project summary information to ensure consistent and reliable data type processing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ucdavis/Walter/pull/286?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->