### PR TITLE
Fix usp_ParseProjectIdFilter 8000-byte STRING_AGG truncation

### DIFF
--- a/datamart/StoredProcedures/usp_ParseProjectIdFilter.sql
+++ b/datamart/StoredProcedures/usp_ParseProjectIdFilter.sql
@@ -35,7 +35,10 @@ BEGIN
     DEALLOCATE ProjectCursor;
 
     -- Build IN clause filter string (e.g., 'K30GS7777','K30GS8888')
-    SELECT @ProjectIdFilter = STRING_AGG('''' + ProjectId + '''', ',')
+    -- CAST the element to NVARCHAR(MAX) so STRING_AGG returns a LOB result; with a non-MAX
+    -- input the aggregate caps at 8000 bytes and silently truncates large project lists,
+    -- producing a malformed IN clause.
+    SELECT @ProjectIdFilter = STRING_AGG(CAST('''' + ProjectId + '''' AS NVARCHAR(MAX)), ',')
     FROM @ValidatedProjects;
 END;
 GO


### PR DESCRIPTION
## Problem

`dbo.usp_GetProjectSummary` failed in production with:

> Could not execute statement on remote server 'AE_Redshift_PROD'.

when called with ~1800 project IDs (see execution log 64100). The failure is **not** in the OPENQUERY/EXEC-AT path that #286 fixed — it's one layer down in `usp_ParseProjectIdFilter`, which builds the `IN (...)` clause shared by all project-summary sprocs.

## Root cause

`STRING_AGG` derives its result type from its input. The input here —
`'''' + ProjectId + ''''` where `ProjectId` is `VARCHAR(15)` — is **non-MAX**, so the aggregate result is capped at **8000 bytes** and silently truncates.

Every Aggie Enterprise project ID is 10 chars, contributing 13 bytes to the filter (`'id',`). The IN clause therefore overflows past ~615 IDs and is cut off **mid-literal** (e.g. `...,'K30AB`). That malformed clause is embedded into the remote Redshift query, which then fails.

The production log confirms the parse returned (truncated) rather than erroring: the failure was recorded from the proc's `CATCH` block, which sits *after* the parse call.

## Fix

CAST the element to `NVARCHAR(MAX)` so `STRING_AGG` returns a LOB result with no 8000-byte cap. One-line, centralized in the parse proc, so **every** caller benefits.

## Scope

This PR fixes only the central parse function — it resolves the reported `usp_GetProjectSummary` incident.

The sibling sprocs (`usp_GetGLTransactionListings`, `usp_GetGLPPMReconciliation`, `usp_GetPositionBudgets`, `usp_GetGLProjectSummaryElzar`, `usp_GetFacultyDeptPortfolio[Elzar]`, `usp_GetPPMProjectSummaryElzar`) still wrap their remote query in `OPENQUERY(..., '<literal>')`, which has its own 8000-char limit (#286 converted only `usp_GetProjectSummary` to `EXEC ... AT`). They are not called with project lists large enough to hit that today, so they are intentionally left for a follow-up.

## Testing

Local DACPAC build is blocked by an unrelated toolchain mismatch (`Microsoft.Build.Sql` 1.0.0 vs dotnet SDK 10.0.101); relying on CI to build. After deploy, feeding >615 valid IDs to the proc should yield a filter of full length with a clean terminating literal rather than one pinned at ~8000 bytes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where large project lists could be truncated during processing, ensuring all projects are handled correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->