### PR TITLE
Fix double FTE division in usp_GetPositionBudgetsLocal

### DIFF
--- a/datamart/StoredProcedures/usp_GetPositionBudgetsLocal.sql
+++ b/datamart/StoredProcedures/usp_GetPositionBudgetsLocal.sql
@@ -90,15 +90,11 @@ BEGIN
             pb.JobEffectiveDate AS JOB_EFFECTIVE_DATE,
             pb.JobEffectiveSequence AS JOB_SEQUENCE,
             pb.EmployeeId AS EMPLOYEE_ID,
-            -- MonthlyRate is stored as-loaded from PS_JOB_V and is inconsistent across comp
-            -- frequencies:
-            --   Hourly (H): already the 1.0 FTE monthly equivalent (hourly_rate * std_hours)
-            --   All others (UC_FY, UC_9M, M, etc.): FTE-adjusted (actual pay, not 1.0 FTE rate)
-            -- Normalize to 1.0 FTE so the client can compute actual salary as MONTHLY_RATE * FTE
-            CASE
-                WHEN pb.CompFrequency = 'H' THEN pb.MonthlyRate
-                ELSE pb.MonthlyRate / NULLIF(pb.Fte, 0)
-            END AS MONTHLY_RATE,
+            -- MonthlyRate in dbo.PositionBudgets is already the 1.0-FTE monthly rate (the ETL
+            -- lands the normalized figure, unlike PS_JOB_V.MONTHLY_RT which the live proc must
+            -- divide by FTE). Return it as-is so the client computes actual salary as
+            -- MONTHLY_RATE * FTE, matching usp_GetPositionBudgets's output.
+            pb.MonthlyRate AS MONTHLY_RATE,
             pb.ExpectedEndDate AS JOB_END_DATE,
             pb.Fte AS FTE,
             pb.Name AS NAME,


### PR DESCRIPTION
## Summary

Follow-up to #291. `usp_GetPositionBudgetsLocal` was dividing `MonthlyRate` by `FTE`, but the ETL already lands the **1.0-FTE** rate in `dbo.PositionBudgets.MonthlyRate` (unlike Oracle `PS_JOB_V.MONTHLY_RT`, which is FTE-adjusted and *must* be divided by the live proc). The local proc was effectively dividing by FTE a second time, inflating `MONTHLY_RATE` by `1/FTE`.

Fix: return `MonthlyRate` as-is so output matches `usp_GetPositionBudgets`.

## Evidence (project `SP0A252322`)

| Position | FTE | Raw `MonthlyRate` | Prod (live) | Local **before** | Local **after** |
|---|---|---|---|---|---|
| 40980766 | 0.50 | 6955.92 | 6955.916 | 13911.84 ❌ | 6955.92 ✅ |
| 41207341 | 0.25 | 5991.24 | 5991.252 | 23964.96 ❌ | 5991.24 ✅ |

(Sub-cent differences vs prod are `DECIMAL(12,2)` rounding.)

## Note

This intentionally diverges from `usp_GetPositionBudgets`'s `CASE … / NULLIF(FTE,0)` logic, because the two procs have different inputs: the live proc reads FTE-adjusted pay and de-prorates; the local table is already de-prorated. Verified against UC_FY rows; assumes the ETL normalizes all comp frequencies (incl. hourly) — worth a spot-check on an hourly position.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected position budget monthly rate calculations in position reports. The system now returns the standardized 1.0-FTE monthly rate directly from the data pipeline without applying unnecessary conditional adjustments. This ensures consistent, predictable results across all compensation structures and aligns calculations with client expectations and related reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->