### PR TITLE
Fix error 1088: grant pipeline role perms on TransactionalListing_ChangedKeys

### DIFF
--- a/datamart/Scripts/Script.PostDeployment.sql
+++ b/datamart/Scripts/Script.PostDeployment.sql
@@ -46,6 +46,7 @@ GRANT INSERT, SELECT, UPDATE, DELETE ON [dbo].[PositionBudgets_Staging] TO [Walt
 GRANT EXECUTE ON [dbo].[usp_SwapPositionBudgets] TO [WalterPipelineRole];
 GRANT INSERT, SELECT, UPDATE, DELETE ON [dbo].[TransactionalListing] TO [WalterPipelineRole];
 GRANT INSERT, SELECT, UPDATE, DELETE ON [dbo].[TransactionalListing_Staging] TO [WalterPipelineRole];
+GRANT INSERT, SELECT, DELETE ON [dbo].[TransactionalListing_ChangedKeys] TO [WalterPipelineRole];
 GRANT EXECUTE ON [dbo].[usp_DiffTransactionalListing] TO [WalterPipelineRole];
 GRANT EXECUTE ON [dbo].[usp_SwapTransactionalListing] TO [WalterPipelineRole];
 

--- a/datamart/StoredProcedures/usp_DiffTransactionalListing.sql
+++ b/datamart/StoredProcedures/usp_DiffTransactionalListing.sql
@@ -59,7 +59,10 @@ begin
         group by 1
     ');
 
-    truncate table dbo.TransactionalListing_ChangedKeys;
+    -- Must stay a DELETE: the pipeline role has only EXECUTE on this proc, and
+    -- ownership chaining covers DML but not TRUNCATE (which needs ALTER on the
+    -- table). A TRUNCATE here fails for the pipeline role with error 1088.
+    delete from dbo.TransactionalListing_ChangedKeys;
 
     with WalterAggs as
     (


### PR DESCRIPTION
## Problem

After #287 merged, the AE DWH loader pipeline failed at runtime:

```
SqlErrorNumber=1088 ... Cannot find the object "TransactionalListing_ChangedKeys"
because it does not exist or you do not have permissions.
```

`WalterPipelineRole` had no permissions on the new `TransactionalListing_ChangedKeys` table, and the diff proc cleared it with `TRUNCATE` — which requires `ALTER` on the table and is **not** covered by ownership chaining, so it surfaced as the 1088 "no permissions" error.

## Fix

- **Explicit grant**: `GRANT INSERT, SELECT, DELETE ON [dbo].[TransactionalListing_ChangedKeys] TO [WalterPipelineRole]` in `Script.PostDeployment.sql`, matching the explicit per-table grants the role already has for the other pipeline tables.
- **Clear with `DELETE` not `TRUNCATE`** in `usp_DiffTransactionalListing`, so the grant stays least-privilege (`DELETE` rather than the broader `ALTER` that `TRUNCATE` would require).

## Verification

- `dotnet build` succeeds (0 warnings, 0 errors).
- After deploy, re-run the pipeline (the Copy activity that executes `usp_DiffTransactionalListing` as its source) and confirm it no longer raises 1088.

🤖 Generated with [Claude Code](https://claude.com/claude-code)