### PR TITLE
AE DWH loader: pass changed chart strings via a table, fix 9829 overflow

### DIFF
--- a/datamart/StoredProcedures/usp_DiffTransactionalListing.sql
+++ b/datamart/StoredProcedures/usp_DiffTransactionalListing.sql
@@ -1,8 +1,9 @@
 -- <summary>
 -- Computes the set of chart strings whose aggregates (row count + amount sums)
 -- differ between Walter's current TransactionalListing and the live source on
--- Redshift. Emits a count and a quoted IN-list string for use as a Fabric
--- pipeline parameter. The full-outer-join classifies a chart string as
+-- Redshift, persists them to dbo.TransactionalListing_ChangedKeys, and returns
+-- a count + quoted IN-list string as a single-row result set for the Fabric
+-- pipeline Lookup activity. The full-outer-join classifies a chart string as
 -- changed if it is new in source, missing from source (deleted), or has any
 -- aggregate divergence.
 --
@@ -12,19 +13,20 @@
 -- rows query (with the potentially large dynamic IN-list) is executed by the
 -- Fabric Copy activity using the IR's direct Redshift connection.
 --
+-- The changed keys are written to dbo.TransactionalListing_ChangedKeys so the
+-- later usp_SwapTransactionalListing can read them directly rather than re-
+-- parsing a string parameter. The returned IN-list is for the Copy activity
+-- only; quotename output is cast to nvarchar(max) before string_agg so the
+-- aggregate does not overflow at high cardinality (the cause of error 9829).
+--
 -- Initial bulk load of dbo.TransactionalListing is performed offline. This
 -- sproc does no first-run handling.
 -- </summary>
 create procedure dbo.usp_DiffTransactionalListing
-    @ChangedChartStringCount   int           output,
-    @ChangedChartStringsInList nvarchar(max) output
 as
 begin
     set nocount on;
     set xact_abort on;
-
-    set @ChangedChartStringCount   = 0;
-    set @ChangedChartStringsInList = N'';
 
     declare @SourceAggs table
     (
@@ -57,6 +59,8 @@ begin
         group by 1
     ');
 
+    truncate table dbo.TransactionalListing_ChangedKeys;
+
     with WalterAggs as
     (
         select
@@ -80,12 +84,22 @@ begin
            or w.SumCommitment   <> s.SumCommitment
            or w.SumObligation   <> s.SumObligation
     )
+    insert into dbo.TransactionalListing_ChangedKeys (ChartStringKey)
+    select ChartStringKey from Changed;
+
+    declare @ChangedChartStringCount   int           = 0;
+    declare @ChangedChartStringsInList nvarchar(max) = N'';
+
     select
         @ChangedChartStringCount   = count(*),
-        @ChangedChartStringsInList = string_agg(quotename(ChartStringKey, ''''), ',')
-    from Changed;
+        @ChangedChartStringsInList = string_agg(cast(quotename(ChartStringKey, '''') as nvarchar(max)), ',')
+    from dbo.TransactionalListing_ChangedKeys;
 
     if @ChangedChartStringsInList is null
         set @ChangedChartStringsInList = N'';
+
+    select
+        @ChangedChartStringCount   as ChangedChartStringCount,
+        @ChangedChartStringsInList as ChangedChartStringsInList;
 end
 go

--- a/datamart/StoredProcedures/usp_SwapTransactionalListing.sql
+++ b/datamart/StoredProcedures/usp_SwapTransactionalListing.sql
@@ -1,45 +1,32 @@
 -- <summary>
--- Atomically replaces all rows for the given chart strings in
+-- Atomically replaces all rows for the changed chart strings in
 -- dbo.TransactionalListing with the rows currently in
 -- dbo.TransactionalListing_Staging.
 --
--- @ChangedChartStringsInList carries the same quoted, comma-separated string
--- emitted by usp_DiffTransactionalListing (format: 'cs1','cs2','cs3'). The list
--- is parsed back to a relation via STRING_SPLIT so we can DELETE by an indexed
--- join rather than a literal IN-clause that could exceed parser limits at
--- high cardinality.
+-- The set of chart strings to replace is read from
+-- dbo.TransactionalListing_ChangedKeys (populated by usp_DiffTransactionalListing
+-- earlier in the same pipeline run) -- no string parameter / STRING_SPLIT needed.
 --
--- Deleted chart strings (present in the list but absent from staging, because
--- the source no longer has any rows for them) are removed by the DELETE step.
--- The INSERT step naturally skips them because staging contains no rows for
--- those chart strings. Atomicity is enforced by SET XACT_ABORT ON and a
--- single explicit transaction.
+-- Deleted chart strings (in ChangedKeys but absent from staging, because the
+-- source no longer has rows for them) are removed by the DELETE step; the INSERT
+-- naturally skips them because staging has no rows for those keys. Atomicity is
+-- enforced by SET XACT_ABORT ON and a single explicit transaction.
 -- </summary>
 create procedure dbo.usp_SwapTransactionalListing
-    @ChangedChartStringsInList nvarchar(max)
 as
 begin
     set nocount on;
     set xact_abort on;
 
-    if @ChangedChartStringsInList is null or len(@ChangedChartStringsInList) = 0
+    if not exists (select 1 from dbo.TransactionalListing_ChangedKeys)
         return;
-
-    declare @ChartStringsToReplace table
-    (
-        ChartStringKey nvarchar(200) not null primary key
-    );
-
-    insert into @ChartStringsToReplace (ChartStringKey)
-    select trim('''' from value)
-    from string_split(@ChangedChartStringsInList, ',')
-    where len(value) > 0;
 
     begin transaction;
 
     delete tl
     from dbo.TransactionalListing tl
-    inner join @ChartStringsToReplace c on c.ChartStringKey = tl.ChartStringKey;
+    inner join dbo.TransactionalListing_ChangedKeys c
+        on c.ChartStringKey = tl.ChartStringKey;
 
     insert into dbo.TransactionalListing
     (

--- a/datamart/Tables/Staging/TransactionalListing_ChangedKeys.sql
+++ b/datamart/Tables/Staging/TransactionalListing_ChangedKeys.sql
@@ -1,0 +1,13 @@
+-- Run-scoped set of chart strings whose source aggregates diverge from
+-- Walter's current TransactionalListing. usp_DiffTransactionalListing truncates
+-- and repopulates this table each pipeline run, then usp_SwapTransactionalListing
+-- reads it to know which chart strings to delete-and-replace. Passing the key
+-- set through a table (rather than a quoted nvarchar(max) IN-list parameter)
+-- avoids STRING_SPLIT round-trips and parser limits at high cardinality.
+CREATE TABLE dbo.TransactionalListing_ChangedKeys
+(
+    ChartStringKey NVARCHAR(200) NOT NULL,
+    CONSTRAINT PK_TransactionalListing_ChangedKeys
+        PRIMARY KEY CLUSTERED (ChartStringKey)
+);
+GO


### PR DESCRIPTION
## What

Reworks the AE Data Warehouse loader's diff/swap stored procedures so the set of changed chart strings is passed between them through a run-scoped table instead of a quoted `nvarchar(max)` IN-list string, and so the diff proc returns its results as a **result set** rather than OUTPUT parameters.

This supersedes the earlier abandoned approach in closed #285 (which only adjusted the diff proc's return shape).

## Why

On change sets with ~160+ changed chart strings, the pipeline hit **SQL error 9829** — the `string_agg(quotename(...), ',')` IN-list overflowed because the aggregate input wasn't `nvarchar(max)`, and the oversized string then had to be re-parsed via `STRING_SPLIT` in the swap proc.

## Changes

- **New** `dbo.TransactionalListing_ChangedKeys` (`Tables/Staging/`) — run-scoped table holding the changed chart strings; the contract between the two procs.
- **`usp_DiffTransactionalListing`** — drops the two OUTPUT params; truncates + populates `ChangedKeys` from the full-outer-join diff (OPENQUERY source-aggregate logic unchanged); returns `ChangedChartStringCount` + `ChangedChartStringsInList` as a single-row result set for the Fabric Lookup activity. `quotename()` is cast to `nvarchar(max)` before `string_agg` — the 9829 fix.
- **`usp_SwapTransactionalListing`** — drops the `@ChangedChartStringsInList` parameter and reads keys directly from `ChangedKeys` (no `STRING_SPLIT`); empty-set guard, DELETE-join, and INSERT-from-staging logic unchanged.

No grant changes (post-deploy grants already cover both procs; names unchanged). No index changes (`IX_TransactionalListing_ChartStringKey` already exists).

## Verification

- `dotnet build` succeeds (0 warnings, 0 errors).
- Post-deploy (requires a deployed DB, not done here): run `exec dbo.usp_DiffTransactionalListing`, confirm `ChangedKeys` row count matches the returned count, then run `pl_AEDatamartLoader` against a change set that previously triggered 9829 (>~160 chart strings) and confirm the Lookup, staging copy, and Swap all succeed with new/modified/deleted keys reflected correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured transactional listing procedures for improved efficiency and optimized data flow.
  * Redesigned output handling mechanisms for simplified integration.

* **Bug Fixes**
  * Enhanced data aggregation logic to handle large datasets without overflow conditions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ucdavis/Walter/pull/287?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->