### PR TITLE
Re-include four CA&ES carryforward ASNs in GL/PPM reconciliation

### DIFF
--- a/datamart/StoredProcedures/usp_GetGLPPMReconciliation.sql
+++ b/datamart/StoredProcedures/usp_GetGLPPMReconciliation.sql
@@ -59,7 +59,7 @@ BEGIN
               acc.parent_level_0_code NOT LIKE ''3%''
               OR (tlr.PERIOD_NAME = ''Jul-23'' AND tlr.ACCOUNTING_SEQUENCE_NUMBER IN (''100009'',''100010'',''100307'',''103283'',''103284''))
               OR (tlr.PERIOD_NAME = ''Apr-24'' AND tlr.JOURNAL_SOURCE = ''UCD Conversion'' AND tlr.JOURNAL_CATEGORY = ''UCD Conversion'')
-              OR tlr.ACCOUNTING_SEQUENCE_NUMBER IN (''292363'',''338926'',''341705'',''341722'',''398465'',''413247'',''419608'',''434173'')
+              OR tlr.ACCOUNTING_SEQUENCE_NUMBER IN (''173421'',''288176'',''292363'',''338926'',''341705'',''341722'',''398465'',''413247'',''419608'',''434173'',''438836'',''441285'')
           )
         GROUP BY tlr.FINANCIAL_DEPARTMENT, tlr.PROJECT, tlr.PROJECT_DESCRIPTION, tlr.FUND, tlr.FUND_DESCRIPTION, tlr.PROGRAM, tlr.PROGRAM_DESCRIPTION, tlr.ACTIVITY, tlr.ACTIVITY_DESCRIPTION';
 

--- a/datamart/StoredProcedures/usp_GetGLTransactionListings.sql
+++ b/datamart/StoredProcedures/usp_GetGLTransactionListings.sql
@@ -83,7 +83,7 @@ BEGIN
             acc.parent_level_0_code NOT LIKE ''3%''
             OR (tlr.PERIOD_NAME = ''Jul-23'' AND tlr.ACCOUNTING_SEQUENCE_NUMBER IN (''100009'',''100010'',''100307'',''103283'',''103284''))
             OR (tlr.PERIOD_NAME = ''Apr-24'' AND tlr.JOURNAL_SOURCE = ''UCD Conversion'' AND tlr.JOURNAL_CATEGORY = ''UCD Conversion'')
-            OR tlr.ACCOUNTING_SEQUENCE_NUMBER IN (''292363'',''338926'',''341705'',''341722'',''398465'',''413247'',''419608'',''434173'')
+            OR tlr.ACCOUNTING_SEQUENCE_NUMBER IN (''173421'',''288176'',''292363'',''338926'',''341705'',''341722'',''398465'',''413247'',''419608'',''434173'',''438836'',''441285'')
         )';
 
     SET @FilterClause = @FilterClause + ' AND tlr.PERIOD_NAME <> ''Jun-23''';


### PR DESCRIPTION
Adds accounting sequence numbers `173421`, `288176`, `438836`, and `441285` to the hardcoded re-include list that exempts specific CA&ES carryforward journals from the 3XXXXXX exclusion in GL/PPM reconciliation.

Both synced sprocs are updated in lockstep:
- `usp_GetGLPPMReconciliation`
- `usp_GetGLTransactionListings`

The four new values are merged into the existing list, numerically sorted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated data filtering configuration in general ledger reconciliation and transaction listing reports for improved accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->