### PR TITLE
employeeid -> iamID

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -44,8 +44,29 @@ _Avoid_: Admin report, manager report
 A user role whose members can inspect accrual reporting and receive the monthly **Accrual Viewer Report**.
 _Avoid_: Admin, viewer
 
+**Person**:
+A campus identity that may be associated with employee, student, external, and contact information. A **Person** is distinct from a Walter user account and from a project role such as Principal Investigator or Project Manager.
+_Avoid_: Walter Person, Employee, User
+
+**IAM ID**:
+The stable campus identity identifier Walter uses when referring to a **Person** in navigation and client-facing person lookups.
+_Avoid_: Employee ID, directory ID
+
+**Employee ID**:
+The employment identifier Walter uses only when a downstream financial or personnel source requires it for a **Person**.
+_Avoid_: IAM ID, public person identifier
+
+**Searchable Person**:
+A **Person** Walter can include in people search because they have both an **IAM ID** and an **Employee ID**.
+_Avoid_: Directory user, employee-only result
+
 ## Relationships
 
+- Walter refers to a **Person** by **IAM ID** in navigation and client-facing person lookups
+- Walter uses **Employee ID** only when a downstream source requires an employment identifier
+- A **Person** can be displayed from downstream project or personnel data without being navigable when Walter cannot identify their **IAM ID**
+- Project lookup can navigate to a **Person** only when Walter can identify their **IAM ID**
+- People search includes **Searchable People**
 - An **Accrual Snapshot** classifies each employee as active, **Approaching Cap**, or **At Cap**
 - An **Accrual Snapshot** identifies the employee recipient email for each employee row
 - Employees who are **Approaching Cap** or **At Cap** are eligible for accrual notifications

--- a/datamart/Scripts/Script.PostDeployment.sql
+++ b/datamart/Scripts/Script.PostDeployment.sql
@@ -24,6 +24,7 @@ GRANT EXECUTE ON [dbo].[usp_GetGLTransactionListings] TO [WalterAppRole];
 GRANT EXECUTE ON [dbo].[usp_GetLaborLedgerData] TO [WalterAppRole];
 GRANT EXECUTE ON [dbo].[usp_GetPositionBudgets] TO [WalterAppRole];
 GRANT EXECUTE ON [dbo].[usp_GetPositionBudgetsLocal] TO [WalterAppRole];
+GRANT EXECUTE ON [dbo].[usp_GetSearchablePeople] TO [WalterAppRole];
 GRANT EXECUTE ON [dbo].[usp_HealthCheck_Connectivity] TO [WalterAppRole];
 GRANT EXECUTE ON [dbo].[usp_HealthCheck_RowCounts] TO [WalterAppRole];
 GRANT EXECUTE ON [dbo].[usp_HealthCheck_SchemaValidation] TO [WalterAppRole];

--- a/datamart/StoredProcedures/usp_GetSearchablePeople.sql
+++ b/datamart/StoredProcedures/usp_GetSearchablePeople.sql
@@ -1,0 +1,119 @@
+-- Returns People records that Walter can navigate by IAM ID and join to downstream Employee ID data.
+CREATE PROCEDURE dbo.usp_GetSearchablePeople
+    @SearchQuery NVARCHAR(128) = NULL,
+    @IamId NVARCHAR(10) = NULL,
+    @EmployeeId NVARCHAR(8) = NULL,
+    @EmployeeIds VARCHAR(MAX) = NULL,
+    @Email NVARCHAR(128) = NULL,
+    @Limit INT = 100
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    DECLARE @NormalizedSearchQuery NVARCHAR(128) = NULLIF(LTRIM(RTRIM(@SearchQuery)), N'');
+    DECLARE @NormalizedIamId NVARCHAR(10) = NULLIF(LTRIM(RTRIM(@IamId)), N'');
+    DECLARE @NormalizedEmployeeId NVARCHAR(8) = NULLIF(LTRIM(RTRIM(@EmployeeId)), N'');
+    DECLARE @NormalizedEmployeeIds VARCHAR(MAX) = NULLIF(LTRIM(RTRIM(@EmployeeIds)), '');
+    DECLARE @NormalizedEmail NVARCHAR(128) = NULLIF(LOWER(LTRIM(RTRIM(@Email))), N'');
+    DECLARE @LikeQuery NVARCHAR(130);
+    DECLARE @StartsWithQuery NVARCHAR(129);
+    DECLARE @ResultLimit INT = 2147483647;
+    DECLARE @CanReturnRows BIT = 0;
+
+    IF @NormalizedSearchQuery IS NOT NULL
+    BEGIN
+        IF LEN(@NormalizedSearchQuery) < 3 OR ISNULL(@Limit, 0) <= 0
+        BEGIN
+            SELECT
+                CAST(NULL AS NVARCHAR(10)) AS IamId,
+                CAST(NULL AS NVARCHAR(8)) AS EmployeeId,
+                CAST(NULL AS NVARCHAR(128)) AS Name,
+                CAST(NULL AS NVARCHAR(128)) AS Email
+            WHERE 1 = 0;
+            RETURN;
+        END;
+
+        SET @LikeQuery = N'%' + @NormalizedSearchQuery + N'%';
+        SET @StartsWithQuery = @NormalizedSearchQuery + N'%';
+        SET @ResultLimit = CASE WHEN @Limit > 100 THEN 100 ELSE @Limit END;
+        SET @CanReturnRows = 1;
+    END;
+
+    IF @NormalizedIamId IS NOT NULL
+       OR @NormalizedEmployeeId IS NOT NULL
+       OR @NormalizedEmployeeIds IS NOT NULL
+       OR @NormalizedEmail IS NOT NULL
+    BEGIN
+        SET @CanReturnRows = 1;
+    END;
+
+    WITH NormalizedPeople AS (
+        SELECT
+            NULLIF(LTRIM(RTRIM(IamId)), '') AS IamId,
+            NULLIF(LTRIM(RTRIM(EmployeeId)), '') AS EmployeeId,
+            NULLIF(LTRIM(RTRIM(FirstName)), '') AS FirstName,
+            NULLIF(LTRIM(RTRIM(LastName)), '') AS LastName,
+            NULLIF(LTRIM(RTRIM(FullName)), '') AS FullName,
+            NULLIF(LTRIM(RTRIM(Email)), '') AS Email,
+            NULLIF(LTRIM(RTRIM(UserId)), '') AS UserId
+        FROM dbo.People
+    ),
+    SearchablePeople AS (
+        SELECT
+            IamId,
+            EmployeeId,
+            COALESCE(
+                FullName,
+                NULLIF(CONCAT(
+                    COALESCE(FirstName, ''),
+                    CASE WHEN FirstName IS NOT NULL AND LastName IS NOT NULL THEN ' ' ELSE '' END,
+                    COALESCE(LastName, '')
+                ), ''),
+                IamId
+            ) AS Name,
+            Email,
+            FirstName,
+            LastName,
+            FullName,
+            UserId
+        FROM NormalizedPeople
+        WHERE IamId IS NOT NULL
+          AND EmployeeId IS NOT NULL
+    )
+    SELECT
+        IamId,
+        EmployeeId,
+        Name,
+        Email
+    FROM SearchablePeople p
+    WHERE @CanReturnRows = 1
+      AND (
+           (@NormalizedSearchQuery IS NOT NULL AND (
+                p.FullName LIKE @LikeQuery
+             OR p.FirstName LIKE @LikeQuery
+             OR p.LastName LIKE @LikeQuery
+             OR p.Email LIKE @LikeQuery
+             OR p.UserId LIKE @LikeQuery
+             OR p.IamId LIKE @LikeQuery
+           ))
+        OR (@NormalizedIamId IS NOT NULL AND p.IamId = @NormalizedIamId)
+        OR (@NormalizedEmployeeId IS NOT NULL AND p.EmployeeId = @NormalizedEmployeeId)
+        OR (@NormalizedEmail IS NOT NULL AND LOWER(p.Email) = @NormalizedEmail)
+        OR (@NormalizedEmployeeIds IS NOT NULL AND EXISTS (
+            SELECT 1
+            FROM STRING_SPLIT(@NormalizedEmployeeIds, ',') ids
+            WHERE LTRIM(RTRIM(ids.value)) = p.EmployeeId
+        ))
+      )
+    ORDER BY
+        CASE
+            WHEN @NormalizedSearchQuery IS NOT NULL AND p.FullName LIKE @StartsWithQuery THEN 0
+            WHEN @NormalizedSearchQuery IS NOT NULL AND p.Email LIKE @StartsWithQuery THEN 1
+            ELSE 2
+        END,
+        p.FullName,
+        p.Email,
+        p.IamId
+    OFFSET 0 ROWS FETCH NEXT @ResultLimit ROWS ONLY;
+END;
+GO

--- a/web/client/src/components/alerts/PiProjectAlerts.tsx
+++ b/web/client/src/components/alerts/PiProjectAlerts.tsx
@@ -22,20 +22,23 @@ export function usePiProjectAlerts(
   managedPis: ManagedPiRecord[],
   pmEmployeeId: string
 ): PiProjectAlertsState {
+  const navigablePis = useMemo(
+    () => managedPis.filter((pi) => Boolean(pi.iamId)),
+    [managedPis]
+  );
   const projectsQueries = useQueries({
-    queries: managedPis.map((pi) => projectsDetailQueryOptions(pi.employeeId)),
+    queries: navigablePis.map((pi) => projectsDetailQueryOptions(pi.iamId!)),
   });
 
   const firstError = projectsQueries.find((q) => q.isError);
   const allLoaded = projectsQueries.every((q) => q.isSuccess);
   const isLoading =
-    managedPis.length > 0 && !allLoaded && !firstError;
+    navigablePis.length > 0 && !allLoaded && !firstError;
 
-  const alerts = useMemo(() => {
-    if (!allLoaded || managedPis.length === 0) return [];
-
+  let alerts: PiProjectAlert[] = [];
+  if (allLoaded && navigablePis.length > 0) {
     const now = new Date();
-    const pisWithProjects: PiWithProjects[] = managedPis.map((pi, index) => {
+    const pisWithProjects: PiWithProjects[] = navigablePis.map((pi, index) => {
       const allProjects = projectsQueries[index]?.data ?? [];
       const projects = allProjects.filter(
         (p) =>
@@ -47,6 +50,7 @@ export function usePiProjectAlerts(
 
       return {
         employeeId: pi.employeeId,
+        iamId: pi.iamId,
         name: pi.name,
         projectCount: projects.length,
         projects,
@@ -55,9 +59,8 @@ export function usePiProjectAlerts(
       };
     });
 
-    return getPiProjectAlerts(pisWithProjects);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [allLoaded, managedPis, pmEmployeeId]);
+    alerts = getPiProjectAlerts(pisWithProjects);
+  }
 
   return {
     alerts,
@@ -76,7 +79,7 @@ export function PiProjectAlerts({
   managedPis,
   pmEmployeeId,
 }: PiProjectAlertsProps) {
-  const { alerts, isLoading, isError, error } = usePiProjectAlerts(
+  const { alerts, error, isError, isLoading } = usePiProjectAlerts(
     managedPis,
     pmEmployeeId
   );
@@ -109,19 +112,27 @@ export function PiProjectAlerts({
     return <p className="mt-4 text-base-content/60">No alerts</p>;
   }
 
+  const iamIdByEmployeeId = new Map(
+    managedPis
+      .filter((pi) => pi.iamId)
+      .map((pi) => [pi.employeeId, pi.iamId!])
+  );
+
   return (
     <div className="mt-4 flex flex-col gap-4">
-      {alerts.map((alert) => (
-        <AlertCard
-          alert={alert}
-          balance={alert.balance}
-          key={alert.id}
-          linkParams={{
-            employeeId: alert.piEmployeeId,
-            projectNumber: alert.projectNumber,
-          }}
-        />
-      ))}
+      {alerts.map((alert) => {
+        const iamId = iamIdByEmployeeId.get(alert.piEmployeeId);
+        return (
+          <AlertCard
+            alert={alert}
+            balance={alert.balance}
+            key={alert.id}
+            linkParams={
+              iamId ? { iamId, projectNumber: alert.projectNumber } : undefined
+            }
+          />
+        );
+      })}
     </div>
   );
 }

--- a/web/client/src/components/alerts/ProjectAlerts.tsx
+++ b/web/client/src/components/alerts/ProjectAlerts.tsx
@@ -21,7 +21,7 @@ function AlertIcon({ type }: { type: Alert['type'] }) {
 interface AlertCardProps {
   alert: Alert;
   balance: number;
-  linkParams?: { employeeId: string; projectNumber: string };
+  linkParams?: { iamId: string; projectNumber: string };
 }
 
 export function AlertCard({ alert, balance, linkParams }: AlertCardProps) {
@@ -58,7 +58,7 @@ export function AlertCard({ alert, balance, linkParams }: AlertCardProps) {
         className={`alert alert-${alert.severity} alert-soft`}
         params={linkParams}
         role="alert"
-        to="/projects/$employeeId/$projectNumber/"
+        to="/projects/$iamId/$projectNumber/"
       >
         {content}
       </Link>
@@ -73,15 +73,15 @@ export function AlertCard({ alert, balance, linkParams }: AlertCardProps) {
 }
 
 interface ProjectAlertsProps {
-  employeeId?: string;
   hasReconciliationDiscrepancy?: boolean;
+  iamId?: string;
   prefix?: string;
   summary: ProjectSummary;
 }
 
 export function ProjectAlerts({
-  employeeId,
   hasReconciliationDiscrepancy,
+  iamId,
   prefix,
   summary,
 }: ProjectAlertsProps) {
@@ -100,8 +100,8 @@ export function ProjectAlerts({
     return null;
   }
 
-  const linkParams = employeeId
-    ? { employeeId, projectNumber: summary.projectNumber }
+  const linkParams = iamId
+    ? { iamId, projectNumber: summary.projectNumber }
     : undefined;
 
   return (

--- a/web/client/src/components/project/Header.tsx
+++ b/web/client/src/components/project/Header.tsx
@@ -68,8 +68,8 @@ const Header: React.FC = () => {
         ? [
             {
               label: 'Projects',
-              params: { employeeId: user.employeeId },
-              to: '/projects/$employeeId',
+              params: { iamId: user.iamId },
+              to: '/projects/$iamId',
             } satisfies NavLinkItem,
           ]
         : []),
@@ -91,7 +91,7 @@ const Header: React.FC = () => {
       { label: 'Help', to: '/help' },
     ],
     [
-      user.employeeId,
+      user.iamId,
       canViewProjects,
       canViewPersonnel,
       canViewPrincipalInvestigators,

--- a/web/client/src/components/project/InternalProjectsTable.tsx
+++ b/web/client/src/components/project/InternalProjectsTable.tsx
@@ -84,13 +84,13 @@ const csvColumns = [
 
 interface InternalProjectsTableProps {
   discrepancies?: Set<string>;
-  employeeId: string;
+  iamId: string;
   records: ProjectRecord[];
 }
 
 export function InternalProjectsTable({
   discrepancies,
-  employeeId,
+  iamId,
   records,
 }: InternalProjectsTableProps) {
   const [showInactive, setShowInactive] = useState(false);
@@ -131,9 +131,9 @@ export function InternalProjectsTable({
             <div className="flex items-start gap-1">
               <Link
                 className="link no-underline min-w-0"
-                params={{ employeeId, projectNumber }}
+                params={{ iamId, projectNumber }}
                 title={name}
-                to="/projects/$employeeId/$projectNumber/"
+                to="/projects/$iamId/$projectNumber/"
               >
                 {projectNumber}
               </Link>
@@ -234,7 +234,7 @@ export function InternalProjectsTable({
         header: () => <span className="flex justify-end w-full">Balance</span>,
       }),
     ],
-    [discrepancies, employeeId, totals.totalBalance, totals.totalBudget, totals.totalEncumbrance, totals.totalExpense]
+    [discrepancies, iamId, totals.totalBalance, totals.totalBudget, totals.totalEncumbrance, totals.totalExpense]
   );
 
   if (allProjects.length === 0) {

--- a/web/client/src/components/project/PersonnelSection.tsx
+++ b/web/client/src/components/project/PersonnelSection.tsx
@@ -2,7 +2,7 @@ import { PersonnelTable } from '@/components/project/PersonnelTable.tsx';
 import { usePersonnelQuery } from '@/queries/personnel.ts';
 
 interface PersonnelSectionProps {
-  employeeId: string;
+  iamId: string;
   projectNumbers: string[];
 }
 
@@ -75,10 +75,10 @@ function PersonnelTableSkeleton({ rows = 5 }: { rows?: number }) {
 }
 
 export function PersonnelSection({
-  employeeId,
+  iamId,
   projectNumbers,
 }: PersonnelSectionProps) {
-  const personnelQuery = usePersonnelQuery(employeeId, projectNumbers);
+  const personnelQuery = usePersonnelQuery(iamId, projectNumbers);
 
   if (projectNumbers.length === 0) {
     return null;

--- a/web/client/src/components/project/PrincipalInvestigatorsTable.tsx
+++ b/web/client/src/components/project/PrincipalInvestigatorsTable.tsx
@@ -7,15 +7,22 @@ const columnHelper = createColumnHelper<ManagedPiRecord>();
 
 const columns = [
   columnHelper.accessor('name', {
-    cell: (info) => (
-      <Link
-        className="link"
-        params={{ employeeId: info.row.original.employeeId }}
-        to="/projects/$employeeId/"
-      >
-        {info.getValue()}
-      </Link>
-    ),
+    cell: (info) => {
+      const iamId = info.row.original.iamId;
+      if (!iamId) {
+        return <span>{info.getValue()}</span>;
+      }
+
+      return (
+        <Link
+          className="link"
+          params={{ iamId }}
+          to="/projects/$iamId/"
+        >
+          {info.getValue()}
+        </Link>
+      );
+    },
     header: 'PI Name',
   }),
 ];

--- a/web/client/src/components/project/ProjectsSidebar.tsx
+++ b/web/client/src/components/project/ProjectsSidebar.tsx
@@ -69,9 +69,9 @@ const linkClasses = (isActive: boolean, isActiveStatus: boolean) =>
   ].join(' ');
 
 export function ProjectsSidebar() {
-  const { employeeId, projectNumber } = useParams({ strict: false });
+  const { iamId, projectNumber } = useParams({ strict: false });
   const { data: projects } = useSuspenseQuery(
-    projectsDetailQueryOptions(employeeId)
+    projectsDetailQueryOptions(iamId)
   );
 
   // mobile drawer
@@ -205,9 +205,9 @@ export function ProjectsSidebar() {
               <Link
                 aria-label={collapsed ? 'All Projects' : undefined}
                 className={linkClasses(isAllProjectsActive, false)}
-                params={{ employeeId }}
+                params={{ iamId }}
                 title={collapsed ? 'All Projects' : undefined}
-                to="/projects/$employeeId"
+                to="/projects/$iamId"
                 viewTransition={{ types: ['slide-right'] }}
               >
                 {collapsed ? (
@@ -235,13 +235,13 @@ export function ProjectsSidebar() {
                     project.projectStatusCode === 'ACTIVE'
                   )}
                   key={project.projectNumber}
-                  params={{ employeeId, projectNumber: project.projectNumber }}
+                  params={{ iamId, projectNumber: project.projectNumber }}
                   title={
                     collapsed
                       ? `${project.displayName} • ${project.projectNumber}`
                       : project.displayName
                   }
-                  to="/projects/$employeeId/$projectNumber"
+                  to="/projects/$iamId/$projectNumber"
                   viewTransition={{ types: ['slide-left'] }}
                 >
                   {collapsed ? (
@@ -367,8 +367,8 @@ export function ProjectsSidebar() {
           <div className="space-y-1 overflow-y-auto max-h-[calc(100vh-120px)]">
             <Link
               className={linkClasses(isAllProjectsActive, false)}
-              params={{ employeeId }}
-              to="/projects/$employeeId"
+              params={{ iamId }}
+              to="/projects/$iamId"
               viewTransition={{ types: ['slide-right'] }}
             >
               <div className="flex justify-between items-start mb-1">
@@ -388,8 +388,8 @@ export function ProjectsSidebar() {
                 )}
                 key={project.projectNumber}
                 onClick={() => setOpen(false)}
-                params={{ employeeId, projectNumber: project.projectNumber }}
-                to="/projects/$employeeId/$projectNumber"
+                params={{ iamId, projectNumber: project.projectNumber }}
+                to="/projects/$iamId/$projectNumber"
                 viewTransition={{ types: ['slide-left'] }}
               >
                 <div className="text-xs text-dark-font/50">

--- a/web/client/src/components/project/SponsoredProjectsTable.tsx
+++ b/web/client/src/components/project/SponsoredProjectsTable.tsx
@@ -117,12 +117,12 @@ const csvColumns = [
 ];
 
 interface SponsoredProjectsTableProps {
-  employeeId: string;
+  iamId: string;
   records: ProjectRecord[];
 }
 
 export function SponsoredProjectsTable({
-  employeeId,
+  iamId,
   records,
 }: SponsoredProjectsTableProps) {
   const [showExpired, setShowExpired] = useState(false);
@@ -167,8 +167,8 @@ export function SponsoredProjectsTable({
           return (
             <Link
               className="link no-underline flex items-start gap-1"
-              params={{ employeeId, projectNumber }}
-              to="/projects/$employeeId/$projectNumber/"
+              params={{ iamId, projectNumber }}
+              to="/projects/$iamId/$projectNumber/"
             >
               <div className="min-w-0">
                 <div className="text-xs text-base-content/70 no-underline">
@@ -284,7 +284,7 @@ export function SponsoredProjectsTable({
         header: () => <span className="flex justify-end">Balance</span>,
       }),
     ],
-    [employeeId, totals.totalBalance, totals.totalBudget, totals.totalEncumbrance, totals.totalExpense]
+    [iamId, totals.totalBalance, totals.totalBudget, totals.totalEncumbrance, totals.totalExpense]
   );
 
   if (allProjects.length === 0) {

--- a/web/client/src/components/project/TaskBreakdown.tsx
+++ b/web/client/src/components/project/TaskBreakdown.tsx
@@ -86,7 +86,7 @@ const csvColumns = [
 ];
 
 interface TaskBreakdownProps {
-  employeeId: string;
+  iamId: string;
   projectNumber: string;
   records: ProjectRecord[];
 }
@@ -95,7 +95,7 @@ function isClosedTask(row: TaskBreakdownRow): boolean {
   return row.taskStatus === 'Inactive';
 }
 
-export function TaskBreakdown({ employeeId, projectNumber, records }: TaskBreakdownProps) {
+export function TaskBreakdown({ iamId, projectNumber, records }: TaskBreakdownProps) {
   const [showClosed, setShowClosed] = useState(false);
   const allRows = useMemo(() => buildRows(records), [records]);
   const closedCount = useMemo(() => allRows.filter(isClosedTask).length, [allRows]);
@@ -236,7 +236,7 @@ export function TaskBreakdown({ employeeId, projectNumber, records }: TaskBreakd
           return (
             <Link
               className="link font-semibold text-sm whitespace-nowrap"
-              params={{ employeeId, projectNumber }}
+              params={{ iamId, projectNumber }}
               search={{
                 activity: row.activityCode,
                 dept: row.financialDepartmentCode,
@@ -244,7 +244,7 @@ export function TaskBreakdown({ employeeId, projectNumber, records }: TaskBreakd
                 program: row.programCode,
                 task: row.taskNum,
               }}
-              to="/projects/$employeeId/$projectNumber/expenditure-categories"
+              to="/projects/$iamId/$projectNumber/expenditure-categories"
             >
               Details
             </Link>
@@ -254,7 +254,7 @@ export function TaskBreakdown({ employeeId, projectNumber, records }: TaskBreakd
         id: 'detailsLink',
       }),
     ],
-    [employeeId, projectNumber, totals.balance, totals.budget, totals.commitments, totals.expenses]
+    [iamId, projectNumber, totals.balance, totals.budget, totals.commitments, totals.expenses]
   );
 
   if (allRows.length === 0) {

--- a/web/client/src/components/search/CommandPaletteProvider.tsx
+++ b/web/client/src/components/search/CommandPaletteProvider.tsx
@@ -1,5 +1,4 @@
 import {
-  resolveSearchPersonById,
   type SearchCatalog,
   type SearchDirectoryPerson,
   type SearchPerson,
@@ -12,7 +11,6 @@ import {
 } from '@/queries/search.ts';
 import { canViewFinancials } from '@/components/search/searchAccess.ts';
 import { useUser } from '@/shared/auth/UserContext.tsx';
-import { HttpError } from '@/lib/api.ts';
 import { useDebouncedValue } from '@/lib/useDebouncedValue.ts';
 import { useNavigate } from '@tanstack/react-router';
 import { Command } from 'cmdk';
@@ -69,10 +67,11 @@ type NavigateSearchItem = {
 
 type ResolvePersonSearchItem = {
   category: 'People';
-  directoryUserId: string;
+  iamId: string;
   id: string;
+  isProjectManager: boolean;
   keywords: string[];
-  kind: 'resolvePerson';
+  kind: 'person';
   label: string;
   secondary?: string;
 };
@@ -135,7 +134,7 @@ const filterAndSort = <T extends { keywords: string[]; label: string }>(
 
 const projectToItem = (
   project: SearchProject,
-  currentEmployeeId: string,
+  currentIamId: string,
   financialSearch: boolean
 ): NavigateSearchItem => {
   if (financialSearch) {
@@ -160,11 +159,11 @@ const projectToItem = (
     kind: 'navigate',
     label: project.projectName,
     params: {
-      employeeId: project.projectPiEmployeeId ?? currentEmployeeId,
+      iamId: project.projectPiIamId ?? currentIamId,
       projectNumber: project.projectNumber,
     },
     secondary: project.projectNumber,
-    to: '/projects/$employeeId/$projectNumber/',
+    to: '/projects/$iamId/$projectNumber/',
   };
 };
 
@@ -181,23 +180,23 @@ const principalInvestigatorToItem = (
   person: SearchPerson
 ): NavigateSearchItem => ({
   category: 'PIs',
-  id: `pi:${person.employeeId}`,
+  id: `pi:${person.iamId}`,
   keywords: person.keywords,
   kind: 'navigate',
   label: person.name,
-  params: { employeeId: person.employeeId },
-  secondary: person.employeeId,
-  to: '/projects/$employeeId/',
+  params: { iamId: person.iamId },
+  to: '/projects/$iamId/',
 });
 
 const directoryPersonToItem = (
   person: SearchDirectoryPerson
 ): ResolvePersonSearchItem => ({
   category: 'People',
-  directoryUserId: person.id,
-  id: `person:${person.id}`,
+  iamId: person.iamId,
+  id: `person:${person.iamId}`,
+  isProjectManager: person.isProjectManager,
   keywords: person.keywords,
-  kind: 'resolvePerson',
+  kind: 'person',
   label: person.name,
   secondary: person.email ?? undefined,
 });
@@ -244,8 +243,6 @@ function CommandPaletteDialog({
 
   const [paletteKey, setPaletteKey] = useState(0);
   const [query, setQuery] = useState('');
-  const [selectionError, setSelectionError] = useState<string | null>(null);
-  const [isResolvingPerson, setIsResolvingPerson] = useState(false);
   const inputRef = useRef<HTMLInputElement | null>(null);
 
   const hasFinancialSearchAccess = canViewFinancials(user.roles);
@@ -256,8 +253,8 @@ function CommandPaletteDialog({
   const catalogQuery = useSearchCatalogQuery({ enabled: isOpen });
 
   const teamProjectsQuery = useSearchTeamMemberProjectsQuery({
-    employeeId: user.employeeId,
-    enabled: isOpen, // if we want to preload on page open later, // user.employeeId.trim().length > 0,
+    enabled: isOpen,
+    iamId: user.iamId,
   });
 
   const financialProjectsQuery = useSearchFinancialProjectsQuery({
@@ -278,22 +275,22 @@ function CommandPaletteDialog({
       teamProjectsQuery.data?.projects ??
       [];
     const raw = rawProjects.map((p) =>
-      projectToItem(p, user.employeeId, false)
+      projectToItem(p, user.iamId, false)
     );
     return filterAndSort(raw, query);
   }, [
     query,
     teamProjectsQuery.data?.myProjects,
     teamProjectsQuery.data?.projects,
-    user.employeeId,
+    user.iamId,
   ]);
 
   const myManagedProjects = useMemo(() => {
     const raw = (teamProjectsQuery.data?.myManagedProjects ?? []).map((p) =>
-      projectToItem(p, user.employeeId, false)
+      projectToItem(p, user.iamId, false)
     );
     return filterAndSort(raw, query);
-  }, [query, teamProjectsQuery.data?.myManagedProjects, user.employeeId]);
+  }, [query, teamProjectsQuery.data?.myManagedProjects, user.iamId]);
 
   const allProjects = useMemo(() => {
     if (!hasFinancialSearchAccess) {
@@ -304,7 +301,7 @@ function CommandPaletteDialog({
       [...myProjects, ...myManagedProjects].map((p) => p.id)
     );
     const raw = (financialProjectsQuery.data ?? []).map((p) =>
-      projectToItem(p, user.employeeId, true)
+      projectToItem(p, user.iamId, true)
     );
 
     return filterAndSort(raw, query)
@@ -316,7 +313,7 @@ function CommandPaletteDialog({
     myManagedProjects,
     myProjects,
     query,
-    user.employeeId,
+    user.iamId,
   ]);
 
   const reports = useMemo(() => {
@@ -382,9 +379,7 @@ function CommandPaletteDialog({
     !hasAnyResults;
 
   const closeAndReset = useCallback(() => {
-    setIsResolvingPerson(false);
     setQuery('');
-    setSelectionError(null);
     setPaletteKey((k) => k + 1);
     onClose();
   }, [onClose]);
@@ -403,40 +398,24 @@ function CommandPaletteDialog({
 
   const onSelectItem = useCallback(
     async (item: SearchItem) => {
-      setSelectionError(null);
-
       if (item.kind === 'navigate') {
         navigate({ params: item.params, to: item.to });
         dialogRef.current?.close();
         return;
       }
 
-      setIsResolvingPerson(true);
-      try {
-        const resolved = await resolveSearchPersonById({
-          userId: item.directoryUserId,
+      if (item.isProjectManager) {
+        navigate({
+          params: { iamId: item.iamId },
+          to: '/principalInvestigators/$iamId',
         });
-        if (resolved.isProjectManager) {
-          navigate({
-            params: { emplid: resolved.employeeId },
-            to: '/principalInvestigators/$emplid',
-          });
-        } else {
-          navigate({
-            params: { employeeId: resolved.employeeId },
-            to: '/projects/$employeeId/',
-          });
-        }
-        dialogRef.current?.close();
-      } catch (error: unknown) {
-        const status =
-          error instanceof HttpError && error.status
-            ? ` (HTTP ${error.status})`
-            : '';
-        setSelectionError(`Unable to open selected person${status}.`);
-      } finally {
-        setIsResolvingPerson(false);
+      } else {
+        navigate({
+          params: { iamId: item.iamId },
+          to: '/projects/$iamId/',
+        });
       }
+      dialogRef.current?.close();
     },
     [dialogRef, navigate]
   );
@@ -483,7 +462,6 @@ function CommandPaletteDialog({
               className="input input-bordered w-full"
               onValueChange={(value) => {
                 setQuery(value);
-                setSelectionError(null);
               }}
               placeholder="Search projects, people, reports..."
               ref={inputRef}
@@ -492,21 +470,6 @@ function CommandPaletteDialog({
           </div>
 
           <Command.List>
-            {isResolvingPerson ? (
-              <div className="px-4 py-2 text-sm text-base-content/70">
-                <div className="flex items-center gap-2">
-                  <div className="loading loading-spinner loading-xs" />
-                  <span>Resolving person...</span>
-                </div>
-              </div>
-            ) : null}
-
-            {selectionError ? (
-              <div className="px-4 py-2 text-sm text-error">
-                {selectionError}
-              </div>
-            ) : null}
-
             {showFinancialStartTypingHint ? (
               <div className="px-4 py-2 text-sm text-base-content/60">
                 Start typing to search all projects and people.

--- a/web/client/src/components/search/CommandPaletteProvider.tsx
+++ b/web/client/src/components/search/CommandPaletteProvider.tsx
@@ -286,9 +286,11 @@ function CommandPaletteDialog({
   ]);
 
   const myManagedProjects = useMemo(() => {
-    const raw = (teamProjectsQuery.data?.myManagedProjects ?? []).map((p) =>
-      projectToItem(p, user.iamId, false)
-    );
+    const raw = (teamProjectsQuery.data?.myManagedProjects ?? [])
+      // Managed project detail links need the PI portfolio route.
+      // The PM portfolio route only contains PM-only orphaned projects.
+      .filter((p) => Boolean(p.projectPiIamId))
+      .map((p) => projectToItem(p, user.iamId, false));
     return filterAndSort(raw, query);
   }, [query, teamProjectsQuery.data?.myManagedProjects, user.iamId]);
 

--- a/web/client/src/queries/personnel.ts
+++ b/web/client/src/queries/personnel.ts
@@ -20,26 +20,26 @@ export interface PersonnelRecord {
 }
 
 export const personnelQueryOptions = (
-  employeeId: string,
+  iamId: string,
   projectCodes: string[]
 ) => {
-  const trimmedEmployeeId = employeeId.trim();
+  const trimmedIamId = iamId.trim();
 
   return {
-    enabled: Boolean(trimmedEmployeeId) && projectCodes.length > 0,
+    enabled: Boolean(trimmedIamId) && projectCodes.length > 0,
     queryFn: async (): Promise<PersonnelRecord[]> => {
       const params = new URLSearchParams();
-      params.set('employeeId', trimmedEmployeeId);
+      params.set('iamId', trimmedIamId);
       params.set('projectCodes', projectCodes.join(','));
       return await fetchJson<PersonnelRecord[]>(
         `/api/project/personnel?${params.toString()}`
       );
     },
-    queryKey: ['personnel', trimmedEmployeeId, projectCodes] as const,
+    queryKey: ['personnel', 'by-iam', trimmedIamId, projectCodes] as const,
     staleTime: 60 * 60 * 1000, // 1 hour
   };
 };
 
-export const usePersonnelQuery = (employeeId: string, projectCodes: string[]) => {
-  return useQuery(personnelQueryOptions(employeeId, projectCodes));
+export const usePersonnelQuery = (iamId: string, projectCodes: string[]) => {
+  return useQuery(personnelQueryOptions(iamId, projectCodes));
 };

--- a/web/client/src/queries/project.ts
+++ b/web/client/src/queries/project.ts
@@ -137,7 +137,10 @@ export interface ManagedPisEnvelope {
 export const projectsDetailQueryOptions = (iamId: string) => ({
   enabled: Boolean(iamId),
   queryFn: async () => {
-    return await fetchJson<ProjectRecord[]>(`/api/project/by-iam/${iamId}`);
+    const encodedIamId = encodeURIComponent(iamId);
+    return await fetchJson<ProjectRecord[]>(
+      `/api/project/by-iam/${encodedIamId}`
+    );
   },
   queryKey: ['projects', 'by-iam', iamId] as const,
   staleTime: 60 * 60 * 1000, // 1 hour
@@ -150,8 +153,9 @@ export const useProjectsDetailQuery = (iamId: string) => {
 export const managedPisQueryOptions = (iamId: string) => ({
   enabled: Boolean(iamId),
   queryFn: async (): Promise<ManagedPisEnvelope> => {
+    const encodedIamId = encodeURIComponent(iamId);
     return await fetchJson<ManagedPisEnvelope>(
-      `/api/project/managed/by-iam/${iamId}`
+      `/api/project/managed/by-iam/${encodedIamId}`
     );
   },
   queryKey: ['projects', 'managed', 'by-iam', iamId] as const,

--- a/web/client/src/queries/project.ts
+++ b/web/client/src/queries/project.ts
@@ -120,6 +120,7 @@ export interface GLPPMReconciliationRecord {
 
 export interface ManagedPiRecord {
   employeeId: string;
+  iamId: string | null;
   name: string;
   projectCount: number;
 }
@@ -128,36 +129,38 @@ export interface ManagedPisEnvelope {
   pis: ManagedPiRecord[];
   projectManager: {
     employeeId: string;
+    iamId: string;
     name: string | null;
   } | null;
 }
 
-export const projectsDetailQueryOptions = (employeeId: string) => ({
-  enabled: Boolean(employeeId),
+export const projectsDetailQueryOptions = (iamId: string) => ({
+  enabled: Boolean(iamId),
   queryFn: async () => {
-    return await fetchJson<ProjectRecord[]>(`/api/project/${employeeId}`);
+    return await fetchJson<ProjectRecord[]>(`/api/project/by-iam/${iamId}`);
   },
-  queryKey: ['projects', employeeId] as const,
+  queryKey: ['projects', 'by-iam', iamId] as const,
   staleTime: 60 * 60 * 1000, // 1 hour
 });
 
-export const useProjectsDetailQuery = (employeeId: string) => {
-  return useQuery(projectsDetailQueryOptions(employeeId));
+export const useProjectsDetailQuery = (iamId: string) => {
+  return useQuery(projectsDetailQueryOptions(iamId));
 };
 
-export const managedPisQueryOptions = (employeeId: string) => ({
-  enabled: Boolean(employeeId),
+export const managedPisQueryOptions = (iamId: string) => ({
+  enabled: Boolean(iamId),
   queryFn: async (): Promise<ManagedPisEnvelope> => {
     return await fetchJson<ManagedPisEnvelope>(
-      `/api/project/managed/${employeeId}`
+      `/api/project/managed/by-iam/${iamId}`
     );
   },
-  queryKey: ['projects', 'managed', employeeId] as const,
+  queryKey: ['projects', 'managed', 'by-iam', iamId] as const,
   staleTime: 5 * 60 * 1000, // 5 minutes
 });
 
 export interface PiWithProjects {
   employeeId: string;
+  iamId: string | null;
   name: string;
   projectCount: number;
   projects: ProjectRecord[];
@@ -165,8 +168,8 @@ export interface PiWithProjects {
   totalBudget: number;
 }
 
-export const useManagedPisQuery = (employeeId: string) => {
-  const managedPisResult = useQuery(managedPisQueryOptions(employeeId));
+export const useManagedPisQuery = (iamId: string) => {
+  const managedPisResult = useQuery(managedPisQueryOptions(iamId));
 
   return {
     error: managedPisResult.error,

--- a/web/client/src/queries/search.ts
+++ b/web/client/src/queries/search.ts
@@ -6,8 +6,8 @@ const TEAM_SEARCH_GC_TIME_MS = 30 * 60 * 1000;
 
 export type SearchProject = {
   keywords: string[];
-  projectPiEmployeeId?: string | null;
   projectName: string;
+  projectPiIamId?: string | null;
   projectNumber: string;
 };
 
@@ -24,14 +24,16 @@ export type SearchCatalog = {
 };
 
 export type SearchPerson = {
-  employeeId: string;
+  iamId: string;
   keywords: string[];
   name: string;
 };
 
 export type SearchDirectoryPerson = {
   email?: string | null;
+  iamId: string;
   id: string;
+  isProjectManager: boolean;
   keywords: string[];
   name: string;
 };
@@ -43,15 +45,8 @@ export type SearchTeamMemberProjectsResponse = {
   projects: SearchProject[];
 };
 
-export type ResolveDirectoryPersonResponse = {
-  email?: string | null;
-  employeeId: string;
-  isProjectManager: boolean;
-  name: string;
-};
-
 export type ResolveProjectPiResponse = {
-  employeeId: string;
+  iamId: string;
   projectNumber: string;
 };
 
@@ -72,7 +67,7 @@ export const useSearchCatalogQuery = ({ enabled }: { enabled: boolean }) => {
   });
 };
 
-export const searchTeamMemberProjectsQueryOptions = (employeeId: string) => ({
+export const searchTeamMemberProjectsQueryOptions = (iamId: string) => ({
   gcTime: TEAM_SEARCH_GC_TIME_MS,
   queryFn: async ({
     signal,
@@ -85,20 +80,20 @@ export const searchTeamMemberProjectsQueryOptions = (employeeId: string) => ({
       signal
     );
   },
-  queryKey: ['search', 'projects', 'team', employeeId] as const,
+  queryKey: ['search', 'projects', 'team', iamId] as const,
   refetchOnWindowFocus: false,
   staleTime: TEAM_SEARCH_STALE_TIME_MS,
 });
 
 export const useSearchTeamMemberProjectsQuery = ({
-  employeeId,
   enabled,
+  iamId,
 }: {
-  employeeId: string;
   enabled: boolean;
+  iamId: string;
 }) => {
   return useQuery({
-    ...searchTeamMemberProjectsQueryOptions(employeeId),
+    ...searchTeamMemberProjectsQueryOptions(iamId),
     enabled,
   });
 };
@@ -223,22 +218,3 @@ export const useResolveProjectPiQuery = ({
     enabled: enabled && options.enabled,
   });
 };
-
-export async function resolveSearchPersonById({
-  signal,
-  userId,
-}: {
-  signal?: AbortSignal;
-  userId: string;
-}): Promise<ResolveDirectoryPersonResponse> {
-  const id = userId.trim();
-  if (!id) {
-    throw new Error('userId is required');
-  }
-
-  return await fetchJson<ResolveDirectoryPersonResponse>(
-    `/api/search/people/resolve?userId=${encodeURIComponent(id)}`,
-    {},
-    signal
-  );
-}

--- a/web/client/src/queries/user.ts
+++ b/web/client/src/queries/user.ts
@@ -4,6 +4,7 @@ import { useQuery } from '@tanstack/react-query';
 export type User = {
   email: string;
   employeeId: string;
+  iamId: string;
   id: string;
   kerberos: string;
   name: string;

--- a/web/client/src/routeTree.gen.ts
+++ b/web/client/src/routeTree.gen.ts
@@ -24,19 +24,19 @@ import { Route as authenticatedReportsIndexRouteImport } from './routes/(authent
 import { Route as authenticatedPrincipalInvestigatorsIndexRouteImport } from './routes/(authenticated)/principalInvestigators/index'
 import { Route as authenticatedAdminIndexRouteImport } from './routes/(authenticated)/admin/index'
 import { Route as authenticatedAccrualsIndexRouteImport } from './routes/(authenticated)/accruals/index'
-import { Route as authenticatedPrincipalInvestigatorsEmplidRouteImport } from './routes/(authenticated)/principalInvestigators/$emplid'
+import { Route as authenticatedPrincipalInvestigatorsIamIdRouteImport } from './routes/(authenticated)/principalInvestigators/$iamId'
 import { Route as authenticatedAdminUsersRouteImport } from './routes/(authenticated)/admin/users'
 import { Route as authenticatedAdminNotificationRouteImport } from './routes/(authenticated)/admin/notification'
 import { Route as authenticatedAdminEmailPreviewRouteImport } from './routes/(authenticated)/admin/email-preview'
 import { Route as authenticatedAccrualsAboutRouteImport } from './routes/(authenticated)/accruals/about'
-import { Route as authenticatedProjectsEmployeeIdRouteRouteImport } from './routes/(authenticated)/projects/$employeeId/route'
-import { Route as authenticatedProjectsEmployeeIdIndexRouteImport } from './routes/(authenticated)/projects/$employeeId/index'
+import { Route as authenticatedProjectsIamIdRouteRouteImport } from './routes/(authenticated)/projects/$iamId/route'
+import { Route as authenticatedProjectsIamIdIndexRouteImport } from './routes/(authenticated)/projects/$iamId/index'
 import { Route as authenticatedProjectsByNumberProjectNumberRouteImport } from './routes/(authenticated)/projects/by-number/$projectNumber'
 import { Route as authenticatedAccrualsDepartmentDepartmentCodeRouteImport } from './routes/(authenticated)/accruals/department/$departmentCode'
 import { Route as authenticatedReportsReconciliationProjectNumberIndexRouteImport } from './routes/(authenticated)/reports/reconciliation/$projectNumber/index'
-import { Route as authenticatedProjectsEmployeeIdProjectNumberIndexRouteImport } from './routes/(authenticated)/projects/$employeeId/$projectNumber/index'
+import { Route as authenticatedProjectsIamIdProjectNumberIndexRouteImport } from './routes/(authenticated)/projects/$iamId/$projectNumber/index'
 import { Route as authenticatedReportsReconciliationProjectNumberDetailRouteImport } from './routes/(authenticated)/reports/reconciliation/$projectNumber/detail'
-import { Route as authenticatedProjectsEmployeeIdProjectNumberExpenditureCategoriesRouteImport } from './routes/(authenticated)/projects/$employeeId/$projectNumber/expenditure-categories'
+import { Route as authenticatedProjectsIamIdProjectNumberExpenditureCategoriesRouteImport } from './routes/(authenticated)/projects/$iamId/$projectNumber/expenditure-categories'
 
 const AboutRoute = AboutRouteImport.update({
   id: '/about',
@@ -116,10 +116,10 @@ const authenticatedAccrualsIndexRoute =
     path: '/accruals/',
     getParentRoute: () => authenticatedRouteRoute,
   } as any)
-const authenticatedPrincipalInvestigatorsEmplidRoute =
-  authenticatedPrincipalInvestigatorsEmplidRouteImport.update({
-    id: '/principalInvestigators/$emplid',
-    path: '/principalInvestigators/$emplid',
+const authenticatedPrincipalInvestigatorsIamIdRoute =
+  authenticatedPrincipalInvestigatorsIamIdRouteImport.update({
+    id: '/principalInvestigators/$iamId',
+    path: '/principalInvestigators/$iamId',
     getParentRoute: () => authenticatedRouteRoute,
   } as any)
 const authenticatedAdminUsersRoute = authenticatedAdminUsersRouteImport.update({
@@ -145,17 +145,17 @@ const authenticatedAccrualsAboutRoute =
     path: '/accruals/about',
     getParentRoute: () => authenticatedRouteRoute,
   } as any)
-const authenticatedProjectsEmployeeIdRouteRoute =
-  authenticatedProjectsEmployeeIdRouteRouteImport.update({
-    id: '/$employeeId',
-    path: '/$employeeId',
+const authenticatedProjectsIamIdRouteRoute =
+  authenticatedProjectsIamIdRouteRouteImport.update({
+    id: '/$iamId',
+    path: '/$iamId',
     getParentRoute: () => authenticatedProjectsRouteRoute,
   } as any)
-const authenticatedProjectsEmployeeIdIndexRoute =
-  authenticatedProjectsEmployeeIdIndexRouteImport.update({
+const authenticatedProjectsIamIdIndexRoute =
+  authenticatedProjectsIamIdIndexRouteImport.update({
     id: '/',
     path: '/',
-    getParentRoute: () => authenticatedProjectsEmployeeIdRouteRoute,
+    getParentRoute: () => authenticatedProjectsIamIdRouteRoute,
   } as any)
 const authenticatedProjectsByNumberProjectNumberRoute =
   authenticatedProjectsByNumberProjectNumberRouteImport.update({
@@ -175,11 +175,11 @@ const authenticatedReportsReconciliationProjectNumberIndexRoute =
     path: '/reconciliation/$projectNumber/',
     getParentRoute: () => authenticatedReportsRoute,
   } as any)
-const authenticatedProjectsEmployeeIdProjectNumberIndexRoute =
-  authenticatedProjectsEmployeeIdProjectNumberIndexRouteImport.update({
+const authenticatedProjectsIamIdProjectNumberIndexRoute =
+  authenticatedProjectsIamIdProjectNumberIndexRouteImport.update({
     id: '/$projectNumber/',
     path: '/$projectNumber/',
-    getParentRoute: () => authenticatedProjectsEmployeeIdRouteRoute,
+    getParentRoute: () => authenticatedProjectsIamIdRouteRoute,
   } as any)
 const authenticatedReportsReconciliationProjectNumberDetailRoute =
   authenticatedReportsReconciliationProjectNumberDetailRouteImport.update({
@@ -187,12 +187,12 @@ const authenticatedReportsReconciliationProjectNumberDetailRoute =
     path: '/reconciliation/$projectNumber/detail',
     getParentRoute: () => authenticatedReportsRoute,
   } as any)
-const authenticatedProjectsEmployeeIdProjectNumberExpenditureCategoriesRoute =
-  authenticatedProjectsEmployeeIdProjectNumberExpenditureCategoriesRouteImport.update(
+const authenticatedProjectsIamIdProjectNumberExpenditureCategoriesRoute =
+  authenticatedProjectsIamIdProjectNumberExpenditureCategoriesRouteImport.update(
     {
       id: '/$projectNumber/expenditure-categories',
       path: '/$projectNumber/expenditure-categories',
-      getParentRoute: () => authenticatedProjectsEmployeeIdRouteRoute,
+      getParentRoute: () => authenticatedProjectsIamIdRouteRoute,
     } as any,
   )
 
@@ -207,22 +207,22 @@ export interface FileRoutesByFullPath {
   '/reports': typeof authenticatedReportsRouteWithChildren
   '/styles': typeof authenticatedStylesRoute
   '/': typeof authenticatedIndexRoute
-  '/projects/$employeeId': typeof authenticatedProjectsEmployeeIdRouteRouteWithChildren
+  '/projects/$iamId': typeof authenticatedProjectsIamIdRouteRouteWithChildren
   '/accruals/about': typeof authenticatedAccrualsAboutRoute
   '/admin/email-preview': typeof authenticatedAdminEmailPreviewRoute
   '/admin/notification': typeof authenticatedAdminNotificationRoute
   '/admin/users': typeof authenticatedAdminUsersRoute
-  '/principalInvestigators/$emplid': typeof authenticatedPrincipalInvestigatorsEmplidRoute
+  '/principalInvestigators/$iamId': typeof authenticatedPrincipalInvestigatorsIamIdRoute
   '/accruals': typeof authenticatedAccrualsIndexRoute
   '/admin/': typeof authenticatedAdminIndexRoute
   '/principalInvestigators': typeof authenticatedPrincipalInvestigatorsIndexRoute
   '/reports/': typeof authenticatedReportsIndexRoute
   '/accruals/department/$departmentCode': typeof authenticatedAccrualsDepartmentDepartmentCodeRoute
   '/projects/by-number/$projectNumber': typeof authenticatedProjectsByNumberProjectNumberRoute
-  '/projects/$employeeId/': typeof authenticatedProjectsEmployeeIdIndexRoute
-  '/projects/$employeeId/$projectNumber/expenditure-categories': typeof authenticatedProjectsEmployeeIdProjectNumberExpenditureCategoriesRoute
+  '/projects/$iamId/': typeof authenticatedProjectsIamIdIndexRoute
+  '/projects/$iamId/$projectNumber/expenditure-categories': typeof authenticatedProjectsIamIdProjectNumberExpenditureCategoriesRoute
   '/reports/reconciliation/$projectNumber/detail': typeof authenticatedReportsReconciliationProjectNumberDetailRoute
-  '/projects/$employeeId/$projectNumber': typeof authenticatedProjectsEmployeeIdProjectNumberIndexRoute
+  '/projects/$iamId/$projectNumber': typeof authenticatedProjectsIamIdProjectNumberIndexRoute
   '/reports/reconciliation/$projectNumber': typeof authenticatedReportsReconciliationProjectNumberIndexRoute
 }
 export interface FileRoutesByTo {
@@ -238,17 +238,17 @@ export interface FileRoutesByTo {
   '/admin/email-preview': typeof authenticatedAdminEmailPreviewRoute
   '/admin/notification': typeof authenticatedAdminNotificationRoute
   '/admin/users': typeof authenticatedAdminUsersRoute
-  '/principalInvestigators/$emplid': typeof authenticatedPrincipalInvestigatorsEmplidRoute
+  '/principalInvestigators/$iamId': typeof authenticatedPrincipalInvestigatorsIamIdRoute
   '/accruals': typeof authenticatedAccrualsIndexRoute
   '/admin': typeof authenticatedAdminIndexRoute
   '/principalInvestigators': typeof authenticatedPrincipalInvestigatorsIndexRoute
   '/reports': typeof authenticatedReportsIndexRoute
   '/accruals/department/$departmentCode': typeof authenticatedAccrualsDepartmentDepartmentCodeRoute
   '/projects/by-number/$projectNumber': typeof authenticatedProjectsByNumberProjectNumberRoute
-  '/projects/$employeeId': typeof authenticatedProjectsEmployeeIdIndexRoute
-  '/projects/$employeeId/$projectNumber/expenditure-categories': typeof authenticatedProjectsEmployeeIdProjectNumberExpenditureCategoriesRoute
+  '/projects/$iamId': typeof authenticatedProjectsIamIdIndexRoute
+  '/projects/$iamId/$projectNumber/expenditure-categories': typeof authenticatedProjectsIamIdProjectNumberExpenditureCategoriesRoute
   '/reports/reconciliation/$projectNumber/detail': typeof authenticatedReportsReconciliationProjectNumberDetailRoute
-  '/projects/$employeeId/$projectNumber': typeof authenticatedProjectsEmployeeIdProjectNumberIndexRoute
+  '/projects/$iamId/$projectNumber': typeof authenticatedProjectsIamIdProjectNumberIndexRoute
   '/reports/reconciliation/$projectNumber': typeof authenticatedReportsReconciliationProjectNumberIndexRoute
 }
 export interface FileRoutesById {
@@ -264,22 +264,22 @@ export interface FileRoutesById {
   '/(authenticated)/reports': typeof authenticatedReportsRouteWithChildren
   '/(authenticated)/styles': typeof authenticatedStylesRoute
   '/(authenticated)/': typeof authenticatedIndexRoute
-  '/(authenticated)/projects/$employeeId': typeof authenticatedProjectsEmployeeIdRouteRouteWithChildren
+  '/(authenticated)/projects/$iamId': typeof authenticatedProjectsIamIdRouteRouteWithChildren
   '/(authenticated)/accruals/about': typeof authenticatedAccrualsAboutRoute
   '/(authenticated)/admin/email-preview': typeof authenticatedAdminEmailPreviewRoute
   '/(authenticated)/admin/notification': typeof authenticatedAdminNotificationRoute
   '/(authenticated)/admin/users': typeof authenticatedAdminUsersRoute
-  '/(authenticated)/principalInvestigators/$emplid': typeof authenticatedPrincipalInvestigatorsEmplidRoute
+  '/(authenticated)/principalInvestigators/$iamId': typeof authenticatedPrincipalInvestigatorsIamIdRoute
   '/(authenticated)/accruals/': typeof authenticatedAccrualsIndexRoute
   '/(authenticated)/admin/': typeof authenticatedAdminIndexRoute
   '/(authenticated)/principalInvestigators/': typeof authenticatedPrincipalInvestigatorsIndexRoute
   '/(authenticated)/reports/': typeof authenticatedReportsIndexRoute
   '/(authenticated)/accruals/department/$departmentCode': typeof authenticatedAccrualsDepartmentDepartmentCodeRoute
   '/(authenticated)/projects/by-number/$projectNumber': typeof authenticatedProjectsByNumberProjectNumberRoute
-  '/(authenticated)/projects/$employeeId/': typeof authenticatedProjectsEmployeeIdIndexRoute
-  '/(authenticated)/projects/$employeeId/$projectNumber/expenditure-categories': typeof authenticatedProjectsEmployeeIdProjectNumberExpenditureCategoriesRoute
+  '/(authenticated)/projects/$iamId/': typeof authenticatedProjectsIamIdIndexRoute
+  '/(authenticated)/projects/$iamId/$projectNumber/expenditure-categories': typeof authenticatedProjectsIamIdProjectNumberExpenditureCategoriesRoute
   '/(authenticated)/reports/reconciliation/$projectNumber/detail': typeof authenticatedReportsReconciliationProjectNumberDetailRoute
-  '/(authenticated)/projects/$employeeId/$projectNumber/': typeof authenticatedProjectsEmployeeIdProjectNumberIndexRoute
+  '/(authenticated)/projects/$iamId/$projectNumber/': typeof authenticatedProjectsIamIdProjectNumberIndexRoute
   '/(authenticated)/reports/reconciliation/$projectNumber/': typeof authenticatedReportsReconciliationProjectNumberIndexRoute
 }
 export interface FileRouteTypes {
@@ -295,22 +295,22 @@ export interface FileRouteTypes {
     | '/reports'
     | '/styles'
     | '/'
-    | '/projects/$employeeId'
+    | '/projects/$iamId'
     | '/accruals/about'
     | '/admin/email-preview'
     | '/admin/notification'
     | '/admin/users'
-    | '/principalInvestigators/$emplid'
+    | '/principalInvestigators/$iamId'
     | '/accruals'
     | '/admin/'
     | '/principalInvestigators'
     | '/reports/'
     | '/accruals/department/$departmentCode'
     | '/projects/by-number/$projectNumber'
-    | '/projects/$employeeId/'
-    | '/projects/$employeeId/$projectNumber/expenditure-categories'
+    | '/projects/$iamId/'
+    | '/projects/$iamId/$projectNumber/expenditure-categories'
     | '/reports/reconciliation/$projectNumber/detail'
-    | '/projects/$employeeId/$projectNumber'
+    | '/projects/$iamId/$projectNumber'
     | '/reports/reconciliation/$projectNumber'
   fileRoutesByTo: FileRoutesByTo
   to:
@@ -326,17 +326,17 @@ export interface FileRouteTypes {
     | '/admin/email-preview'
     | '/admin/notification'
     | '/admin/users'
-    | '/principalInvestigators/$emplid'
+    | '/principalInvestigators/$iamId'
     | '/accruals'
     | '/admin'
     | '/principalInvestigators'
     | '/reports'
     | '/accruals/department/$departmentCode'
     | '/projects/by-number/$projectNumber'
-    | '/projects/$employeeId'
-    | '/projects/$employeeId/$projectNumber/expenditure-categories'
+    | '/projects/$iamId'
+    | '/projects/$iamId/$projectNumber/expenditure-categories'
     | '/reports/reconciliation/$projectNumber/detail'
-    | '/projects/$employeeId/$projectNumber'
+    | '/projects/$iamId/$projectNumber'
     | '/reports/reconciliation/$projectNumber'
   id:
     | '__root__'
@@ -351,22 +351,22 @@ export interface FileRouteTypes {
     | '/(authenticated)/reports'
     | '/(authenticated)/styles'
     | '/(authenticated)/'
-    | '/(authenticated)/projects/$employeeId'
+    | '/(authenticated)/projects/$iamId'
     | '/(authenticated)/accruals/about'
     | '/(authenticated)/admin/email-preview'
     | '/(authenticated)/admin/notification'
     | '/(authenticated)/admin/users'
-    | '/(authenticated)/principalInvestigators/$emplid'
+    | '/(authenticated)/principalInvestigators/$iamId'
     | '/(authenticated)/accruals/'
     | '/(authenticated)/admin/'
     | '/(authenticated)/principalInvestigators/'
     | '/(authenticated)/reports/'
     | '/(authenticated)/accruals/department/$departmentCode'
     | '/(authenticated)/projects/by-number/$projectNumber'
-    | '/(authenticated)/projects/$employeeId/'
-    | '/(authenticated)/projects/$employeeId/$projectNumber/expenditure-categories'
+    | '/(authenticated)/projects/$iamId/'
+    | '/(authenticated)/projects/$iamId/$projectNumber/expenditure-categories'
     | '/(authenticated)/reports/reconciliation/$projectNumber/detail'
-    | '/(authenticated)/projects/$employeeId/$projectNumber/'
+    | '/(authenticated)/projects/$iamId/$projectNumber/'
     | '/(authenticated)/reports/reconciliation/$projectNumber/'
   fileRoutesById: FileRoutesById
 }
@@ -482,11 +482,11 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof authenticatedAccrualsIndexRouteImport
       parentRoute: typeof authenticatedRouteRoute
     }
-    '/(authenticated)/principalInvestigators/$emplid': {
-      id: '/(authenticated)/principalInvestigators/$emplid'
-      path: '/principalInvestigators/$emplid'
-      fullPath: '/principalInvestigators/$emplid'
-      preLoaderRoute: typeof authenticatedPrincipalInvestigatorsEmplidRouteImport
+    '/(authenticated)/principalInvestigators/$iamId': {
+      id: '/(authenticated)/principalInvestigators/$iamId'
+      path: '/principalInvestigators/$iamId'
+      fullPath: '/principalInvestigators/$iamId'
+      preLoaderRoute: typeof authenticatedPrincipalInvestigatorsIamIdRouteImport
       parentRoute: typeof authenticatedRouteRoute
     }
     '/(authenticated)/admin/users': {
@@ -517,19 +517,19 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof authenticatedAccrualsAboutRouteImport
       parentRoute: typeof authenticatedRouteRoute
     }
-    '/(authenticated)/projects/$employeeId': {
-      id: '/(authenticated)/projects/$employeeId'
-      path: '/$employeeId'
-      fullPath: '/projects/$employeeId'
-      preLoaderRoute: typeof authenticatedProjectsEmployeeIdRouteRouteImport
+    '/(authenticated)/projects/$iamId': {
+      id: '/(authenticated)/projects/$iamId'
+      path: '/$iamId'
+      fullPath: '/projects/$iamId'
+      preLoaderRoute: typeof authenticatedProjectsIamIdRouteRouteImport
       parentRoute: typeof authenticatedProjectsRouteRoute
     }
-    '/(authenticated)/projects/$employeeId/': {
-      id: '/(authenticated)/projects/$employeeId/'
+    '/(authenticated)/projects/$iamId/': {
+      id: '/(authenticated)/projects/$iamId/'
       path: '/'
-      fullPath: '/projects/$employeeId/'
-      preLoaderRoute: typeof authenticatedProjectsEmployeeIdIndexRouteImport
-      parentRoute: typeof authenticatedProjectsEmployeeIdRouteRoute
+      fullPath: '/projects/$iamId/'
+      preLoaderRoute: typeof authenticatedProjectsIamIdIndexRouteImport
+      parentRoute: typeof authenticatedProjectsIamIdRouteRoute
     }
     '/(authenticated)/projects/by-number/$projectNumber': {
       id: '/(authenticated)/projects/by-number/$projectNumber'
@@ -552,12 +552,12 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof authenticatedReportsReconciliationProjectNumberIndexRouteImport
       parentRoute: typeof authenticatedReportsRoute
     }
-    '/(authenticated)/projects/$employeeId/$projectNumber/': {
-      id: '/(authenticated)/projects/$employeeId/$projectNumber/'
+    '/(authenticated)/projects/$iamId/$projectNumber/': {
+      id: '/(authenticated)/projects/$iamId/$projectNumber/'
       path: '/$projectNumber'
-      fullPath: '/projects/$employeeId/$projectNumber'
-      preLoaderRoute: typeof authenticatedProjectsEmployeeIdProjectNumberIndexRouteImport
-      parentRoute: typeof authenticatedProjectsEmployeeIdRouteRoute
+      fullPath: '/projects/$iamId/$projectNumber'
+      preLoaderRoute: typeof authenticatedProjectsIamIdProjectNumberIndexRouteImport
+      parentRoute: typeof authenticatedProjectsIamIdRouteRoute
     }
     '/(authenticated)/reports/reconciliation/$projectNumber/detail': {
       id: '/(authenticated)/reports/reconciliation/$projectNumber/detail'
@@ -566,12 +566,12 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof authenticatedReportsReconciliationProjectNumberDetailRouteImport
       parentRoute: typeof authenticatedReportsRoute
     }
-    '/(authenticated)/projects/$employeeId/$projectNumber/expenditure-categories': {
-      id: '/(authenticated)/projects/$employeeId/$projectNumber/expenditure-categories'
+    '/(authenticated)/projects/$iamId/$projectNumber/expenditure-categories': {
+      id: '/(authenticated)/projects/$iamId/$projectNumber/expenditure-categories'
       path: '/$projectNumber/expenditure-categories'
-      fullPath: '/projects/$employeeId/$projectNumber/expenditure-categories'
-      preLoaderRoute: typeof authenticatedProjectsEmployeeIdProjectNumberExpenditureCategoriesRouteImport
-      parentRoute: typeof authenticatedProjectsEmployeeIdRouteRoute
+      fullPath: '/projects/$iamId/$projectNumber/expenditure-categories'
+      preLoaderRoute: typeof authenticatedProjectsIamIdProjectNumberExpenditureCategoriesRouteImport
+      parentRoute: typeof authenticatedProjectsIamIdRouteRoute
     }
   }
 }
@@ -596,36 +596,35 @@ const authenticatedAdminRouteRouteWithChildren =
     authenticatedAdminRouteRouteChildren,
   )
 
-interface authenticatedProjectsEmployeeIdRouteRouteChildren {
-  authenticatedProjectsEmployeeIdIndexRoute: typeof authenticatedProjectsEmployeeIdIndexRoute
-  authenticatedProjectsEmployeeIdProjectNumberExpenditureCategoriesRoute: typeof authenticatedProjectsEmployeeIdProjectNumberExpenditureCategoriesRoute
-  authenticatedProjectsEmployeeIdProjectNumberIndexRoute: typeof authenticatedProjectsEmployeeIdProjectNumberIndexRoute
+interface authenticatedProjectsIamIdRouteRouteChildren {
+  authenticatedProjectsIamIdIndexRoute: typeof authenticatedProjectsIamIdIndexRoute
+  authenticatedProjectsIamIdProjectNumberExpenditureCategoriesRoute: typeof authenticatedProjectsIamIdProjectNumberExpenditureCategoriesRoute
+  authenticatedProjectsIamIdProjectNumberIndexRoute: typeof authenticatedProjectsIamIdProjectNumberIndexRoute
 }
 
-const authenticatedProjectsEmployeeIdRouteRouteChildren: authenticatedProjectsEmployeeIdRouteRouteChildren =
+const authenticatedProjectsIamIdRouteRouteChildren: authenticatedProjectsIamIdRouteRouteChildren =
   {
-    authenticatedProjectsEmployeeIdIndexRoute:
-      authenticatedProjectsEmployeeIdIndexRoute,
-    authenticatedProjectsEmployeeIdProjectNumberExpenditureCategoriesRoute:
-      authenticatedProjectsEmployeeIdProjectNumberExpenditureCategoriesRoute,
-    authenticatedProjectsEmployeeIdProjectNumberIndexRoute:
-      authenticatedProjectsEmployeeIdProjectNumberIndexRoute,
+    authenticatedProjectsIamIdIndexRoute: authenticatedProjectsIamIdIndexRoute,
+    authenticatedProjectsIamIdProjectNumberExpenditureCategoriesRoute:
+      authenticatedProjectsIamIdProjectNumberExpenditureCategoriesRoute,
+    authenticatedProjectsIamIdProjectNumberIndexRoute:
+      authenticatedProjectsIamIdProjectNumberIndexRoute,
   }
 
-const authenticatedProjectsEmployeeIdRouteRouteWithChildren =
-  authenticatedProjectsEmployeeIdRouteRoute._addFileChildren(
-    authenticatedProjectsEmployeeIdRouteRouteChildren,
+const authenticatedProjectsIamIdRouteRouteWithChildren =
+  authenticatedProjectsIamIdRouteRoute._addFileChildren(
+    authenticatedProjectsIamIdRouteRouteChildren,
   )
 
 interface authenticatedProjectsRouteRouteChildren {
-  authenticatedProjectsEmployeeIdRouteRoute: typeof authenticatedProjectsEmployeeIdRouteRouteWithChildren
+  authenticatedProjectsIamIdRouteRoute: typeof authenticatedProjectsIamIdRouteRouteWithChildren
   authenticatedProjectsByNumberProjectNumberRoute: typeof authenticatedProjectsByNumberProjectNumberRoute
 }
 
 const authenticatedProjectsRouteRouteChildren: authenticatedProjectsRouteRouteChildren =
   {
-    authenticatedProjectsEmployeeIdRouteRoute:
-      authenticatedProjectsEmployeeIdRouteRouteWithChildren,
+    authenticatedProjectsIamIdRouteRoute:
+      authenticatedProjectsIamIdRouteRouteWithChildren,
     authenticatedProjectsByNumberProjectNumberRoute:
       authenticatedProjectsByNumberProjectNumberRoute,
   }
@@ -663,7 +662,7 @@ interface authenticatedRouteRouteChildren {
   authenticatedStylesRoute: typeof authenticatedStylesRoute
   authenticatedIndexRoute: typeof authenticatedIndexRoute
   authenticatedAccrualsAboutRoute: typeof authenticatedAccrualsAboutRoute
-  authenticatedPrincipalInvestigatorsEmplidRoute: typeof authenticatedPrincipalInvestigatorsEmplidRoute
+  authenticatedPrincipalInvestigatorsIamIdRoute: typeof authenticatedPrincipalInvestigatorsIamIdRoute
   authenticatedAccrualsIndexRoute: typeof authenticatedAccrualsIndexRoute
   authenticatedPrincipalInvestigatorsIndexRoute: typeof authenticatedPrincipalInvestigatorsIndexRoute
   authenticatedAccrualsDepartmentDepartmentCodeRoute: typeof authenticatedAccrualsDepartmentDepartmentCodeRoute
@@ -680,8 +679,8 @@ const authenticatedRouteRouteChildren: authenticatedRouteRouteChildren = {
   authenticatedStylesRoute: authenticatedStylesRoute,
   authenticatedIndexRoute: authenticatedIndexRoute,
   authenticatedAccrualsAboutRoute: authenticatedAccrualsAboutRoute,
-  authenticatedPrincipalInvestigatorsEmplidRoute:
-    authenticatedPrincipalInvestigatorsEmplidRoute,
+  authenticatedPrincipalInvestigatorsIamIdRoute:
+    authenticatedPrincipalInvestigatorsIamIdRoute,
   authenticatedAccrualsIndexRoute: authenticatedAccrualsIndexRoute,
   authenticatedPrincipalInvestigatorsIndexRoute:
     authenticatedPrincipalInvestigatorsIndexRoute,

--- a/web/client/src/routes/(authenticated)/index.tsx
+++ b/web/client/src/routes/(authenticated)/index.tsx
@@ -31,15 +31,15 @@ function RouteComponent() {
   const [activeTab, setActiveTab] = useState<Tab>('pis');
   const user = useUser();
   const { error, isError, isPending, managedPis } = useManagedPisQuery(
-    user.employeeId
+    user.iamId
   );
 
   const isProjectManager = managedPis.length > 0;
 
   const userProjectsQuery = useQuery({
-    ...projectsDetailQueryOptions(user.employeeId),
+    ...projectsDetailQueryOptions(user.iamId),
     enabled:
-      Boolean(user.employeeId) && !isPending && !isError && !isProjectManager,
+      Boolean(user.iamId) && !isPending && !isError && !isProjectManager,
   });
 
   const isPrincipalInvestigator =
@@ -201,7 +201,7 @@ function RouteComponent() {
               <div className="mt-4">
                 <h2 className="h2">Sponsored Projects</h2>
                 <SponsoredProjectsTable
-                  employeeId={user.employeeId}
+                  iamId={user.iamId}
                   records={sponsoredProjects}
                 />
               </div>
@@ -216,7 +216,7 @@ function RouteComponent() {
                   questions.
                 </p>
                 <InternalProjectsTable
-                  employeeId={user.employeeId}
+                  iamId={user.iamId}
                   records={internalProjects}
                 />
               </div>
@@ -240,7 +240,7 @@ function RouteComponent() {
                     balance={alert.balance}
                     key={alert.id}
                     linkParams={{
-                      employeeId: alert.piEmployeeId,
+                      iamId: user.iamId,
                       projectNumber: alert.projectNumber,
                     }}
                   />

--- a/web/client/src/routes/(authenticated)/personnel.tsx
+++ b/web/client/src/routes/(authenticated)/personnel.tsx
@@ -15,12 +15,12 @@ export const Route = createFileRoute('/(authenticated)/personnel')({
 
 function RouteComponent() {
   const user = useUser();
-  const userProjectsQuery = useProjectsDetailQuery(user.employeeId);
+  const userProjectsQuery = useProjectsDetailQuery(user.iamId);
   const projectCodes = useMemo(() => {
     const projects = userProjectsQuery.data ?? [];
     return [...new Set(projects.map((p) => p.projectNumber))];
   }, [userProjectsQuery.data]);
-  const personnelQuery = usePersonnelQuery(user.employeeId, projectCodes);
+  const personnelQuery = usePersonnelQuery(user.iamId, projectCodes);
 
   const isLoading =
     userProjectsQuery.isPending ||

--- a/web/client/src/routes/(authenticated)/principalInvestigators/$iamId.tsx
+++ b/web/client/src/routes/(authenticated)/principalInvestigators/$iamId.tsx
@@ -5,18 +5,18 @@ import { meQueryOptions } from '@/queries/user.ts';
 import { ROLE_NAMES } from '@/shared/auth/roleAccess.ts';
 
 export const Route = createFileRoute(
-  '/(authenticated)/principalInvestigators/$emplid'
+  '/(authenticated)/principalInvestigators/$iamId'
 )({
   beforeLoad: async ({
     context,
-    params: { emplid },
+    params: { iamId },
   }: {
     context: RouterContext;
-    params: { emplid: string };
+    params: { iamId: string };
   }) => {
     const user = await context.queryClient.ensureQueryData(meQueryOptions());
     const isFinancialViewer = user.roles.includes(ROLE_NAMES.financialViewer);
-    const isSelf = emplid === user.employeeId;
+    const isSelf = iamId === user.iamId;
 
     if (!isFinancialViewer && !isSelf) {
       throw redirect({ to: '/' });
@@ -26,6 +26,6 @@ export const Route = createFileRoute(
 });
 
 function RouteComponent() {
-  const { emplid } = Route.useParams();
-  return <ManagedPisView employeeId={emplid} />;
+  const { iamId } = Route.useParams();
+  return <ManagedPisView iamId={iamId} />;
 }

--- a/web/client/src/routes/(authenticated)/principalInvestigators/index.tsx
+++ b/web/client/src/routes/(authenticated)/principalInvestigators/index.tsx
@@ -29,12 +29,12 @@ export const Route = createFileRoute(
 
 function RouteComponent() {
   const user = useUser();
-  return <ManagedPisView employeeId={user.employeeId} />;
+  return <ManagedPisView iamId={user.iamId} />;
 }
 
-export function ManagedPisView({ employeeId }: { employeeId: string }) {
+export function ManagedPisView({ iamId }: { iamId: string }) {
   const { error, isError, isPending, managedPis, projectManagerName } =
-    useManagedPisQuery(employeeId);
+    useManagedPisQuery(iamId);
 
   if (isPending) {
     return <PageLoading message="Fetching principal investigators..." />;

--- a/web/client/src/routes/(authenticated)/projects/$iamId/$projectNumber/expenditure-categories.tsx
+++ b/web/client/src/routes/(authenticated)/projects/$iamId/$projectNumber/expenditure-categories.tsx
@@ -18,7 +18,7 @@ interface SearchParams {
 }
 
 export const Route = createFileRoute(
-  '/(authenticated)/projects/$employeeId/$projectNumber/expenditure-categories'
+  '/(authenticated)/projects/$iamId/$projectNumber/expenditure-categories'
 )({
   component: RouteComponent,
   validateSearch: (search: Record<string, unknown>): SearchParams => ({
@@ -89,11 +89,11 @@ const csvColumns = [
 ];
 
 function RouteComponent() {
-  const { employeeId, projectNumber } = Route.useParams();
+  const { iamId, projectNumber } = Route.useParams();
   const search = Route.useSearch();
 
   const { data: projects } = useSuspenseQuery(
-    projectsDetailQueryOptions(employeeId)
+    projectsDetailQueryOptions(iamId)
   );
 
   const rows = useMemo(
@@ -213,8 +213,8 @@ function RouteComponent() {
       <section className="mt-8 mb-6">
         <Link
           className="btn btn-sm mb-4"
-          params={{ employeeId, projectNumber }}
-          to="/projects/$employeeId/$projectNumber/"
+          params={{ iamId, projectNumber }}
+          to="/projects/$iamId/$projectNumber/"
         >
           Back to Project
         </Link>

--- a/web/client/src/routes/(authenticated)/projects/$iamId/$projectNumber/index.tsx
+++ b/web/client/src/routes/(authenticated)/projects/$iamId/$projectNumber/index.tsx
@@ -23,7 +23,7 @@ import { createFileRoute } from '@tanstack/react-router';
 import ProjectAdditionalInfo from '@/components/project/ProjectAdditionalInfo.tsx';
 
 export const Route = createFileRoute(
-  '/(authenticated)/projects/$employeeId/$projectNumber/'
+  '/(authenticated)/projects/$iamId/$projectNumber/'
 )({
   component: RouteComponent,
 });
@@ -42,15 +42,15 @@ const ProjectNotFound = ({ projectNumber }: { projectNumber: string }) => (
 );
 
 function ProjectContent({
-  employeeId,
+  iamId,
   projectRecords,
   summary,
 }: {
-  employeeId: string;
+  iamId: string;
   projectRecords: ProjectRecord[];
   summary: ProjectSummary;
 }) {
-  const personnelQuery = usePersonnelQuery(employeeId, [summary.projectNumber]);
+  const personnelQuery = usePersonnelQuery(iamId, [summary.projectNumber]);
   const user = useUser();
   const canSeeDiscrepancy = canViewProjectDiscrepancy(
     user.roles,
@@ -84,10 +84,10 @@ function ProjectContent({
         )}
         <div className="mt-6">
           <ProjectAlerts
-            employeeId={employeeId}
             hasReconciliationDiscrepancy={discrepancies.has(
               summary.projectNumber
             )}
+            iamId={iamId}
             summary={summary}
           />
         </div>
@@ -106,7 +106,7 @@ function ProjectContent({
         </h2>
         <div className="mt-4">
           <TaskBreakdown
-            employeeId={employeeId}
+            iamId={iamId}
             projectNumber={summary.projectNumber}
             records={projectRecords}
           />
@@ -130,9 +130,9 @@ function ProjectContent({
 }
 
 function RouteComponent() {
-  const { employeeId, projectNumber } = Route.useParams();
+  const { iamId, projectNumber } = Route.useParams();
   const { data: projects } = useSuspenseQuery(
-    projectsDetailQueryOptions(employeeId)
+    projectsDetailQueryOptions(iamId)
   );
   const summary = summarizeProjectByNumber(projects, projectNumber);
 
@@ -146,7 +146,7 @@ function RouteComponent() {
 
   return (
     <ProjectContent
-      employeeId={employeeId}
+      iamId={iamId}
       projectRecords={projectRecords}
       summary={summary}
     />

--- a/web/client/src/routes/(authenticated)/projects/$iamId/index.tsx
+++ b/web/client/src/routes/(authenticated)/projects/$iamId/index.tsx
@@ -24,14 +24,14 @@ import { ProjectFundingChart } from '@/components/project/ProjectFundingChart.ts
 import { TooltipLabel } from '@/shared/TooltipLabel.tsx';
 import { tooltipDefinitions } from '@/shared/tooltips.ts';
 
-export const Route = createFileRoute('/(authenticated)/projects/$employeeId/')({
+export const Route = createFileRoute('/(authenticated)/projects/$iamId/')({
   component: RouteComponent,
 });
 
 function RouteComponent() {
-  const { employeeId } = Route.useParams();
+  const { iamId } = Route.useParams();
   const { data: projects } = useSuspenseQuery(
-    projectsDetailQueryOptions(employeeId)
+    projectsDetailQueryOptions(iamId)
   );
 
   const projectNumbers = useMemo(
@@ -75,7 +75,7 @@ function RouteComponent() {
     [projects]
   );
 
-  const personnelQuery = usePersonnelQuery(employeeId, projectNumbers);
+  const personnelQuery = usePersonnelQuery(iamId, projectNumbers);
   const personnelCount = useMemo(() => {
     if (!personnelQuery.data) {
       return null;
@@ -157,7 +157,7 @@ function RouteComponent() {
         <section className="section-margin">
           <h2 className="h2">Sponsored Projects</h2>
           <SponsoredProjectsTable
-            employeeId={employeeId}
+            iamId={iamId}
             records={sponsoredProjects}
           />
         </section>
@@ -173,14 +173,14 @@ function RouteComponent() {
           </p>
           <InternalProjectsTable
             discrepancies={visibleDiscrepancies}
-            employeeId={employeeId}
+            iamId={iamId}
             records={internalProjects}
           />
         </section>
       )}
 
       <PersonnelSection
-        employeeId={employeeId}
+        iamId={iamId}
         projectNumbers={projectNumbers}
       />
     </main>

--- a/web/client/src/routes/(authenticated)/projects/$iamId/route.tsx
+++ b/web/client/src/routes/(authenticated)/projects/$iamId/route.tsx
@@ -11,11 +11,11 @@ import { PageError } from '@/components/states/PageError.tsx';
 import { getErrorPresentation } from '@/lib/errorPresentation.ts';
 import { useUser } from '@/shared/auth/UserContext.tsx';
 
-export const Route = createFileRoute('/(authenticated)/projects/$employeeId')({
+export const Route = createFileRoute('/(authenticated)/projects/$iamId')({
   component: RouteComponent,
   errorComponent: ProjectsErrorBoundary,
-  loader: ({ context: { queryClient }, params: { employeeId } }) =>
-    queryClient.ensureQueryData(projectsDetailQueryOptions(employeeId)),
+  loader: ({ context: { queryClient }, params: { iamId } }) =>
+    queryClient.ensureQueryData(projectsDetailQueryOptions(iamId)),
   pendingComponent: () => <PageLoading message="Fetching projects..." />,
 });
 
@@ -63,8 +63,8 @@ function ProjectsErrorBoundary({ error, reset }: ErrorComponentProps) {
               </button>
               <Link
                 className="btn btn-outline"
-                params={{ employeeId: user.employeeId }}
-                to="/projects/$employeeId"
+                params={{ iamId: user.iamId }}
+                to="/projects/$iamId"
               >
                 Open your projects
               </Link>

--- a/web/client/src/routes/(authenticated)/projects/by-number/$projectNumber.tsx
+++ b/web/client/src/routes/(authenticated)/projects/by-number/$projectNumber.tsx
@@ -20,20 +20,20 @@ function RouteComponent() {
   });
 
   useEffect(() => {
-    const employeeId = resolvePiQuery.data?.employeeId;
-    if (!employeeId) {
+    const iamId = resolvePiQuery.data?.iamId;
+    if (!iamId) {
       return;
     }
 
     navigate({
       params: {
-        employeeId,
+        iamId,
         projectNumber,
       },
       replace: true,
-      to: '/projects/$employeeId/$projectNumber/',
+      to: '/projects/$iamId/$projectNumber/',
     });
-  }, [navigate, projectNumber, resolvePiQuery.data?.employeeId]);
+  }, [navigate, projectNumber, resolvePiQuery.data?.iamId]);
 
   if (resolvePiQuery.isPending) {
     return <PageLoading message={`Finding project owner for ${projectNumber}...`} />;
@@ -51,7 +51,7 @@ function RouteComponent() {
           {isNotFound ? (
             <p>
               We found project <span className="font-mono">{projectNumber}</span>{' '}
-              but could not resolve a principal investigator employee ID.
+              but could not resolve an IAM ID for its project owner.
             </p>
           ) : (
             <p>

--- a/web/client/src/routes/(authenticated)/projects/route.tsx
+++ b/web/client/src/routes/(authenticated)/projects/route.tsx
@@ -7,7 +7,7 @@ export const Route = createFileRoute('/(authenticated)/projects')({
   component: RouteComponent,
   loader: async ({ context: { queryClient } }) => {
     const user = await queryClient.ensureQueryData(meQueryOptions());
-    return queryClient.ensureQueryData(managedPisQueryOptions(user.employeeId));
+    return queryClient.ensureQueryData(managedPisQueryOptions(user.iamId));
   },
   pendingComponent: () => (
     <PageLoading message="Fetching Managed Investigators..." />

--- a/web/client/src/routes/(authenticated)/route.tsx
+++ b/web/client/src/routes/(authenticated)/route.tsx
@@ -46,7 +46,7 @@ function AuthenticatedErrorContent({
   const isForbiddenProjectPortfolio =
     error instanceof HttpError &&
     error.status === 403 &&
-    /^\/api\/project\/[^/]+$/.test(error.url);
+    /^\/api\/project\/by-iam\/[^/]+$/.test(error.url);
 
   const presentation = getErrorPresentation(
     error,
@@ -68,8 +68,8 @@ function AuthenticatedErrorContent({
       </button>
       <Link
         className="btn btn-outline"
-        params={{ employeeId: user.employeeId }}
-        to="/projects/$employeeId"
+        params={{ iamId: user.iamId }}
+        to="/projects/$iamId"
       >
         Open your projects
       </Link>

--- a/web/client/src/test/components/alerts/PiProjectAlerts.test.ts
+++ b/web/client/src/test/components/alerts/PiProjectAlerts.test.ts
@@ -12,6 +12,7 @@ const createPi = (
   }>
 ): PiWithProjects => ({
   employeeId,
+  iamId: `IAM-${employeeId}`,
   name: `PI ${employeeId}`,
   projectCount: projects.length,
   projects: projects as PiWithProjects['projects'],

--- a/web/client/src/test/components/project/ProjectsTable.test.tsx
+++ b/web/client/src/test/components/project/ProjectsTable.test.tsx
@@ -90,7 +90,7 @@ describe('InternalProjectsTable', () => {
     render(
       <InternalProjectsTable
         discrepancies={new Set(['P1'])}
-        employeeId="123"
+        iamId="1000000123"
         records={projects}
       />
     );
@@ -106,7 +106,7 @@ describe('InternalProjectsTable', () => {
     render(
       <InternalProjectsTable
         discrepancies={new Set()}
-        employeeId="123"
+        iamId="1000000123"
         records={projects}
       />
     );
@@ -125,7 +125,7 @@ describe('InternalProjectsTable', () => {
     render(
       <InternalProjectsTable
         discrepancies={new Set()}
-        employeeId="123"
+        iamId="1000000123"
         records={projects}
       />
     );
@@ -143,7 +143,7 @@ describe('InternalProjectsTable', () => {
     render(
       <InternalProjectsTable
         discrepancies={new Set()}
-        employeeId="123"
+        iamId="1000000123"
         records={projects}
       />
     );
@@ -179,7 +179,7 @@ describe('InternalProjectsTable', () => {
     render(
       <InternalProjectsTable
         discrepancies={new Set()}
-        employeeId="123"
+        iamId="1000000123"
         records={projects}
       />
     );
@@ -222,7 +222,7 @@ describe('InternalProjectsTable', () => {
     render(
       <InternalProjectsTable
         discrepancies={new Set()}
-        employeeId="123"
+        iamId="1000000123"
         records={projects}
       />
     );
@@ -264,7 +264,7 @@ describe('InternalProjectsTable', () => {
     render(
       <InternalProjectsTable
         discrepancies={new Set()}
-        employeeId="123"
+        iamId="1000000123"
         records={projects}
       />
     );

--- a/web/client/src/test/components/project/SponsoredProjectsTable.test.tsx
+++ b/web/client/src/test/components/project/SponsoredProjectsTable.test.tsx
@@ -95,7 +95,7 @@ describe('SponsoredProjectsTable', () => {
       }),
     ];
 
-    render(<SponsoredProjectsTable employeeId="123" records={projects} />);
+    render(<SponsoredProjectsTable iamId="1000000123" records={projects} />);
 
     expect(screen.getByRole('button', { name: 'Export' })).toBeInTheDocument();
     expect(
@@ -122,7 +122,7 @@ describe('SponsoredProjectsTable', () => {
       }),
     ];
 
-    render(<SponsoredProjectsTable employeeId="123" records={projects} />);
+    render(<SponsoredProjectsTable iamId="1000000123" records={projects} />);
 
     fireEvent.input(screen.getByPlaceholderText('Search all columns...'), {
       target: { value: 'Sunny' },
@@ -156,7 +156,7 @@ describe('SponsoredProjectsTable', () => {
       }),
     ];
 
-    render(<SponsoredProjectsTable employeeId="123" records={projects} />);
+    render(<SponsoredProjectsTable iamId="1000000123" records={projects} />);
 
     expect(screen.getByText('Sunny Project')).toBeInTheDocument();
     expect(screen.getByText('Rainy Project')).toBeInTheDocument();

--- a/web/client/src/test/components/project/TaskBreakdown.test.tsx
+++ b/web/client/src/test/components/project/TaskBreakdown.test.tsx
@@ -90,7 +90,7 @@ describe('TaskBreakdown', () => {
     const user = userEvent.setup();
     render(
       <TaskBreakdown
-        employeeId="123"
+        iamId="1000000123"
         projectNumber="P1"
         records={[createProject()]}
       />
@@ -117,7 +117,7 @@ describe('TaskBreakdown', () => {
     const user = userEvent.setup();
     render(
       <TaskBreakdown
-        employeeId="123"
+        iamId="1000000123"
         projectNumber="P1"
         records={[createProject()]}
       />
@@ -141,7 +141,7 @@ describe('TaskBreakdown', () => {
   it('shows the filtered export action only when a search filter is active', () => {
     render(
       <TaskBreakdown
-        employeeId="123"
+        iamId="1000000123"
         projectNumber="P1"
         records={[
           createProject({
@@ -179,7 +179,7 @@ describe('TaskBreakdown', () => {
   it('exports only filtered task breakdown rows when the filtered export button is used', () => {
     render(
       <TaskBreakdown
-        employeeId="123"
+        iamId="1000000123"
         projectNumber="P1"
         records={[
           createProject({

--- a/web/client/src/test/components/search/CommandPaletteProvider.test.tsx
+++ b/web/client/src/test/components/search/CommandPaletteProvider.test.tsx
@@ -460,6 +460,7 @@ describe('CommandPaletteProvider', () => {
         HttpResponse.json({
           myManagedProjects: Array.from({ length: 6 }, (_, i) => ({
             keywords: [`MANAGED-${i + 1}`],
+            projectPiIamId: `IAM-MANAGED-PI-${i + 1}`,
             projectName: `Managed Project ${i + 1}`,
             projectNumber: `MANAGED-${i + 1}`,
           })),
@@ -546,6 +547,54 @@ describe('CommandPaletteProvider', () => {
       await waitFor(() =>
         expect(screen.queryByText('Spang Person 6')).not.toBeInTheDocument()
       );
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('hides managed projects that do not have a PI IAM ID', async () => {
+    server.use(
+      http.get('/api/user/me', () => HttpResponse.json(defaultUser)),
+      http.get('/api/search/catalog', () =>
+        HttpResponse.json({ projects: [], reports: [] })
+      ),
+      http.get('/api/search/projects/team', () =>
+        HttpResponse.json({
+          myManagedProjects: [
+            {
+              keywords: ['resolved', 'Resolved Managed Project'],
+              projectPiIamId: 'IAM-PI-2001',
+              projectName: 'Resolved Managed Project',
+              projectNumber: 'RESOLVED-001',
+            },
+            {
+              keywords: ['unresolved', 'Unresolved Managed Project'],
+              projectPiIamId: null,
+              projectName: 'Unresolved Managed Project',
+              projectNumber: 'UNRESOLVED-001',
+            },
+          ],
+          myProjects: [],
+          principalInvestigators: [],
+          projects: [],
+        })
+      )
+    );
+
+    const { cleanup } = renderRoute({ initialPath: '/styles' });
+
+    try {
+      await screen.findByText('Heading 1');
+      const user = userEvent.setup();
+
+      await user.click(screen.getByRole('button', { name: /search…/i }));
+
+      expect(
+        await screen.findByText('Resolved Managed Project')
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByText('Unresolved Managed Project')
+      ).not.toBeInTheDocument();
     } finally {
       cleanup();
     }

--- a/web/client/src/test/components/search/CommandPaletteProvider.test.tsx
+++ b/web/client/src/test/components/search/CommandPaletteProvider.test.tsx
@@ -8,6 +8,7 @@ import { describe, expect, it } from 'vitest';
 const defaultUser = {
   email: 'alpha@example.com',
   employeeId: '1000',
+  iamId: 'IAM-1000',
   id: 'user-1',
   kerberos: 'alpha',
   name: 'Alpha User',
@@ -39,27 +40,32 @@ const setUpPersonResolution = ({
       HttpResponse.json([
         {
           email: 'patty@ucdavis.edu',
-          id: 'entra-patty',
+          id: 'IAM-PATTY',
+          iamId: 'IAM-PATTY',
+          isProjectManager,
           keywords: ['Patty Manager'],
           name: 'Patty Manager',
         },
       ])
     ),
-    http.get('/api/search/people/resolve', () =>
+    http.get('/api/project/managed/by-iam/:iamId', () =>
       HttpResponse.json({
-        email: 'patty@ucdavis.edu',
-        employeeId: 'PM-1',
-        isProjectManager,
-        name: 'Patty Manager',
+        pis: [
+          {
+            employeeId: '2001',
+            iamId: 'IAM-2001',
+            name: 'PI One',
+            projectCount: 1,
+          },
+        ],
+        projectManager: {
+          employeeId: 'PM-1',
+          iamId: 'IAM-PATTY',
+          name: 'Patty Manager',
+        },
       })
     ),
-    http.get('/api/project/managed/:employeeId', () =>
-      HttpResponse.json({
-        pis: [{ employeeId: '2001', name: 'PI One', projectCount: 1 }],
-        projectManager: { employeeId: 'PM-1', name: 'Patty Manager' },
-      })
-    ),
-    http.get('/api/project/:employeeId', () => HttpResponse.json([])),
+    http.get('/api/project/by-iam/:iamId', () => HttpResponse.json([])),
     http.get('/api/project/personnel', () => HttpResponse.json([]))
   );
 };
@@ -172,7 +178,7 @@ describe('CommandPaletteProvider', () => {
           myProjects: [
             {
               keywords: ['P-001', 'Alpha'],
-              projectPiEmployeeId: '2001',
+              projectPiIamId: 'IAM-2001',
               projectName: 'Project Alpha',
               projectNumber: 'P-001',
             },
@@ -181,7 +187,7 @@ describe('CommandPaletteProvider', () => {
           projects: [
             {
               keywords: ['P-001', 'Alpha'],
-              projectPiEmployeeId: '2001',
+              projectPiIamId: 'IAM-2001',
               projectName: 'Project Alpha',
               projectNumber: 'P-001',
             },
@@ -280,8 +286,8 @@ describe('CommandPaletteProvider', () => {
           myProjects: [],
           principalInvestigators: [
             {
-              employeeId: '2001',
-              keywords: ['Alice', '2001'],
+              iamId: 'IAM-2001',
+              keywords: ['Alice'],
               name: 'Alice Example',
             },
           ],
@@ -323,7 +329,7 @@ describe('CommandPaletteProvider', () => {
           myManagedProjects: [
             {
               keywords: ['seeded', 'Seeded PM Project', 'SEED-001'],
-              projectPiEmployeeId: '2001',
+              projectPiIamId: 'IAM-2001',
               projectName: 'Seeded PM Project',
               projectNumber: 'SEED-001',
             },
@@ -331,28 +337,28 @@ describe('CommandPaletteProvider', () => {
           myProjects: [
             {
               keywords: ['seeded', 'Seeded PI Project', 'SEED-PI-001'],
-              projectPiEmployeeId: '2002',
+              projectPiIamId: 'IAM-2002',
               projectName: 'Seeded PI Project',
               projectNumber: 'SEED-PI-001',
             },
           ],
           principalInvestigators: [
             {
-              employeeId: '2001',
-              keywords: ['Alice Example', '2001'],
+              iamId: 'IAM-2001',
+              keywords: ['Alice Example'],
               name: 'Alice Example',
             },
           ],
           projects: [
             {
               keywords: ['seeded', 'Seeded PM Project', 'SEED-001'],
-              projectPiEmployeeId: '2001',
+              projectPiIamId: 'IAM-2001',
               projectName: 'Seeded PM Project',
               projectNumber: 'SEED-001',
             },
             {
               keywords: ['seeded', 'Seeded PI Project', 'SEED-PI-001'],
-              projectPiEmployeeId: '2002',
+              projectPiIamId: 'IAM-2002',
               projectName: 'Seeded PI Project',
               projectNumber: 'SEED-PI-001',
             },
@@ -382,7 +388,9 @@ describe('CommandPaletteProvider', () => {
           return HttpResponse.json([
             {
               email: 'esspang@ucdavis.edu',
-              id: 'entra-esspang',
+              id: 'IAM-ESSPANG',
+              iamId: 'IAM-ESSPANG',
+              isProjectManager: false,
               keywords: ['Edward Spang', 'esspang@ucdavis.edu'],
               name: 'Edward Spang',
             },
@@ -461,7 +469,7 @@ describe('CommandPaletteProvider', () => {
             projectNumber: `MINE-${i + 1}`,
           })),
           principalInvestigators: Array.from({ length: 6 }, (_, i) => ({
-            employeeId: `PI-${i + 1}`,
+            iamId: `IAM-PI-${i + 1}`,
             keywords: [`PI ${i + 1}`],
             name: `PI ${i + 1}`,
           })),
@@ -493,7 +501,9 @@ describe('CommandPaletteProvider', () => {
         return HttpResponse.json(
           Array.from({ length: 6 }, (_, i) => ({
             email: `spang${i + 1}@ucdavis.edu`,
-            id: `entra-spang-${i + 1}`,
+            id: `IAM-SPANG-${i + 1}`,
+            iamId: `IAM-SPANG-${i + 1}`,
+            isProjectManager: false,
             keywords: [`Spang ${i + 1}`],
             name: `Spang Person ${i + 1}`,
           }))
@@ -563,7 +573,7 @@ describe('CommandPaletteProvider', () => {
 
         await waitFor(() => {
           expect(router.state.location.pathname).toBe(
-            '/principalInvestigators/PM-1'
+            '/principalInvestigators/IAM-PATTY'
           );
         });
       } finally {
@@ -591,7 +601,7 @@ describe('CommandPaletteProvider', () => {
         await user.click(result);
 
         await waitFor(() => {
-          expect(router.state.location.pathname).toBe('/projects/PM-1');
+          expect(router.state.location.pathname).toBe('/projects/IAM-PATTY');
         });
       } finally {
         cleanup();

--- a/web/client/src/test/components/search/SearchButton.test.tsx
+++ b/web/client/src/test/components/search/SearchButton.test.tsx
@@ -7,6 +7,7 @@ const openMock = vi.fn();
 const defaultUser: User = {
   email: 'user@example.com',
   employeeId: '12345',
+  iamId: '1000012345',
   id: '1',
   kerberos: 'user',
   name: 'Test User',

--- a/web/client/src/test/routes/(authenticated)/accruals-access.test.tsx
+++ b/web/client/src/test/routes/(authenticated)/accruals-access.test.tsx
@@ -7,6 +7,7 @@ import { renderRoute } from '@/test/routerUtils.tsx';
 const createUser = (roles: string[]) => ({
   email: 'test@example.com',
   employeeId: '1000',
+  iamId: 'IAM-1000',
   id: 'user-1',
   kerberos: 'testuser',
   name: 'Test User',
@@ -20,10 +21,10 @@ describe('Accruals access control', () => {
         http.get('/api/user/me', () =>
           HttpResponse.json(createUser(['AccrualViewer']))
         ),
-        http.get('/api/project/managed/:employeeId', () =>
+        http.get('/api/project/managed/by-iam/:iamId', () =>
           HttpResponse.json({ pis: [], projectManager: null })
         ),
-        http.get('/api/project/:employeeId', () => HttpResponse.json([])),
+        http.get('/api/project/by-iam/:iamId', () => HttpResponse.json([])),
         http.get('/api/project/personnel', () => HttpResponse.json([]))
       );
 
@@ -42,10 +43,10 @@ describe('Accruals access control', () => {
     it('hides Accruals link for default users', async () => {
       server.use(
         http.get('/api/user/me', () => HttpResponse.json(createUser([]))),
-        http.get('/api/project/managed/:employeeId', () =>
+        http.get('/api/project/managed/by-iam/:iamId', () =>
           HttpResponse.json({ pis: [], projectManager: null })
         ),
-        http.get('/api/project/:employeeId', () => HttpResponse.json([])),
+        http.get('/api/project/by-iam/:iamId', () => HttpResponse.json([])),
         http.get('/api/project/personnel', () => HttpResponse.json([]))
       );
 

--- a/web/client/src/test/routes/(authenticated)/admin-access.test.tsx
+++ b/web/client/src/test/routes/(authenticated)/admin-access.test.tsx
@@ -7,6 +7,7 @@ import { describe, expect, it } from 'vitest';
 const createUser = (roles: string[]) => ({
   email: 'test@example.com',
   employeeId: '1000',
+  iamId: 'IAM-1000',
   id: 'user-1',
   kerberos: 'testuser',
   name: 'Test User',
@@ -15,8 +16,8 @@ const createUser = (roles: string[]) => ({
 
 const registerHomeApis = () => {
   server.use(
-    http.get('/api/project/managed/:employeeId', () => HttpResponse.json({ pis: [], projectManager: null })),
-    http.get('/api/project/:employeeId', () => HttpResponse.json([])),
+    http.get('/api/project/managed/by-iam/:iamId', () => HttpResponse.json({ pis: [], projectManager: null })),
+    http.get('/api/project/by-iam/:iamId', () => HttpResponse.json([])),
     http.get('/api/project/personnel', () => HttpResponse.json([]))
   );
 };

--- a/web/client/src/test/routes/(authenticated)/admin-email-preview.test.tsx
+++ b/web/client/src/test/routes/(authenticated)/admin-email-preview.test.tsx
@@ -16,10 +16,10 @@ const createUser = (roles: string[]) => ({
 
 const registerHomeApis = () => {
   server.use(
-    http.get('/api/project/managed/:employeeId', () =>
+    http.get('/api/project/managed/by-iam/:iamId', () =>
       HttpResponse.json({ pis: [], projectManager: null })
     ),
-    http.get('/api/project/:employeeId', () => HttpResponse.json([])),
+    http.get('/api/project/by-iam/:iamId', () => HttpResponse.json([])),
     http.get('/api/project/personnel', () => HttpResponse.json([]))
   );
 };

--- a/web/client/src/test/routes/(authenticated)/admin-email-preview.test.tsx
+++ b/web/client/src/test/routes/(authenticated)/admin-email-preview.test.tsx
@@ -8,6 +8,7 @@ import { describe, expect, it } from 'vitest';
 const createUser = (roles: string[]) => ({
   email: 'test@example.com',
   employeeId: '1000',
+  iamId: 'IAM-1000',
   id: 'user-1',
   kerberos: 'testuser',
   name: 'Test User',

--- a/web/client/src/test/routes/(authenticated)/admin-notification.test.tsx
+++ b/web/client/src/test/routes/(authenticated)/admin-notification.test.tsx
@@ -16,8 +16,8 @@ const createUser = (roles: string[]) => ({
 
 const registerHomeApis = () => {
   server.use(
-    http.get('/api/project/managed/:employeeId', () => HttpResponse.json([])),
-    http.get('/api/project/:employeeId', () => HttpResponse.json([])),
+    http.get('/api/project/managed/by-iam/:iamId', () => HttpResponse.json([])),
+    http.get('/api/project/by-iam/:iamId', () => HttpResponse.json([])),
     http.get('/api/project/personnel', () => HttpResponse.json([]))
   );
 };

--- a/web/client/src/test/routes/(authenticated)/admin-notification.test.tsx
+++ b/web/client/src/test/routes/(authenticated)/admin-notification.test.tsx
@@ -8,6 +8,7 @@ import { renderRoute } from '@/test/routerUtils.tsx';
 const createUser = (roles: string[]) => ({
   email: 'test@example.com',
   employeeId: '1000',
+  iamId: 'IAM-1000',
   id: 'user-1',
   kerberos: 'testuser',
   name: 'Test User',
@@ -16,7 +17,9 @@ const createUser = (roles: string[]) => ({
 
 const registerHomeApis = () => {
   server.use(
-    http.get('/api/project/managed/by-iam/:iamId', () => HttpResponse.json([])),
+    http.get('/api/project/managed/by-iam/:iamId', () =>
+      HttpResponse.json({ pis: [], projectManager: null })
+    ),
     http.get('/api/project/by-iam/:iamId', () => HttpResponse.json([])),
     http.get('/api/project/personnel', () => HttpResponse.json([]))
   );

--- a/web/client/src/test/routes/(authenticated)/admin-users.test.tsx
+++ b/web/client/src/test/routes/(authenticated)/admin-users.test.tsx
@@ -16,8 +16,8 @@ const createUser = (roles: string[]) => ({
 
 const registerHomeApis = () => {
   server.use(
-    http.get('/api/project/managed/:employeeId', () => HttpResponse.json({ pis: [], projectManager: null })),
-    http.get('/api/project/:employeeId', () => HttpResponse.json([])),
+    http.get('/api/project/managed/by-iam/:iamId', () => HttpResponse.json({ pis: [], projectManager: null })),
+    http.get('/api/project/by-iam/:iamId', () => HttpResponse.json([])),
     http.get('/api/project/personnel', () => HttpResponse.json([]))
   );
 };

--- a/web/client/src/test/routes/(authenticated)/admin-users.test.tsx
+++ b/web/client/src/test/routes/(authenticated)/admin-users.test.tsx
@@ -8,6 +8,7 @@ import { describe, expect, it } from 'vitest';
 const createUser = (roles: string[]) => ({
   email: 'test@example.com',
   employeeId: '1000',
+  iamId: 'IAM-1000',
   id: 'user-1',
   kerberos: 'testuser',
   name: 'Test User',
@@ -16,7 +17,9 @@ const createUser = (roles: string[]) => ({
 
 const registerHomeApis = () => {
   server.use(
-    http.get('/api/project/managed/by-iam/:iamId', () => HttpResponse.json({ pis: [], projectManager: null })),
+    http.get('/api/project/managed/by-iam/:iamId', () =>
+      HttpResponse.json({ pis: [], projectManager: null })
+    ),
     http.get('/api/project/by-iam/:iamId', () => HttpResponse.json([])),
     http.get('/api/project/personnel', () => HttpResponse.json([]))
   );

--- a/web/client/src/test/routes/(authenticated)/employee-projects.test.tsx
+++ b/web/client/src/test/routes/(authenticated)/employee-projects.test.tsx
@@ -89,13 +89,14 @@ const setupHandlers = ({
 }: {
   projects: ProjectRecord[];
   reconciliation: ReturnType<typeof discrepancyRecord>[];
-  user: { employeeId: string; name: string; roles: string[] };
+  user: { employeeId: string; iamId: string; name: string; roles: string[] };
 }) => {
   server.use(
     http.get('/api/user/me', () =>
       HttpResponse.json({
         email: `${user.name.toLowerCase()}@example.com`,
         employeeId: user.employeeId,
+        iamId: user.iamId,
         id: 'user-1',
         kerberos: user.name.toLowerCase(),
         name: user.name,
@@ -119,10 +120,15 @@ describe('employee project list — discrepancy icon gating', () => {
     setupHandlers({
       projects,
       reconciliation: [discrepancyRecord('P1')],
-      user: { employeeId: '1000', name: 'PI User', roles: [] },
+      user: {
+        employeeId: '1000',
+        iamId: 'IAM-1000',
+        name: 'PI User',
+        roles: [],
+      },
     });
 
-    const { cleanup } = renderRoute({ initialPath: '/projects/1000' });
+    const { cleanup } = renderRoute({ initialPath: '/projects/IAM-1000' });
 
     try {
       await screen.findByText('Internal Projects');
@@ -133,5 +139,4 @@ describe('employee project list — discrepancy icon gating', () => {
       cleanup();
     }
   });
-
 });

--- a/web/client/src/test/routes/(authenticated)/employee-projects.test.tsx
+++ b/web/client/src/test/routes/(authenticated)/employee-projects.test.tsx
@@ -102,10 +102,10 @@ const setupHandlers = ({
         roles: user.roles,
       })
     ),
-    http.get('/api/project/managed/:employeeId', () =>
+    http.get('/api/project/managed/by-iam/:iamId', () =>
       HttpResponse.json({ pis: [], projectManager: null })
     ),
-    http.get('/api/project/:employeeId', () => HttpResponse.json(projects)),
+    http.get('/api/project/by-iam/:iamId', () => HttpResponse.json(projects)),
     http.get('/api/project/personnel', () => HttpResponse.json([])),
     http.get('/api/project/gl-ppm-reconciliation', () =>
       HttpResponse.json(reconciliation)

--- a/web/client/src/test/routes/(authenticated)/index.test.tsx
+++ b/web/client/src/test/routes/(authenticated)/index.test.tsx
@@ -18,6 +18,7 @@ const createPi = (
   }>
 ): PiWithProjects => ({
   employeeId,
+  iamId: `IAM-${employeeId}`,
   name: `PI ${employeeId}`,
   projectCount: projects.length,
   projects: projects as PiWithProjects['projects'],
@@ -28,13 +29,14 @@ const createPi = (
 describe('home route', () => {
   it('renders managed investigators dashboard when user manages investigators', async () => {
     const managedPis = [
-      { employeeId: '2001', name: 'PI One', projectCount: 2 },
-      { employeeId: '2002', name: 'PI Two', projectCount: 1 },
+      { employeeId: '2001', iamId: 'IAM-2001', name: 'PI One', projectCount: 2 },
+      { employeeId: '2002', iamId: 'IAM-2002', name: 'PI Two', projectCount: 1 },
     ];
 
     const user = {
       email: 'alpha@example.com',
       employeeId: '1000',
+      iamId: 'IAM-1000',
       id: 'user-1',
       kerberos: 'alpha',
       name: 'Alpha User',
@@ -45,9 +47,9 @@ describe('home route', () => {
     let userRequestCount = 0;
 
     server.use(
-      http.get('/api/project/managed/:employeeId', ({ params }) => {
+      http.get('/api/project/managed/by-iam/:iamId', ({ params }) => {
         managedRequestCount += 1;
-        if (params.employeeId !== user.employeeId) {
+        if (params.iamId !== user.iamId) {
           return HttpResponse.json(
             { pis: [], projectManager: null },
             { status: 400 }
@@ -55,10 +57,14 @@ describe('home route', () => {
         }
         return HttpResponse.json({
           pis: managedPis,
-          projectManager: { employeeId: user.employeeId, name: user.name },
+          projectManager: {
+            employeeId: user.employeeId,
+            iamId: user.iamId,
+            name: user.name,
+          },
         });
       }),
-      http.get('/api/project/:employeeId', () => {
+      http.get('/api/project/by-iam/:iamId', () => {
         // Return empty projects for each PI
         return HttpResponse.json([]);
       }),
@@ -88,6 +94,7 @@ describe('home route', () => {
     const user = {
       email: 'alpha@example.com',
       employeeId: '1000',
+      iamId: 'IAM-1000',
       id: 'user-1',
       kerberos: 'alpha',
       name: 'Alpha User',
@@ -113,10 +120,10 @@ describe('home route', () => {
 
     server.use(
       http.get('/api/user/me', () => HttpResponse.json(user)),
-      http.get('/api/project/managed/:employeeId', () =>
+      http.get('/api/project/managed/by-iam/:iamId', () =>
         HttpResponse.json({ pis: [], projectManager: null })
       ),
-      http.get('/api/project/:employeeId', () => HttpResponse.json(projects)),
+      http.get('/api/project/by-iam/:iamId', () => HttpResponse.json(projects)),
       http.get('/api/project/personnel', () => HttpResponse.json([]))
     );
 
@@ -138,6 +145,7 @@ describe('home route', () => {
     const user = {
       email: 'alpha@example.com',
       employeeId: '1000',
+      iamId: 'IAM-1000',
       id: 'user-1',
       kerberos: 'alpha',
       name: 'Alpha User',
@@ -171,10 +179,10 @@ describe('home route', () => {
 
     server.use(
       http.get('/api/user/me', () => HttpResponse.json(user)),
-      http.get('/api/project/managed/:employeeId', () =>
+      http.get('/api/project/managed/by-iam/:iamId', () =>
         HttpResponse.json({ pis: [], projectManager: null })
       ),
-      http.get('/api/project/:employeeId', () => HttpResponse.json(projects)),
+      http.get('/api/project/by-iam/:iamId', () => HttpResponse.json(projects)),
       http.get('/api/project/personnel', () => HttpResponse.json([]))
     );
 
@@ -198,6 +206,7 @@ describe('home route', () => {
     const user = {
       email: 'alpha@example.com',
       employeeId: '1000',
+      iamId: 'IAM-1000',
       id: 'user-1',
       kerberos: 'alpha',
       name: 'Alpha User',
@@ -206,10 +215,10 @@ describe('home route', () => {
 
     server.use(
       http.get('/api/user/me', () => HttpResponse.json(user)),
-      http.get('/api/project/managed/:employeeId', () =>
+      http.get('/api/project/managed/by-iam/:iamId', () =>
         HttpResponse.json({ pis: [], projectManager: null })
       ),
-      http.get('/api/project/:employeeId', () => HttpResponse.json([])),
+      http.get('/api/project/by-iam/:iamId', () => HttpResponse.json([])),
       http.get('/api/project/personnel', () => HttpResponse.json([])),
     );
 
@@ -230,7 +239,7 @@ describe('home route', () => {
 
   it('switches between PIs and Alerts tabs', async () => {
     const managedPis = [
-      { employeeId: '2001', name: 'PI One', projectCount: 2 },
+      { employeeId: '2001', iamId: 'IAM-2001', name: 'PI One', projectCount: 2 },
     ];
 
     const projects = [
@@ -246,6 +255,7 @@ describe('home route', () => {
     const testUser = {
       email: 'alpha@example.com',
       employeeId: '1000',
+      iamId: 'IAM-1000',
       id: 'user-1',
       kerberos: 'alpha',
       name: 'Alpha User',
@@ -253,16 +263,17 @@ describe('home route', () => {
     };
 
     server.use(
-      http.get('/api/project/managed/:employeeId', () =>
+      http.get('/api/project/managed/by-iam/:iamId', () =>
         HttpResponse.json({
           pis: managedPis,
           projectManager: {
             employeeId: testUser.employeeId,
+            iamId: testUser.iamId,
             name: testUser.name,
           },
         })
       ),
-      http.get('/api/project/:employeeId', () => HttpResponse.json(projects)),
+      http.get('/api/project/by-iam/:iamId', () => HttpResponse.json(projects)),
       http.get('/api/user/me', () => HttpResponse.json(testUser)),
       http.get('/api/project/personnel', () => HttpResponse.json([]))
     );
@@ -301,6 +312,7 @@ describe('home route', () => {
     const testUser = {
       email: 'pi@example.com',
       employeeId: '1000',
+      iamId: 'IAM-1000',
       id: 'user-1',
       kerberos: 'piuser',
       name: 'PI User',
@@ -323,10 +335,10 @@ describe('home route', () => {
     let reconciliationCalls = 0;
     server.use(
       http.get('/api/user/me', () => HttpResponse.json(testUser)),
-      http.get('/api/project/managed/:employeeId', () =>
+      http.get('/api/project/managed/by-iam/:iamId', () =>
         HttpResponse.json({ pis: [], projectManager: null })
       ),
-      http.get('/api/project/:employeeId', () => HttpResponse.json(projects)),
+      http.get('/api/project/by-iam/:iamId', () => HttpResponse.json(projects)),
       http.get('/api/project/personnel', () => HttpResponse.json([])),
       http.get('/api/project/gl-ppm-reconciliation', () => {
         reconciliationCalls += 1;

--- a/web/client/src/test/routes/(authenticated)/nav-access.test.tsx
+++ b/web/client/src/test/routes/(authenticated)/nav-access.test.tsx
@@ -7,6 +7,7 @@ import { renderRoute } from '@/test/routerUtils.tsx';
 const createUser = (roles: string[]) => ({
   email: 'test@example.com',
   employeeId: '1000',
+  iamId: 'IAM-1000',
   id: 'user-1',
   kerberos: 'testuser',
   name: 'Test User',
@@ -15,8 +16,8 @@ const createUser = (roles: string[]) => ({
 
 const registerHomeApis = () => {
   server.use(
-    http.get('/api/project/managed/:employeeId', () => HttpResponse.json({ pis: [], projectManager: null })),
-    http.get('/api/project/:employeeId', () => HttpResponse.json([])),
+    http.get('/api/project/managed/by-iam/:iamId', () => HttpResponse.json({ pis: [], projectManager: null })),
+    http.get('/api/project/by-iam/:iamId', () => HttpResponse.json([])),
     http.get('/api/project/personnel', () => HttpResponse.json([]))
   );
 };

--- a/web/client/src/test/routes/(authenticated)/personnel.test.tsx
+++ b/web/client/src/test/routes/(authenticated)/personnel.test.tsx
@@ -7,6 +7,7 @@ import { renderRoute } from '@/test/routerUtils.tsx';
 const mockUser = {
   email: 'test@example.com',
   employeeId: '1000',
+  iamId: 'IAM-1000',
   id: 'user-1',
   kerberos: 'testuser',
   name: 'Test User',
@@ -86,7 +87,7 @@ describe('personnel page', () => {
       http.get('/api/user/me', () => HttpResponse.json(mockUser)),
       // Personnel handler must be before :employeeId to avoid conflict
       http.get('/api/project/personnel', () => HttpResponse.json(personnel)),
-      http.get('/api/project/:employeeId', () => HttpResponse.json(projects))
+      http.get('/api/project/by-iam/:iamId', () => HttpResponse.json(projects))
     );
 
     const { cleanup } = renderRoute({ initialPath: '/personnel' });

--- a/web/client/src/test/routes/(authenticated)/principal-investigators.test.tsx
+++ b/web/client/src/test/routes/(authenticated)/principal-investigators.test.tsx
@@ -7,6 +7,7 @@ import { renderRoute } from '@/test/routerUtils.tsx';
 const createUser = (roles: string[]) => ({
   email: 'test@example.com',
   employeeId: '1000',
+  iamId: 'IAM-1000',
   id: 'user-1',
   kerberos: 'testuser',
   name: 'Test User',
@@ -20,10 +21,10 @@ const emptyManagedResponse = {
 
 const managedResponse = (name: string | null = 'Test User') => ({
   pis: [
-    { employeeId: '2001', name: 'PI One', projectCount: 2 },
-    { employeeId: '2002', name: 'PI Two', projectCount: 1 },
+    { employeeId: '2001', iamId: 'IAM-2001', name: 'PI One', projectCount: 2 },
+    { employeeId: '2002', iamId: 'IAM-2002', name: 'PI Two', projectCount: 1 },
   ],
-  projectManager: { employeeId: '1000', name },
+  projectManager: { employeeId: '1000', iamId: 'IAM-1000', name },
 });
 
 describe('principal investigators route', () => {
@@ -32,7 +33,7 @@ describe('principal investigators route', () => {
       http.get('/api/user/me', () =>
         HttpResponse.json(createUser(['FinancialViewer']))
       ),
-      http.get('/api/project/managed/:employeeId', () =>
+      http.get('/api/project/managed/by-iam/:iamId', () =>
         HttpResponse.json(managedResponse())
       )
     );
@@ -60,7 +61,7 @@ describe('principal investigators route', () => {
       http.get('/api/user/me', () =>
         HttpResponse.json(createUser(['FinancialViewer']))
       ),
-      http.get('/api/project/managed/:employeeId', () =>
+      http.get('/api/project/managed/by-iam/:iamId', () =>
         HttpResponse.json(managedResponse(null))
       )
     );
@@ -83,7 +84,7 @@ describe('principal investigators route', () => {
       http.get('/api/user/me', () =>
         HttpResponse.json(createUser(['ProjectManager']))
       ),
-      http.get('/api/project/managed/:employeeId', () =>
+      http.get('/api/project/managed/by-iam/:iamId', () =>
         HttpResponse.json(emptyManagedResponse)
       )
     );
@@ -101,13 +102,52 @@ describe('principal investigators route', () => {
     }
   });
 
+  it('links managed investigators only when an IAM ID is present', async () => {
+    server.use(
+      http.get('/api/user/me', () =>
+        HttpResponse.json(createUser(['FinancialViewer']))
+      ),
+      http.get('/api/project/managed/by-iam/:iamId', () =>
+        HttpResponse.json({
+          pis: [
+            {
+              employeeId: '2001',
+              iamId: 'IAM-PI-ONE',
+              name: 'PI One',
+              projectCount: 2,
+            },
+            {
+              employeeId: '2002',
+              iamId: null,
+              name: 'PI Two',
+              projectCount: 1,
+            },
+          ],
+          projectManager: { employeeId: '1000', iamId: 'IAM-1000', name: 'Test User' },
+        })
+      )
+    );
+
+    const { cleanup } = renderRoute({
+      initialPath: '/principalInvestigators',
+    });
+
+    try {
+      const linkedPi = await screen.findByRole('link', { name: 'PI One' });
+      expect(linkedPi).toHaveAttribute('href', '/projects/IAM-PI-ONE');
+      expect(screen.getByText('PI Two').closest('a')).toBeNull();
+    } finally {
+      cleanup();
+    }
+  });
+
   it('redirects unauthorized users back to home', async () => {
     server.use(
       http.get('/api/user/me', () => HttpResponse.json(createUser([]))),
-      http.get('/api/project/managed/:employeeId', () =>
+      http.get('/api/project/managed/by-iam/:iamId', () =>
         HttpResponse.json(emptyManagedResponse)
       ),
-      http.get('/api/project/:employeeId', () => HttpResponse.json([])),
+      http.get('/api/project/by-iam/:iamId', () => HttpResponse.json([])),
       http.get('/api/project/personnel', () => HttpResponse.json([]))
     );
 
@@ -127,22 +167,22 @@ describe('principal investigators route', () => {
   });
 });
 
-describe('principal investigators $emplid route', () => {
+describe('principal investigators $iamId route', () => {
   it('allows a FinancialViewer to view another PM', async () => {
     server.use(
       http.get('/api/user/me', () =>
         HttpResponse.json(createUser(['FinancialViewer']))
       ),
-      http.get('/api/project/managed/:employeeId', () =>
+      http.get('/api/project/managed/by-iam/:iamId', () =>
         HttpResponse.json({
-          pis: [{ employeeId: '2001', name: 'PI One', projectCount: 2 }],
-          projectManager: { employeeId: '9999', name: 'Other PM' },
+          pis: [{ employeeId: '2001', iamId: 'IAM-2001', name: 'PI One', projectCount: 2 }],
+          projectManager: { employeeId: '9999', iamId: 'IAM-9999', name: 'Other PM' },
         })
       )
     );
 
     const { cleanup } = renderRoute({
-      initialPath: '/principalInvestigators/9999',
+      initialPath: '/principalInvestigators/IAM-9999',
     });
 
     try {
@@ -155,18 +195,18 @@ describe('principal investigators $emplid route', () => {
     }
   });
 
-  it('allows a user to view their own managed PIs via $emplid', async () => {
+  it('allows a user to view their own managed PIs via $iamId', async () => {
     server.use(
       http.get('/api/user/me', () =>
         HttpResponse.json(createUser(['ProjectManager']))
       ),
-      http.get('/api/project/managed/:employeeId', () =>
+      http.get('/api/project/managed/by-iam/:iamId', () =>
         HttpResponse.json(managedResponse())
       )
     );
 
     const { cleanup } = renderRoute({
-      initialPath: '/principalInvestigators/1000',
+      initialPath: '/principalInvestigators/IAM-1000',
     });
 
     try {
@@ -183,15 +223,15 @@ describe('principal investigators $emplid route', () => {
       http.get('/api/user/me', () =>
         HttpResponse.json(createUser(['ProjectManager']))
       ),
-      http.get('/api/project/managed/:employeeId', () =>
+      http.get('/api/project/managed/by-iam/:iamId', () =>
         HttpResponse.json(emptyManagedResponse)
       ),
-      http.get('/api/project/:employeeId', () => HttpResponse.json([])),
+      http.get('/api/project/by-iam/:iamId', () => HttpResponse.json([])),
       http.get('/api/project/personnel', () => HttpResponse.json([]))
     );
 
     const { cleanup } = renderRoute({
-      initialPath: '/principalInvestigators/9999',
+      initialPath: '/principalInvestigators/IAM-9999',
     });
 
     try {

--- a/web/client/src/test/routes/(authenticated)/project-detail.test.tsx
+++ b/web/client/src/test/routes/(authenticated)/project-detail.test.tsx
@@ -83,8 +83,8 @@ const setupHandlers = (
         roles: [],
       })
     ),
-    http.get('/api/project/managed/:employeeId', () => HttpResponse.json({ pis: [], projectManager: null })),
-    http.get('/api/project/:employeeId', () => HttpResponse.json(projects)),
+    http.get('/api/project/managed/by-iam/:iamId', () => HttpResponse.json({ pis: [], projectManager: null })),
+    http.get('/api/project/by-iam/:iamId', () => HttpResponse.json(projects)),
     http.get('/api/project/personnel', () => HttpResponse.json([])),
     http.get('/api/project/gl-ppm-reconciliation', () => HttpResponse.json([]))
   );
@@ -143,9 +143,9 @@ describe('project detail page', () => {
           roles: [],
         })
       ),
-      http.get('/api/project/managed/:employeeId', () => HttpResponse.json({ pis: [], projectManager: null })),
-      http.get('/api/project/:employeeId', ({ params }) => {
-        if (params.employeeId === '10212674') {
+      http.get('/api/project/managed/by-iam/:iamId', () => HttpResponse.json({ pis: [], projectManager: null })),
+      http.get('/api/project/by-iam/:iamId', ({ params }) => {
+        if (params.iamId === '10212674') {
           return HttpResponse.json(
             { message: 'You are not allowed to view this portfolio.' },
             { status: 403 }
@@ -293,10 +293,10 @@ describe('project detail page', () => {
             roles: user.roles,
           })
         ),
-        http.get('/api/project/managed/:employeeId', () =>
+        http.get('/api/project/managed/by-iam/:iamId', () =>
           HttpResponse.json({ pis: [], projectManager: null })
         ),
-        http.get('/api/project/:employeeId', () =>
+        http.get('/api/project/by-iam/:iamId', () =>
           HttpResponse.json(projects)
         ),
         http.get('/api/project/personnel', () => HttpResponse.json([])),

--- a/web/server.core/Models/SearchablePersonRecord.cs
+++ b/web/server.core/Models/SearchablePersonRecord.cs
@@ -1,0 +1,18 @@
+using System.Text.Json.Serialization;
+
+namespace server.core.Models;
+
+public sealed class SearchablePersonRecord
+{
+    [JsonPropertyName("iamId")]
+    public string IamId { get; set; } = string.Empty;
+
+    [JsonPropertyName("employeeId")]
+    public string EmployeeId { get; set; } = string.Empty;
+
+    [JsonPropertyName("name")]
+    public string Name { get; set; } = string.Empty;
+
+    [JsonPropertyName("email")]
+    public string? Email { get; set; }
+}

--- a/web/server.core/Services/DatamartService.cs
+++ b/web/server.core/Services/DatamartService.cs
@@ -104,8 +104,10 @@ public sealed class DatamartService : IDatamartService, IAccrualReportDataSource
         """;
 
     private const string SearchablePersonWhere = """
-        WHERE NULLIF(LTRIM(RTRIM(IamId)), '') IS NOT NULL
-          AND NULLIF(LTRIM(RTRIM(EmployeeId)), '') IS NOT NULL
+        WHERE IamId IS NOT NULL
+          AND IamId <> ''
+          AND EmployeeId IS NOT NULL
+          AND EmployeeId <> ''
         """;
 
     private readonly string _connectionString;
@@ -212,7 +214,7 @@ public sealed class DatamartService : IDatamartService, IAccrualReportDataSource
         const string sql = $"""
             {SearchablePersonSelect}
             {SearchablePersonWhere}
-              AND LTRIM(RTRIM(IamId)) = @IamId
+              AND IamId = @IamId
             """;
 
         var results = await ExecuteQueryAsync<SearchablePersonRecord>(
@@ -234,7 +236,7 @@ public sealed class DatamartService : IDatamartService, IAccrualReportDataSource
         const string sql = $"""
             {SearchablePersonSelect}
             {SearchablePersonWhere}
-              AND LTRIM(RTRIM(EmployeeId)) = @EmployeeId
+              AND EmployeeId = @EmployeeId
             """;
 
         var results = await ExecuteQueryAsync<SearchablePersonRecord>(
@@ -261,7 +263,7 @@ public sealed class DatamartService : IDatamartService, IAccrualReportDataSource
         const string sql = $"""
             {SearchablePersonSelect}
             {SearchablePersonWhere}
-              AND LTRIM(RTRIM(EmployeeId)) IN @EmployeeIds
+              AND EmployeeId IN @EmployeeIds
             """;
 
         return await ExecuteQueryAsync<SearchablePersonRecord>(

--- a/web/server.core/Services/DatamartService.cs
+++ b/web/server.core/Services/DatamartService.cs
@@ -82,33 +82,7 @@ public interface IDatamartService
 
 public sealed class DatamartService : IDatamartService, IAccrualReportDataSource
 {
-    private const string SearchablePersonSelect = """
-        SELECT
-            LTRIM(RTRIM(IamId)) AS IamId,
-            LTRIM(RTRIM(EmployeeId)) AS EmployeeId,
-            COALESCE(
-                NULLIF(LTRIM(RTRIM(FullName)), ''),
-                NULLIF(LTRIM(RTRIM(CONCAT(
-                    COALESCE(NULLIF(LTRIM(RTRIM(FirstName)), ''), ''),
-                    CASE
-                        WHEN NULLIF(LTRIM(RTRIM(FirstName)), '') IS NOT NULL
-                         AND NULLIF(LTRIM(RTRIM(LastName)), '') IS NOT NULL THEN ' '
-                        ELSE ''
-                    END,
-                    COALESCE(NULLIF(LTRIM(RTRIM(LastName)), ''), '')
-                ))), ''),
-                LTRIM(RTRIM(IamId))
-            ) AS Name,
-            NULLIF(LTRIM(RTRIM(Email)), '') AS Email
-        FROM dbo.People
-        """;
-
-    private const string SearchablePersonWhere = """
-        WHERE IamId IS NOT NULL
-          AND IamId <> ''
-          AND EmployeeId IS NOT NULL
-          AND EmployeeId <> ''
-        """;
+    private const string GetSearchablePeopleSproc = "dbo.usp_GetSearchablePeople";
 
     private readonly string _connectionString;
     private readonly string _appName;
@@ -169,37 +143,12 @@ public sealed class DatamartService : IDatamartService, IAccrualReportDataSource
         }
         var boundedLimit = Math.Min(limit, MaxSearchPeopleLimit);
 
-        const string sql = $"""
-            {SearchablePersonSelect}
-            {SearchablePersonWhere}
-              AND (
-                   FullName LIKE @LikeQuery
-                OR FirstName LIKE @LikeQuery
-                OR LastName LIKE @LikeQuery
-                OR Email LIKE @LikeQuery
-                OR UserId LIKE @LikeQuery
-                OR IamId LIKE @LikeQuery
-              )
-            ORDER BY
-                CASE
-                    WHEN FullName LIKE @StartsWithQuery THEN 0
-                    WHEN Email LIKE @StartsWithQuery THEN 1
-                    ELSE 2
-                END,
-                FullName,
-                Email,
-                IamId
-            OFFSET 0 ROWS FETCH NEXT @Limit ROWS ONLY
-            """;
-
-        return await ExecuteQueryAsync<SearchablePersonRecord>(
-            sql,
+        return await ExecuteSprocAsync<SearchablePersonRecord>(
+            GetSearchablePeopleSproc,
             new
             {
-                LikeQuery = $"%{normalizedQuery}%",
-                StartsWithQuery = $"{normalizedQuery}%",
+                SearchQuery = normalizedQuery,
                 Limit = boundedLimit,
-                ApplicationName = _appName,
             },
             ct: ct);
     }
@@ -213,15 +162,9 @@ public sealed class DatamartService : IDatamartService, IAccrualReportDataSource
             return null;
         }
 
-        const string sql = $"""
-            {SearchablePersonSelect}
-            {SearchablePersonWhere}
-              AND IamId = @IamId
-            """;
-
-        var results = await ExecuteQueryAsync<SearchablePersonRecord>(
-            sql,
-            new { IamId = normalizedIamId, ApplicationName = _appName },
+        var results = await ExecuteSprocAsync<SearchablePersonRecord>(
+            GetSearchablePeopleSproc,
+            new { IamId = normalizedIamId },
             ct: ct);
         return results.FirstOrDefault();
     }
@@ -235,15 +178,9 @@ public sealed class DatamartService : IDatamartService, IAccrualReportDataSource
             return null;
         }
 
-        const string sql = $"""
-            {SearchablePersonSelect}
-            {SearchablePersonWhere}
-              AND EmployeeId = @EmployeeId
-            """;
-
-        var results = await ExecuteQueryAsync<SearchablePersonRecord>(
-            sql,
-            new { EmployeeId = normalizedEmployeeId, ApplicationName = _appName },
+        var results = await ExecuteSprocAsync<SearchablePersonRecord>(
+            GetSearchablePeopleSproc,
+            new { EmployeeId = normalizedEmployeeId },
             ct: ct);
         return results.FirstOrDefault();
     }
@@ -262,15 +199,9 @@ public sealed class DatamartService : IDatamartService, IAccrualReportDataSource
             return Array.Empty<SearchablePersonRecord>();
         }
 
-        const string sql = $"""
-            {SearchablePersonSelect}
-            {SearchablePersonWhere}
-              AND EmployeeId IN @EmployeeIds
-            """;
-
-        return await ExecuteQueryAsync<SearchablePersonRecord>(
-            sql,
-            new { EmployeeIds = normalizedEmployeeIds, ApplicationName = _appName },
+        return await ExecuteSprocAsync<SearchablePersonRecord>(
+            GetSearchablePeopleSproc,
+            new { EmployeeIds = string.Join(",", normalizedEmployeeIds) },
             ct: ct);
     }
 
@@ -283,15 +214,9 @@ public sealed class DatamartService : IDatamartService, IAccrualReportDataSource
             return null;
         }
 
-        const string sql = $"""
-            {SearchablePersonSelect}
-            {SearchablePersonWhere}
-              AND LOWER(LTRIM(RTRIM(Email))) = @Email
-            """;
-
-        var results = await ExecuteQueryAsync<SearchablePersonRecord>(
-            sql,
-            new { Email = normalizedEmail.ToLowerInvariant(), ApplicationName = _appName },
+        var results = await ExecuteSprocAsync<SearchablePersonRecord>(
+            GetSearchablePeopleSproc,
+            new { Email = normalizedEmail.ToLowerInvariant() },
             ct: ct);
         return results.FirstOrDefault();
     }

--- a/web/server.core/Services/DatamartService.cs
+++ b/web/server.core/Services/DatamartService.cs
@@ -161,11 +161,13 @@ public sealed class DatamartService : IDatamartService, IAccrualReportDataSource
     public async Task<IReadOnlyList<SearchablePersonRecord>> SearchPeopleAsync(
         string query, int limit, CancellationToken ct = default)
     {
+        const int MaxSearchPeopleLimit = 100;
         var normalizedQuery = query.Trim();
         if (normalizedQuery.Length < 3 || limit <= 0)
         {
             return Array.Empty<SearchablePersonRecord>();
         }
+        var boundedLimit = Math.Min(limit, MaxSearchPeopleLimit);
 
         const string sql = $"""
             {SearchablePersonSelect}
@@ -196,7 +198,7 @@ public sealed class DatamartService : IDatamartService, IAccrualReportDataSource
             {
                 LikeQuery = $"%{normalizedQuery}%",
                 StartsWithQuery = $"{normalizedQuery}%",
-                Limit = limit,
+                Limit = boundedLimit,
                 ApplicationName = _appName,
             },
             ct: ct);

--- a/web/server.core/Services/DatamartService.cs
+++ b/web/server.core/Services/DatamartService.cs
@@ -34,6 +34,36 @@ public sealed class DatamartOptions
 
 public interface IDatamartService
 {
+    /// <summary>
+    /// Searches People records that have both an IAM ID for navigation and an Employee ID for downstream project data.
+    /// </summary>
+    Task<IReadOnlyList<SearchablePersonRecord>> SearchPeopleAsync(
+        string query, int limit, CancellationToken ct = default);
+
+    /// <summary>
+    /// Resolves a public IAM ID to the corresponding People record when downstream services require Employee ID.
+    /// </summary>
+    Task<SearchablePersonRecord?> GetSearchablePersonByIamIdAsync(
+        string iamId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Resolves a downstream Employee ID to a People record when Walter needs to decide whether a Person can be navigated by IAM ID.
+    /// </summary>
+    Task<SearchablePersonRecord?> GetSearchablePersonByEmployeeIdAsync(
+        string employeeId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Resolves downstream Employee IDs to People records in batches for project team navigation.
+    /// </summary>
+    Task<IReadOnlyList<SearchablePersonRecord>> GetSearchablePeopleByEmployeeIdsAsync(
+        IEnumerable<string> employeeIds, CancellationToken ct = default);
+
+    /// <summary>
+    /// Resolves an email address from downstream project data to a People record when PPM does not provide Employee ID.
+    /// </summary>
+    Task<SearchablePersonRecord?> GetSearchablePersonByEmailAsync(
+        string email, CancellationToken ct = default);
+
     Task<IReadOnlyList<EmployeeAccrualBalanceRecord>> GetEmployeeAccrualBalancesAsync(
         DateTime startDate, string? applicationUser = null, string? emulatingUser = null, CancellationToken ct = default);
 
@@ -52,6 +82,32 @@ public interface IDatamartService
 
 public sealed class DatamartService : IDatamartService, IAccrualReportDataSource
 {
+    private const string SearchablePersonSelect = """
+        SELECT
+            LTRIM(RTRIM(IamId)) AS IamId,
+            LTRIM(RTRIM(EmployeeId)) AS EmployeeId,
+            COALESCE(
+                NULLIF(LTRIM(RTRIM(FullName)), ''),
+                NULLIF(LTRIM(RTRIM(CONCAT(
+                    COALESCE(NULLIF(LTRIM(RTRIM(FirstName)), ''), ''),
+                    CASE
+                        WHEN NULLIF(LTRIM(RTRIM(FirstName)), '') IS NOT NULL
+                         AND NULLIF(LTRIM(RTRIM(LastName)), '') IS NOT NULL THEN ' '
+                        ELSE ''
+                    END,
+                    COALESCE(NULLIF(LTRIM(RTRIM(LastName)), ''), '')
+                ))), ''),
+                LTRIM(RTRIM(IamId))
+            ) AS Name,
+            NULLIF(LTRIM(RTRIM(Email)), '') AS Email
+        FROM dbo.People
+        """;
+
+    private const string SearchablePersonWhere = """
+        WHERE NULLIF(LTRIM(RTRIM(IamId)), '') IS NOT NULL
+          AND NULLIF(LTRIM(RTRIM(EmployeeId)), '') IS NOT NULL
+        """;
+
     private readonly string _connectionString;
     private readonly string _appName;
     private readonly string _positionBudgetsSproc;
@@ -98,6 +154,142 @@ public sealed class DatamartService : IDatamartService, IAccrualReportDataSource
             "dbo.usp_GetProjectSummary",
             new { ProjectIds = projectNumbersParam, ApplicationName = _appName, ApplicationUser = applicationUser, EmulatingUser = emulatingUser },
             ct: ct);
+    }
+
+    public async Task<IReadOnlyList<SearchablePersonRecord>> SearchPeopleAsync(
+        string query, int limit, CancellationToken ct = default)
+    {
+        var normalizedQuery = query.Trim();
+        if (normalizedQuery.Length < 3 || limit <= 0)
+        {
+            return Array.Empty<SearchablePersonRecord>();
+        }
+
+        const string sql = $"""
+            {SearchablePersonSelect}
+            {SearchablePersonWhere}
+              AND (
+                   FullName LIKE @LikeQuery
+                OR FirstName LIKE @LikeQuery
+                OR LastName LIKE @LikeQuery
+                OR Email LIKE @LikeQuery
+                OR UserId LIKE @LikeQuery
+                OR IamId LIKE @LikeQuery
+              )
+            ORDER BY
+                CASE
+                    WHEN FullName LIKE @StartsWithQuery THEN 0
+                    WHEN Email LIKE @StartsWithQuery THEN 1
+                    ELSE 2
+                END,
+                FullName,
+                Email,
+                IamId
+            OFFSET 0 ROWS FETCH NEXT @Limit ROWS ONLY
+            """;
+
+        return await ExecuteQueryAsync<SearchablePersonRecord>(
+            sql,
+            new
+            {
+                LikeQuery = $"%{normalizedQuery}%",
+                StartsWithQuery = $"{normalizedQuery}%",
+                Limit = limit,
+                ApplicationName = _appName,
+            },
+            ct: ct);
+    }
+
+    public async Task<SearchablePersonRecord?> GetSearchablePersonByIamIdAsync(
+        string iamId, CancellationToken ct = default)
+    {
+        var normalizedIamId = iamId.Trim();
+        if (string.IsNullOrWhiteSpace(normalizedIamId))
+        {
+            return null;
+        }
+
+        const string sql = $"""
+            {SearchablePersonSelect}
+            {SearchablePersonWhere}
+              AND LTRIM(RTRIM(IamId)) = @IamId
+            """;
+
+        var results = await ExecuteQueryAsync<SearchablePersonRecord>(
+            sql,
+            new { IamId = normalizedIamId, ApplicationName = _appName },
+            ct: ct);
+        return results.FirstOrDefault();
+    }
+
+    public async Task<SearchablePersonRecord?> GetSearchablePersonByEmployeeIdAsync(
+        string employeeId, CancellationToken ct = default)
+    {
+        var normalizedEmployeeId = employeeId.Trim();
+        if (string.IsNullOrWhiteSpace(normalizedEmployeeId))
+        {
+            return null;
+        }
+
+        const string sql = $"""
+            {SearchablePersonSelect}
+            {SearchablePersonWhere}
+              AND LTRIM(RTRIM(EmployeeId)) = @EmployeeId
+            """;
+
+        var results = await ExecuteQueryAsync<SearchablePersonRecord>(
+            sql,
+            new { EmployeeId = normalizedEmployeeId, ApplicationName = _appName },
+            ct: ct);
+        return results.FirstOrDefault();
+    }
+
+    public async Task<IReadOnlyList<SearchablePersonRecord>> GetSearchablePeopleByEmployeeIdsAsync(
+        IEnumerable<string> employeeIds, CancellationToken ct = default)
+    {
+        var normalizedEmployeeIds = employeeIds
+            .Where(id => !string.IsNullOrWhiteSpace(id))
+            .Select(id => id.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        if (normalizedEmployeeIds.Length == 0)
+        {
+            return Array.Empty<SearchablePersonRecord>();
+        }
+
+        const string sql = $"""
+            {SearchablePersonSelect}
+            {SearchablePersonWhere}
+              AND LTRIM(RTRIM(EmployeeId)) IN @EmployeeIds
+            """;
+
+        return await ExecuteQueryAsync<SearchablePersonRecord>(
+            sql,
+            new { EmployeeIds = normalizedEmployeeIds, ApplicationName = _appName },
+            ct: ct);
+    }
+
+    public async Task<SearchablePersonRecord?> GetSearchablePersonByEmailAsync(
+        string email, CancellationToken ct = default)
+    {
+        var normalizedEmail = email.Trim();
+        if (string.IsNullOrWhiteSpace(normalizedEmail))
+        {
+            return null;
+        }
+
+        const string sql = $"""
+            {SearchablePersonSelect}
+            {SearchablePersonWhere}
+              AND LOWER(LTRIM(RTRIM(Email))) = @Email
+            """;
+
+        var results = await ExecuteQueryAsync<SearchablePersonRecord>(
+            sql,
+            new { Email = normalizedEmail.ToLowerInvariant(), ApplicationName = _appName },
+            ct: ct);
+        return results.FirstOrDefault();
     }
 
     public async Task<IReadOnlyList<EmployeeAccrualBalanceRecord>> GetEmployeeAccrualBalancesAsync(

--- a/web/server/Controllers/ProjectController.cs
+++ b/web/server/Controllers/ProjectController.cs
@@ -1,6 +1,7 @@
 using AggieEnterpriseApi.Extensions;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using System.Text.Json.Serialization;
 using server.core.Models;
 using server.core.Services;
 using server.Helpers;
@@ -15,6 +16,22 @@ public sealed class ProjectController : ApiControllerBase
     private readonly IDatamartService _datamartService;
     private readonly IAuthorizationService _authorizationService;
     private readonly IUserService _userService;
+
+    public sealed record ManagedPiRecord(
+        [property: JsonPropertyName("employeeId")] string EmployeeId,
+        [property: JsonPropertyName("iamId")] string? IamId,
+        [property: JsonPropertyName("name")] string Name,
+        [property: JsonPropertyName("projectCount")] int ProjectCount);
+
+    public sealed record ManagedPisProjectManager(
+        [property: JsonPropertyName("employeeId")] string EmployeeId,
+        [property: JsonPropertyName("iamId")] string IamId,
+        [property: JsonPropertyName("name")] string? Name);
+
+    public sealed record ManagedPisEnvelope(
+        [property: JsonPropertyName("projectManager")] ManagedPisProjectManager? ProjectManager,
+        [property: JsonPropertyName("pis")] IReadOnlyList<ManagedPiRecord> Pis);
+
     public ProjectController(
         IFinancialApiService financialApiService,
         IDatamartService datamartService,
@@ -27,9 +44,17 @@ public sealed class ProjectController : ApiControllerBase
         _userService = userService;
     }
 
-    [HttpGet("{employeeId}")]
-    public async Task<IActionResult> GetByEmployeeIdAsync(string employeeId, CancellationToken cancellationToken)
+    [HttpGet("by-iam/{iamId}")]
+    public async Task<IActionResult> GetByIamIdAsync(string iamId, CancellationToken cancellationToken)
     {
+        var person = await _datamartService.GetSearchablePersonByIamIdAsync(iamId, cancellationToken);
+        if (person is null)
+        {
+            return NotFound();
+        }
+
+        var employeeId = person.EmployeeId;
+
         // Check if the user has financial access
         var hasFinancialAccess = (await _authorizationService.AuthorizeAsync(
             User,
@@ -140,7 +165,7 @@ public sealed class ProjectController : ApiControllerBase
     [HttpGet("personnel")]
     public async Task<IActionResult> GetPersonnelForProjects(
         CancellationToken cancellationToken,
-        [FromQuery] string? employeeId = null,
+        [FromQuery] string? iamId = null,
         [FromQuery] string? projectCodes = null)
     {
         if (string.IsNullOrWhiteSpace(projectCodes))
@@ -159,18 +184,24 @@ public sealed class ProjectController : ApiControllerBase
 
         if (!hasFinancialAccess)
         {
-            if (string.IsNullOrWhiteSpace(employeeId))
+            if (string.IsNullOrWhiteSpace(iamId))
             {
-                return BadRequest("employeeId is required.");
+                return BadRequest("iamId is required.");
+            }
+
+            var person = await _datamartService.GetSearchablePersonByIamIdAsync(iamId, cancellationToken);
+            if (person is null)
+            {
+                return NotFound();
             }
 
             var currentEmployeeId = await GetCurrentEmployeeIdAsync(cancellationToken);
-            if (!await IsOnAnyProjectForPiAsync(currentEmployeeId, employeeId, cancellationToken))
+            if (!await IsOnAnyProjectForPiAsync(currentEmployeeId, person.EmployeeId, cancellationToken))
             {
                 return Forbid();
             }
 
-            var accessibleProjectNumbers = await GetAccessibleProjectNumbersForEmployeeAsync(employeeId, cancellationToken);
+            var accessibleProjectNumbers = await GetAccessibleProjectNumbersForEmployeeAsync(person.EmployeeId, cancellationToken);
             var requestedProjectNumbers = new HashSet<string>(codes, StringComparer.OrdinalIgnoreCase);
 
             if (!requestedProjectNumbers.IsSubsetOf(accessibleProjectNumbers))
@@ -231,14 +262,21 @@ public sealed class ProjectController : ApiControllerBase
     }
 
     /// <summary>
-    /// Gets a unique list of Principal Investigators for all projects managed by the specified employee.
+    /// Gets a unique list of Principal Investigators for all projects managed by the specified Person.
     /// </summary>
-    /// <param name="employeeId">The employee ID of the Project Manager</param>
+    /// <param name="iamId">The IAM ID of the Project Manager</param>
     /// <param name="cancellationToken">Cancellation token</param>
-    /// <returns>A unique list of Principal Investigators with their name and employee ID</returns>
-    [HttpGet("managed/{employeeId}")]
-    public async Task<IActionResult> GetManagedFaculty(string employeeId, CancellationToken cancellationToken)
+    /// <returns>A unique list of Principal Investigators with Employee ID for transitional logic and nullable IAM ID for navigation.</returns>
+    [HttpGet("managed/by-iam/{iamId}")]
+    public async Task<IActionResult> GetManagedFaculty(string iamId, CancellationToken cancellationToken)
     {
+        var projectManagerPerson = await _datamartService.GetSearchablePersonByIamIdAsync(iamId, cancellationToken);
+        if (projectManagerPerson is null)
+        {
+            return NotFound();
+        }
+
+        var employeeId = projectManagerPerson.EmployeeId;
         var hasFinancialAccess = (await _authorizationService.AuthorizeAsync(
             User,
             resource: null,
@@ -326,15 +364,27 @@ public sealed class ProjectController : ApiControllerBase
             principalInvestigators = principalInvestigators.OrderBy(pi => pi.name).ToList();
         }
 
-        return Ok(new
-        {
-            projectManager = new
+        var peopleByEmployeeId = (await _datamartService.GetSearchablePeopleByEmployeeIdsAsync(
+                principalInvestigators.Select(pi => pi.employeeId).Append(employeeId),
+                cancellationToken))
+            .ToDictionary(p => p.EmployeeId, StringComparer.OrdinalIgnoreCase);
+
+        var managedPiRecords = principalInvestigators
+            .Select(pi =>
             {
-                employeeId,
-                name = pmMember?.Name,
-            },
-            pis = principalInvestigators,
-        });
+                peopleByEmployeeId.TryGetValue(pi.employeeId, out var person);
+                return new ManagedPiRecord(
+                    pi.employeeId,
+                    person?.IamId,
+                    pi.name,
+                    pi.projectCount);
+            })
+            .OrderBy(pi => pi.Name, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        return Ok(new ManagedPisEnvelope(
+            new ManagedPisProjectManager(employeeId, projectManagerPerson.IamId, pmMember?.Name),
+            managedPiRecords));
     }
 
     private async Task<string?> GetCurrentEmployeeIdAsync(CancellationToken cancellationToken)

--- a/web/server/Controllers/ProjectController.cs
+++ b/web/server/Controllers/ProjectController.cs
@@ -389,11 +389,9 @@ public sealed class ProjectController : ApiControllerBase
 
     private IActionResult EmptyManagedFacultyResult()
     {
-        return Ok(new
-        {
-            projectManager = (object?)null,
-            pis = Array.Empty<object>(),
-        });
+        return Ok(new ManagedPisEnvelope(
+            ProjectManager: null,
+            Pis: Array.Empty<ManagedPiRecord>()));
     }
 
     private async Task<string?> GetCurrentEmployeeIdAsync(CancellationToken cancellationToken)

--- a/web/server/Controllers/ProjectController.cs
+++ b/web/server/Controllers/ProjectController.cs
@@ -47,19 +47,20 @@ public sealed class ProjectController : ApiControllerBase
     [HttpGet("by-iam/{iamId}")]
     public async Task<IActionResult> GetByIamIdAsync(string iamId, CancellationToken cancellationToken)
     {
-        var person = await _datamartService.GetSearchablePersonByIamIdAsync(iamId, cancellationToken);
-        if (person is null)
-        {
-            return NotFound();
-        }
-
-        var employeeId = person.EmployeeId;
-
         // Check if the user has financial access
         var hasFinancialAccess = (await _authorizationService.AuthorizeAsync(
             User,
             resource: null,
             policyName: AuthorizationHelper.Policies.CanViewFinancials)).Succeeded;
+
+        var person = await _datamartService.GetSearchablePersonByIamIdAsync(iamId, cancellationToken);
+        if (person is null)
+        {
+            // Non-financial callers should not be able to distinguish unknown IAM IDs from inaccessible portfolios.
+            return hasFinancialAccess ? NotFound() : Forbid();
+        }
+
+        var employeeId = person.EmployeeId;
 
         // If no financial access, verify the current user is PI or PM on at least one
         // of the requested employee's projects (covers both self-lookup and PM-views-PI)
@@ -192,7 +193,8 @@ public sealed class ProjectController : ApiControllerBase
             var person = await _datamartService.GetSearchablePersonByIamIdAsync(iamId, cancellationToken);
             if (person is null)
             {
-                return NotFound();
+                // Keep missing IAM IDs indistinguishable from inaccessible personnel for restricted callers.
+                return Forbid();
             }
 
             var currentEmployeeId = await GetCurrentEmployeeIdAsync(cancellationToken);
@@ -270,17 +272,19 @@ public sealed class ProjectController : ApiControllerBase
     [HttpGet("managed/by-iam/{iamId}")]
     public async Task<IActionResult> GetManagedFaculty(string iamId, CancellationToken cancellationToken)
     {
-        var projectManagerPerson = await _datamartService.GetSearchablePersonByIamIdAsync(iamId, cancellationToken);
-        if (projectManagerPerson is null)
-        {
-            return NotFound();
-        }
-
-        var employeeId = projectManagerPerson.EmployeeId;
         var hasFinancialAccess = (await _authorizationService.AuthorizeAsync(
             User,
             resource: null,
             policyName: AuthorizationHelper.Policies.CanViewFinancials)).Succeeded;
+
+        var projectManagerPerson = await _datamartService.GetSearchablePersonByIamIdAsync(iamId, cancellationToken);
+        if (projectManagerPerson is null)
+        {
+            // Match the non-self response below so restricted callers cannot enumerate IAM IDs.
+            return hasFinancialAccess ? NotFound() : EmptyManagedFacultyResult();
+        }
+
+        var employeeId = projectManagerPerson.EmployeeId;
 
         if (!hasFinancialAccess)
         {
@@ -289,11 +293,7 @@ public sealed class ProjectController : ApiControllerBase
 
             if (!isSelf)
             {
-                return Ok(new
-                {
-                    projectManager = (object?)null,
-                    pis = Array.Empty<object>(),
-                });
+                return EmptyManagedFacultyResult();
             }
         }
 
@@ -385,6 +385,15 @@ public sealed class ProjectController : ApiControllerBase
         return Ok(new ManagedPisEnvelope(
             new ManagedPisProjectManager(employeeId, projectManagerPerson.IamId, pmMember?.Name),
             managedPiRecords));
+    }
+
+    private IActionResult EmptyManagedFacultyResult()
+    {
+        return Ok(new
+        {
+            projectManager = (object?)null,
+            pis = Array.Empty<object>(),
+        });
     }
 
     private async Task<string?> GetCurrentEmployeeIdAsync(CancellationToken cancellationToken)

--- a/web/server/Controllers/SearchController.cs
+++ b/web/server/Controllers/SearchController.cs
@@ -4,52 +4,41 @@ using AggieEnterpriseApi.Extensions;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Identity.Client;
-using Microsoft.Identity.Web;
-using Microsoft.Kiota.Abstractions;
 using server.core.Data;
+using server.core.Models;
 using server.core.Services;
 using server.Helpers;
 using server.Services;
-using Server.Services;
 
 namespace Server.Controllers;
 
 public sealed class SearchController : ApiControllerBase
 {
-    // Marks synthetic person IDs emitted by fallback search when Graph IDs are unavailable.
-    private const string SyntheticEmployeeIdPrefix = "employee:";
     private const int SearchResultLimit = 5;
 
     private readonly AppDbContext _dbContext;
     private readonly IFinancialApiService _financialApiService;
     private readonly IAuthorizationService _authorizationService;
-    private readonly IGraphService _graphService;
-    private readonly IIdentityService _identityService;
-    private readonly ILogger<SearchController> _logger;
+    private readonly IDatamartService _datamartService;
 
     public SearchController(
         AppDbContext dbContext,
         IFinancialApiService financialApiService,
         IAuthorizationService authorizationService,
-        IGraphService graphService,
-        IIdentityService identityService,
-        ILogger<SearchController> logger)
+        IDatamartService datamartService)
     {
         _dbContext = dbContext;
         _financialApiService = financialApiService;
         _authorizationService = authorizationService;
-        _graphService = graphService;
-        _identityService = identityService;
-        _logger = logger;
+        _datamartService = datamartService;
     }
 
     public sealed record SearchProject(
         [property: JsonPropertyName("projectNumber")] string ProjectNumber,
         [property: JsonPropertyName("projectName")] string ProjectName,
         [property: JsonPropertyName("keywords")] IReadOnlyList<string> Keywords,
-        [property: JsonPropertyName("projectPiEmployeeId")]
-        string? ProjectPiEmployeeId = null);
+        [property: JsonPropertyName("projectPiIamId")]
+        string? ProjectPiIamId = null);
 
     public sealed record SearchReport(
         [property: JsonPropertyName("id")] string Id,
@@ -62,14 +51,16 @@ public sealed class SearchController : ApiControllerBase
         [property: JsonPropertyName("reports")] IReadOnlyList<SearchReport> Reports);
 
     public sealed record SearchPerson(
-        [property: JsonPropertyName("employeeId")] string EmployeeId,
+        [property: JsonPropertyName("iamId")] string IamId,
         [property: JsonPropertyName("name")] string Name,
         [property: JsonPropertyName("keywords")] IReadOnlyList<string> Keywords);
 
     public sealed record SearchDirectoryPerson(
         [property: JsonPropertyName("id")] string Id,
+        [property: JsonPropertyName("iamId")] string IamId,
         [property: JsonPropertyName("name")] string Name,
         [property: JsonPropertyName("email")] string? Email,
+        [property: JsonPropertyName("isProjectManager")] bool IsProjectManager,
         [property: JsonPropertyName("keywords")] IReadOnlyList<string> Keywords);
 
     public sealed record SearchTeamMemberProjectsResponse(
@@ -78,14 +69,8 @@ public sealed class SearchController : ApiControllerBase
         [property: JsonPropertyName("projects")] IReadOnlyList<SearchProject> Projects,
         [property: JsonPropertyName("principalInvestigators")] IReadOnlyList<SearchPerson> PrincipalInvestigators);
 
-    public sealed record ResolveDirectoryPersonResponse(
-        [property: JsonPropertyName("employeeId")] string EmployeeId,
-        [property: JsonPropertyName("name")] string Name,
-        [property: JsonPropertyName("email")] string? Email,
-        [property: JsonPropertyName("isProjectManager")] bool IsProjectManager);
-
     public sealed record ResolveProjectPiResponse(
-        [property: JsonPropertyName("employeeId")] string EmployeeId,
+        [property: JsonPropertyName("iamId")] string IamId,
         [property: JsonPropertyName("projectNumber")] string ProjectNumber);
 
     [HttpGet("catalog")]
@@ -148,139 +133,21 @@ public sealed class SearchController : ApiControllerBase
             return Ok(Array.Empty<SearchDirectoryPerson>());
         }
 
-        try
+        var people = await _datamartService.SearchPeopleAsync(normalizedQuery, SearchResultLimit, cancellationToken);
+        var results = new List<SearchDirectoryPerson>(people.Count);
+        foreach (var person in people)
         {
-            var results = await _graphService.SearchUsersAsync(User, normalizedQuery, cancellationToken);
-            var mapped = results
-                .Where(r => !string.IsNullOrWhiteSpace(r.Id))
-                .Select(r =>
-                {
-                    var name = r.DisplayName?.Trim();
-                    var email = r.Email?.Trim();
-                    var displayValue = !string.IsNullOrWhiteSpace(name)
-                        ? name
-                        : !string.IsNullOrWhiteSpace(email)
-                            ? email
-                            : r.Id;
-
-                    return new SearchDirectoryPerson(
-                        Id: r.Id,
-                        Name: displayValue,
-                        Email: email,
-                        Keywords: BuildKeywords(name, email));
-                })
-                .Take(SearchResultLimit)
-                .ToArray();
-
-            return Ok(mapped);
-        }
-        catch (MicrosoftIdentityWebChallengeUserException ex)
-        {
-            _logger.LogInformation(ex, "User interaction required to acquire Graph token for search people.");
-            var fallback = await SearchManagedPeopleFallbackAsync(normalizedQuery, cancellationToken);
-            return Ok(fallback);
-        }
-        catch (MsalUiRequiredException ex)
-        {
-            _logger.LogInformation(ex, "User interaction required to acquire Graph token for search people.");
-            var fallback = await SearchManagedPeopleFallbackAsync(normalizedQuery, cancellationToken);
-            return Ok(fallback);
-        }
-        catch (ApiException ex)
-        {
-            _logger.LogWarning(ex, "Microsoft Graph people search failed.");
-            return StatusCode(StatusCodes.Status502BadGateway);
-        }
-        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-        {
-            throw;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "Unexpected error searching people.");
-            return StatusCode(StatusCodes.Status502BadGateway);
-        }
-    }
-
-    [HttpGet("people/resolve")]
-    public async Task<IActionResult> ResolvePersonByDirectoryId([FromQuery] string? userId, CancellationToken cancellationToken)
-    {
-        cancellationToken.ThrowIfCancellationRequested();
-
-        if (!await HasFinancialAccessAsync())
-        {
-            return Forbid();
+            var isProjectManager = await IsProjectManagerAsync(person.EmployeeId, cancellationToken);
+            results.Add(new SearchDirectoryPerson(
+                person.IamId,
+                person.IamId,
+                person.Name,
+                person.Email,
+                isProjectManager,
+                BuildKeywords(person.Name, person.Email, person.IamId)));
         }
 
-        var normalizedUserId = userId?.Trim();
-        if (string.IsNullOrWhiteSpace(normalizedUserId))
-        {
-            return BadRequest("userId is required.");
-        }
-
-        if (normalizedUserId.StartsWith(SyntheticEmployeeIdPrefix, StringComparison.OrdinalIgnoreCase))
-        {
-            var employeeId = normalizedUserId[SyntheticEmployeeIdPrefix.Length..].Trim();
-            if (string.IsNullOrWhiteSpace(employeeId))
-            {
-                return NotFound();
-            }
-
-            var isPm = await IsProjectManagerAsync(employeeId, cancellationToken);
-            return Ok(new ResolveDirectoryPersonResponse(employeeId, employeeId, null, isPm));
-        }
-
-        GraphUserProfile? profile;
-        try
-        {
-            profile = await _graphService.GetUserProfileAsync(User, normalizedUserId, cancellationToken);
-        }
-        catch (MicrosoftIdentityWebChallengeUserException ex)
-        {
-            _logger.LogInformation(ex, "User interaction required to acquire Graph token for resolve person.");
-            return NotFound();
-        }
-        catch (MsalUiRequiredException ex)
-        {
-            _logger.LogInformation(ex, "User interaction required to acquire Graph token for resolve person.");
-            return NotFound();
-        }
-        catch (ApiException ex)
-        {
-            _logger.LogWarning(ex, "Microsoft Graph profile lookup failed during person resolve.");
-            return StatusCode(StatusCodes.Status502BadGateway);
-        }
-
-        if (profile is null || string.IsNullOrWhiteSpace(profile.IamId))
-        {
-            return NotFound();
-        }
-
-        IamIdentity? identity;
-        try
-        {
-            identity = await _identityService.GetByIamId(profile.IamId);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "IAM lookup failed while resolving person for IAM ID '{IamId}'.", profile.IamId);
-            return StatusCode(StatusCodes.Status502BadGateway);
-        }
-
-        if (identity is null || string.IsNullOrWhiteSpace(identity.EmployeeId))
-        {
-            return NotFound();
-        }
-
-        var resolvedName = !string.IsNullOrWhiteSpace(profile.DisplayName)
-            ? profile.DisplayName
-            : !string.IsNullOrWhiteSpace(identity.FullName)
-                ? identity.FullName
-                : profile.Email ?? identity.EmployeeId;
-
-        var isProjectManager = await IsProjectManagerAsync(identity.EmployeeId, cancellationToken);
-
-        return Ok(new ResolveDirectoryPersonResponse(identity.EmployeeId, resolvedName, profile.Email, isProjectManager));
+        return Ok(results);
     }
 
     private async Task<bool> IsProjectManagerAsync(string employeeId, CancellationToken cancellationToken)
@@ -389,61 +256,31 @@ public sealed class SearchController : ApiControllerBase
         }
 
         var client = _financialApiService.GetClient();
-        var result = await client.PpmProjectTeamMembers.ExecuteAsync(
+        var piResolution = await ResolveFirstTeamMemberIamIdByEmailAsync(
+            client,
             normalizedProjectNumber,
             PpmRole.PrincipalInvestigator,
             cancellationToken);
-        var data = result.ReadData();
 
-        var project = data.PpmProjectByNumber;
-        var principalInvestigators = project?.TeamMembers?
-            .Where(m => m.RoleName == PpmRole.PrincipalInvestigator)
-            .Where(m => !string.IsNullOrWhiteSpace(m.Person?.Email))
-            .OrderBy(m => m.Name, StringComparer.OrdinalIgnoreCase)
-            .ToArray() ?? [];
-
-        foreach (var pi in principalInvestigators)
+        if (!string.IsNullOrWhiteSpace(piResolution.IamId))
         {
-            var email = pi.Person?.Email;
-            if (string.IsNullOrWhiteSpace(email))
-            {
-                continue;
-            }
-
-            var resolvedEmployeeId = await TryResolveEmployeeIdByEmailAsync(email, cancellationToken);
-            if (!string.IsNullOrWhiteSpace(resolvedEmployeeId))
-            {
-                return Ok(new ResolveProjectPiResponse(resolvedEmployeeId, normalizedProjectNumber));
-            }
+            return Ok(new ResolveProjectPiResponse(piResolution.IamId, normalizedProjectNumber));
         }
 
-        // Fallback: projects without a (resolvable) PI may still be navigable via their
-        // Project Manager. ProjectController.GetByEmployeeIdAsync includes orphaned PM-only
-        // projects in its response, so handing the by-number route a PM employeeId works.
-        var pmResult = await client.PpmProjectTeamMembers.ExecuteAsync(
+        if (piResolution.HasTeamMembers)
+        {
+            return NotFound();
+        }
+
+        var pmResolution = await ResolveFirstTeamMemberIamIdByEmailAsync(
+            client,
             normalizedProjectNumber,
             PpmRole.ProjectManager,
             cancellationToken);
-        var pmProject = pmResult.ReadData().PpmProjectByNumber;
-        var projectManagers = pmProject?.TeamMembers?
-            .Where(m => m.RoleName == PpmRole.ProjectManager)
-            .Where(m => !string.IsNullOrWhiteSpace(m.Person?.Email))
-            .OrderBy(m => m.Name, StringComparer.OrdinalIgnoreCase)
-            .ToArray() ?? [];
 
-        foreach (var pm in projectManagers)
+        if (!string.IsNullOrWhiteSpace(pmResolution.IamId))
         {
-            var email = pm.Person?.Email;
-            if (string.IsNullOrWhiteSpace(email))
-            {
-                continue;
-            }
-
-            var resolvedEmployeeId = await TryResolveEmployeeIdByEmailAsync(email, cancellationToken);
-            if (!string.IsNullOrWhiteSpace(resolvedEmployeeId))
-            {
-                return Ok(new ResolveProjectPiResponse(resolvedEmployeeId, normalizedProjectNumber));
-            }
+            return Ok(new ResolveProjectPiResponse(pmResolution.IamId, normalizedProjectNumber));
         }
 
         return NotFound();
@@ -494,26 +331,25 @@ public sealed class SearchController : ApiControllerBase
 
         var piData = piResultTask.Result.ReadData();
         var pmData = pmResultTask.Result.ReadData();
+        var peopleByEmployeeId = await GetPeopleByEmployeeIdAsync(
+            piData.PpmProjectByProjectTeamMemberEmployeeId
+                .Concat(pmData.PpmProjectByProjectTeamMemberEmployeeId)
+                .SelectMany(p => p.TeamMembers)
+                .Select(m => m.EmployeeId),
+            cancellationToken);
 
         var myProjects = piData.PpmProjectByProjectTeamMemberEmployeeId
             .GroupBy(p => p.ProjectNumber, StringComparer.OrdinalIgnoreCase)
             .Select(g =>
             {
                 var first = g.First();
-                var projectPiEmployeeId = g
-                    .SelectMany(p => p.TeamMembers)
-                    .Where(m => m.RoleName == PpmRole.PrincipalInvestigator)
-                    .Where(m => !string.IsNullOrWhiteSpace(m.EmployeeId))
-                    .OrderBy(m => m.Name)
-                    .ThenBy(m => m.EmployeeId)
-                    .Select(m => m.EmployeeId)
-                    .FirstOrDefault();
+                var projectPiEmployeeId = GetFirstPiEmployeeId(g.SelectMany(p => p.TeamMembers));
 
                 return new SearchProject(
                     first.ProjectNumber,
                     first.Name,
                     BuildKeywords(first.ProjectNumber, first.Name),
-                    projectPiEmployeeId);
+                    TryGetIamId(peopleByEmployeeId, projectPiEmployeeId));
             })
             .OrderBy(p => p.ProjectName)
             .ToArray();
@@ -523,20 +359,13 @@ public sealed class SearchController : ApiControllerBase
             .Select(g =>
             {
                 var first = g.First();
-                var projectPiEmployeeId = g
-                    .SelectMany(p => p.TeamMembers)
-                    .Where(m => m.RoleName == PpmRole.PrincipalInvestigator)
-                    .Where(m => !string.IsNullOrWhiteSpace(m.EmployeeId))
-                    .OrderBy(m => m.Name)
-                    .ThenBy(m => m.EmployeeId)
-                    .Select(m => m.EmployeeId)
-                    .FirstOrDefault();
+                var projectPiEmployeeId = GetFirstPiEmployeeId(g.SelectMany(p => p.TeamMembers));
 
                 return new SearchProject(
                     first.ProjectNumber,
                     first.Name,
                     BuildKeywords(first.ProjectNumber, first.Name),
-                    projectPiEmployeeId);
+                    TryGetIamId(peopleByEmployeeId, projectPiEmployeeId));
             })
             .OrderBy(p => p.ProjectName)
             .ToArray();
@@ -557,8 +386,12 @@ public sealed class SearchController : ApiControllerBase
             .Select(g =>
             {
                 var first = g.First();
-                return new SearchPerson(first.EmployeeId, first.Name, BuildKeywords(first.Name, first.EmployeeId));
+                return peopleByEmployeeId.TryGetValue(first.EmployeeId, out var person)
+                    ? new SearchPerson(person.IamId, first.Name, BuildKeywords(first.Name, person.IamId))
+                    : null;
             })
+            .Where(pi => pi is not null)
+            .Select(pi => pi!)
             .OrderBy(pi => pi.Name)
             .ToArray();
 
@@ -569,6 +402,64 @@ public sealed class SearchController : ApiControllerBase
             principalInvestigators));
     }
 
+    private sealed record TeamMemberIamResolution(string? IamId, bool HasTeamMembers);
+
+    private async Task<TeamMemberIamResolution> ResolveFirstTeamMemberIamIdByEmailAsync(
+        IAggieEnterpriseClient client,
+        string projectNumber,
+        string roleName,
+        CancellationToken cancellationToken)
+    {
+        var result = await client.PpmProjectTeamMembers.ExecuteAsync(
+            projectNumber,
+            roleName,
+            cancellationToken);
+        var project = result.ReadData().PpmProjectByNumber;
+        var teamMembers = project?.TeamMembers?
+            .Where(m => m.RoleName == roleName)
+            .ToArray() ?? [];
+        var membersWithEmail = teamMembers
+            .Where(m => !string.IsNullOrWhiteSpace(m.Person?.Email))
+            .OrderBy(m => m.Name, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        foreach (var member in membersWithEmail)
+        {
+            var email = member.Person?.Email;
+            if (string.IsNullOrWhiteSpace(email))
+            {
+                continue;
+            }
+
+            var person = await _datamartService.GetSearchablePersonByEmailAsync(email, cancellationToken);
+            if (!string.IsNullOrWhiteSpace(person?.IamId))
+            {
+                return new TeamMemberIamResolution(person.IamId, teamMembers.Length > 0);
+            }
+        }
+
+        return new TeamMemberIamResolution(null, teamMembers.Length > 0);
+    }
+
+    private async Task<IReadOnlyDictionary<string, SearchablePersonRecord>> GetPeopleByEmployeeIdAsync(
+        IEnumerable<string?> employeeIds,
+        CancellationToken cancellationToken)
+    {
+        var normalizedEmployeeIds = employeeIds
+            .Where(id => !string.IsNullOrWhiteSpace(id))
+            .Select(id => id!.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        if (normalizedEmployeeIds.Length == 0)
+        {
+            return new Dictionary<string, SearchablePersonRecord>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        var people = await _datamartService.GetSearchablePeopleByEmployeeIdsAsync(normalizedEmployeeIds, cancellationToken);
+        return people.ToDictionary(p => p.EmployeeId, StringComparer.OrdinalIgnoreCase);
+    }
+
     private async Task<bool> HasFinancialAccessAsync()
     {
         var result = await _authorizationService.AuthorizeAsync(
@@ -577,6 +468,32 @@ public sealed class SearchController : ApiControllerBase
             AuthorizationHelper.Policies.CanViewFinancials);
 
         return result.Succeeded;
+    }
+
+    private static string? GetFirstPiEmployeeId(
+        IEnumerable<IPpmProjectByProjectTeamMemberEmployeeId_PpmProjectByProjectTeamMemberEmployeeId_TeamMembers> members)
+    {
+        return members
+            .Where(m => m.RoleName == PpmRole.PrincipalInvestigator)
+            .Where(m => !string.IsNullOrWhiteSpace(m.EmployeeId))
+            .OrderBy(m => m.Name)
+            .ThenBy(m => m.EmployeeId)
+            .Select(m => m.EmployeeId)
+            .FirstOrDefault();
+    }
+
+    private static string? TryGetIamId(
+        IReadOnlyDictionary<string, SearchablePersonRecord> peopleByEmployeeId,
+        string? employeeId)
+    {
+        if (string.IsNullOrWhiteSpace(employeeId))
+        {
+            return null;
+        }
+
+        return peopleByEmployeeId.TryGetValue(employeeId, out var person)
+            ? person.IamId
+            : null;
     }
 
     private static string[] BuildKeywords(params string?[] values)
@@ -606,351 +523,5 @@ public sealed class SearchController : ApiControllerBase
         }
 
         return value.Trim().ToUpperInvariant();
-    }
-
-    private async Task<string?> TryResolveEmployeeIdByEmailAsync(string email, CancellationToken cancellationToken)
-    {
-        var normalizedEmail = email.Trim();
-        if (string.IsNullOrWhiteSpace(normalizedEmail))
-        {
-            return null;
-        }
-
-        var normalizedLower = normalizedEmail.ToLowerInvariant();
-        var localEmployeeId = await _dbContext.Users
-            .AsNoTracking()
-            .Where(u => u.Email != null && u.Email.ToLower() == normalizedLower)
-            .Select(u => u.EmployeeId)
-            .FirstOrDefaultAsync(cancellationToken);
-
-        if (!string.IsNullOrWhiteSpace(localEmployeeId))
-        {
-            return localEmployeeId;
-        }
-
-        var kerberosFallback = normalizedEmail.Split('@', 2, StringSplitOptions.TrimEntries)[0];
-        if (!string.IsNullOrWhiteSpace(kerberosFallback))
-        {
-            var normalizedKerberos = kerberosFallback.ToLowerInvariant();
-            var localKerberosEmployeeId = await _dbContext.Users
-                .AsNoTracking()
-                .Where(u => u.Kerberos.ToLower() == normalizedKerberos)
-                .Select(u => u.EmployeeId)
-                .FirstOrDefaultAsync(cancellationToken);
-
-            if (!string.IsNullOrWhiteSpace(localKerberosEmployeeId))
-            {
-                return localKerberosEmployeeId;
-            }
-        }
-
-        try
-        {
-            // Try the direct match first, then keep searching alternate directory objects until one actually resolves.
-            var employeeId = await TryResolveEmployeeIdFromGraphMatchesAsync(normalizedEmail, cancellationToken);
-            if (string.IsNullOrWhiteSpace(employeeId))
-            {
-                _logger.LogInformation("PI email '{Email}' did not resolve to a Graph profile.", normalizedEmail);
-                return null;
-            }
-
-            return employeeId;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "Failed to resolve employee ID from directory email '{Email}'.", normalizedEmail);
-            return null;
-        }
-    }
-
-    // Resolve a PI email against one or more Graph directory objects and keep going until one yields an employee ID.
-    private async Task<string?> TryResolveEmployeeIdFromGraphMatchesAsync(
-        string email,
-        CancellationToken cancellationToken)
-    {
-        var seenProfileIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-
-        async Task<string?> TryProfileAsync(GraphUserProfile? profile)
-        {
-            if (profile?.Id is null || !seenProfileIds.Add(profile.Id))
-            {
-                return null;
-            }
-
-            return await TryResolveEmployeeIdFromGraphProfileAsync(profile, email, cancellationToken);
-        }
-
-        var directProfile = await _graphService.FindUserByEmailAsync(User, email, cancellationToken);
-        var directEmployeeId = await TryProfileAsync(directProfile);
-        if (!string.IsNullOrWhiteSpace(directEmployeeId))
-        {
-            return directEmployeeId;
-        }
-
-        foreach (var candidateProfile in await FindCandidateGraphProfilesByEmailAsync(email, cancellationToken))
-        {
-            var candidateEmployeeId = await TryProfileAsync(candidateProfile);
-            if (!string.IsNullOrWhiteSpace(candidateEmployeeId))
-            {
-                return candidateEmployeeId;
-            }
-        }
-
-        return null;
-    }
-
-    // Convert a specific Graph profile into an employee ID using the local Users table first, then IAM.
-    private async Task<string?> TryResolveEmployeeIdFromGraphProfileAsync(
-        GraphUserProfile profile,
-        string email,
-        CancellationToken cancellationToken)
-    {
-        if (Guid.TryParse(profile.Id, out var userId))
-        {
-            var localEmployeeIdByUserId = await _dbContext.Users
-                .AsNoTracking()
-                .Where(u => u.Id == userId)
-                .Select(u => u.EmployeeId)
-                .FirstOrDefaultAsync(cancellationToken);
-
-            if (!string.IsNullOrWhiteSpace(localEmployeeIdByUserId))
-            {
-                _logger.LogInformation(
-                    "Resolved PI email '{Email}' via local user record for Entra object '{UserId}'.",
-                    email,
-                    userId);
-                return localEmployeeIdByUserId;
-            }
-        }
-
-        if (string.IsNullOrWhiteSpace(profile.IamId))
-        {
-            _logger.LogInformation(
-                "Graph profile '{UserId}' for PI email '{Email}' has no IAM ID.",
-                profile.Id,
-                email);
-            return null;
-        }
-
-        var identity = await _identityService.GetByIamId(profile.IamId);
-        if (identity is null || string.IsNullOrWhiteSpace(identity.EmployeeId))
-        {
-            _logger.LogInformation(
-                "IAM lookup for PI email '{Email}' and IAM ID '{IamId}' returned no employee ID.",
-                email,
-                profile.IamId);
-            return null;
-        }
-
-        return identity.EmployeeId;
-    }
-
-    // Mirror the people-search fallback by searching on the email local-part and returning all plausible matches.
-    private async Task<IReadOnlyList<GraphUserProfile>> FindCandidateGraphProfilesByEmailAsync(
-        string email,
-        CancellationToken cancellationToken)
-    {
-        var localPart = ExtractEmailLocalPart(email);
-        if (string.IsNullOrWhiteSpace(localPart) || localPart.Length < 3)
-        {
-            return [];
-        }
-
-        // Mirror the proven /api/search/people behavior and keep all matching directory objects, not just the first.
-        var results = await _graphService.SearchUsersAsync(User, localPart, cancellationToken);
-        var matchingUsers = results
-            .Where(result => result.Id is not null && HasMatchingEmailLocalPart(result.Email, email))
-            .ToArray();
-
-        if (matchingUsers.Length == 0)
-        {
-            return [];
-        }
-
-        var profiles = new List<GraphUserProfile>(matchingUsers.Length);
-        foreach (var matchingUser in matchingUsers)
-        {
-            var profile = await _graphService.GetUserProfileAsync(User, matchingUser.Id, cancellationToken);
-            if (profile is not null)
-            {
-                profiles.Add(profile);
-            }
-        }
-
-        return profiles;
-    }
-
-    private static bool HasMatchingEmailLocalPart(string? resultEmail, string candidateEmail)
-    {
-        var resultLocalPart = ExtractEmailLocalPart(resultEmail);
-        var candidateLocalPart = ExtractEmailLocalPart(candidateEmail);
-
-        return !string.IsNullOrWhiteSpace(resultLocalPart) &&
-               !string.IsNullOrWhiteSpace(candidateLocalPart) &&
-               string.Equals(resultLocalPart, candidateLocalPart, StringComparison.OrdinalIgnoreCase);
-    }
-
-    private static string? ExtractEmailLocalPart(string? email)
-    {
-        if (string.IsNullOrWhiteSpace(email))
-        {
-            return null;
-        }
-
-        var atIndex = email.IndexOf('@');
-        if (atIndex <= 0)
-        {
-            return null;
-        }
-
-        return email[..atIndex].Trim();
-    }
-
-    private async Task<IReadOnlyList<SearchDirectoryPerson>> SearchManagedPeopleFallbackAsync(
-        string query,
-        CancellationToken cancellationToken)
-    {
-        Guid userId;
-        try
-        {
-            userId = User.GetUserId();
-        }
-        catch (InvalidOperationException)
-        {
-            return Array.Empty<SearchDirectoryPerson>();
-        }
-
-        var currentEmployeeId = await _dbContext.Users
-            .AsNoTracking()
-            .Where(u => u.Id == userId)
-            .Select(u => u.EmployeeId)
-            .SingleOrDefaultAsync(cancellationToken);
-
-        if (string.IsNullOrWhiteSpace(currentEmployeeId))
-        {
-            return Array.Empty<SearchDirectoryPerson>();
-        }
-
-        var client = _financialApiService.GetClient();
-        var pmProjectsResult = await client.PpmProjectByProjectTeamMemberEmployeeId.ExecuteAsync(
-            currentEmployeeId,
-            PpmRole.ProjectManager,
-            cancellationToken);
-
-        var teamMembers = pmProjectsResult.ReadData().PpmProjectByProjectTeamMemberEmployeeId
-            .SelectMany(p => p.TeamMembers)
-            .Where(member => !string.IsNullOrWhiteSpace(member.EmployeeId))
-            .ToArray();
-
-        if (teamMembers.Length == 0)
-        {
-            return Array.Empty<SearchDirectoryPerson>();
-        }
-
-        var employeeIds = teamMembers
-            .Select(member => member.EmployeeId)
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .ToArray();
-
-        var localUsers = await _dbContext.Users
-            .AsNoTracking()
-            .Where(u => employeeIds.Contains(u.EmployeeId))
-            .Select(u => new
-            {
-                u.EmployeeId,
-                u.DisplayName,
-                u.Email,
-                u.Kerberos,
-            })
-            .ToArrayAsync(cancellationToken);
-
-        var localUsersByEmployeeId = localUsers.ToDictionary(
-            u => u.EmployeeId,
-            StringComparer.OrdinalIgnoreCase);
-
-        var queryTokens = NormalizeForSearch(query)
-            .Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-
-        var managedPeople = teamMembers
-            .GroupBy(member => member.EmployeeId, StringComparer.OrdinalIgnoreCase)
-            .Where(member =>
-            {
-                var first = member.First();
-                localUsersByEmployeeId.TryGetValue(first.EmployeeId, out var localUser);
-
-                var normalizedName = first.Name?.Trim() ?? string.Empty;
-                var alternateName = TryGetAlternateName(normalizedName);
-                var normalizedSearchTerms = NormalizeForSearch(string.Join(
-                    ' ',
-                    BuildKeywords(
-                        normalizedName,
-                        alternateName,
-                        first.EmployeeId,
-                        localUser?.DisplayName,
-                        localUser?.Email,
-                        localUser?.Kerberos)));
-
-                return queryTokens.All(token =>
-                    normalizedSearchTerms.Contains(token, StringComparison.OrdinalIgnoreCase));
-            })
-            .Select(g =>
-            {
-                var first = g.First();
-                localUsersByEmployeeId.TryGetValue(first.EmployeeId, out var localUser);
-                var alternateName = TryGetAlternateName(first.Name);
-                var resolvedName = !string.IsNullOrWhiteSpace(first.Name)
-                    ? first.Name
-                    : localUser?.DisplayName ?? first.EmployeeId;
-
-                return new SearchDirectoryPerson(
-                    Id: $"{SyntheticEmployeeIdPrefix}{first.EmployeeId}",
-                    Name: resolvedName,
-                    Email: localUser?.Email,
-                    Keywords: BuildKeywords(
-                        resolvedName,
-                        alternateName,
-                        first.EmployeeId,
-                        localUser?.DisplayName,
-                        localUser?.Email,
-                        localUser?.Kerberos));
-            })
-            .OrderBy(p => p.Name, StringComparer.OrdinalIgnoreCase)
-            .Take(SearchResultLimit)
-            .ToArray();
-
-        return managedPeople;
-    }
-
-    private static string NormalizeForSearch(string value)
-    {
-        if (string.IsNullOrWhiteSpace(value))
-        {
-            return string.Empty;
-        }
-
-        var chars = value
-            .ToLowerInvariant()
-            .Select(ch => char.IsLetterOrDigit(ch) ? ch : ' ')
-            .ToArray();
-
-        return string.Join(
-            ' ',
-            new string(chars).Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries));
-    }
-
-    private static string? TryGetAlternateName(string? name)
-    {
-        if (string.IsNullOrWhiteSpace(name))
-        {
-            return null;
-        }
-
-        var parts = name.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-        if (parts.Length != 2)
-        {
-            return null;
-        }
-
-        return $"{parts[1]} {parts[0]}";
     }
 }

--- a/web/server/Controllers/SearchController.cs
+++ b/web/server/Controllers/SearchController.cs
@@ -460,6 +460,7 @@ public sealed class SearchController : ApiControllerBase
         return people.ToDictionary(p => p.EmployeeId, StringComparer.OrdinalIgnoreCase);
     }
 
+    /// <summary>Returns true only when the current user satisfies the financial-data access policy.</summary>
     private async Task<bool> HasFinancialAccessAsync()
     {
         var result = await _authorizationService.AuthorizeAsync(

--- a/web/server/Controllers/UserController.cs
+++ b/web/server/Controllers/UserController.cs
@@ -52,6 +52,7 @@ public class UserController : ApiControllerBase
             Id = user.Id,
             Name = user.DisplayName ?? user.Kerberos,
             Email = user.Email,
+            IamId = user.IamId,
             EmployeeId = user.EmployeeId,
             Kerberos = user.Kerberos,
             Roles = roles,

--- a/web/tests/server.tests/Controllers/ProjectControllerTests.cs
+++ b/web/tests/server.tests/Controllers/ProjectControllerTests.cs
@@ -58,6 +58,92 @@ public sealed class ProjectControllerTests
     }
 
     [Fact]
+    public async Task GetByIamId_returns_forbid_for_unknown_iam_when_user_lacks_financial_access()
+    {
+        using AppDbContext ctx = TestDbContextFactory.CreateInMemory();
+        var authorizationService = CreateAuthorizationService();
+
+        var controller = new ProjectController(
+            new ThrowingFinancialApiService(),
+            new ResolvingDatamartService(),
+            authorizationService,
+            new UserService(NullLogger<UserService>.Instance, ctx))
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext
+                {
+                    User = CreateUser(roles: []),
+                },
+            },
+        };
+
+        var result = await controller.GetByIamIdAsync("UNKNOWN-IAM", CancellationToken.None);
+
+        result.Should().BeOfType<ForbidResult>();
+    }
+
+    [Fact]
+    public async Task GetPersonnelForProjects_returns_forbid_for_unknown_iam_when_user_lacks_financial_access()
+    {
+        using AppDbContext ctx = TestDbContextFactory.CreateInMemory();
+        var authorizationService = CreateAuthorizationService();
+
+        var controller = new ProjectController(
+            new ThrowingFinancialApiService(),
+            new ResolvingDatamartService(),
+            authorizationService,
+            new UserService(NullLogger<UserService>.Instance, ctx))
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext
+                {
+                    User = CreateUser(roles: []),
+                },
+            },
+        };
+
+        var result = await controller.GetPersonnelForProjects(
+            CancellationToken.None,
+            iamId: "UNKNOWN-IAM",
+            projectCodes: "PROJ-001");
+
+        result.Should().BeOfType<ForbidResult>();
+    }
+
+    [Fact]
+    public async Task GetManagedFaculty_returns_empty_array_for_unknown_iam_when_user_lacks_financial_access()
+    {
+        using AppDbContext ctx = TestDbContextFactory.CreateInMemory();
+        var authorizationService = CreateAuthorizationService();
+
+        var controller = new ProjectController(
+            new ThrowingFinancialApiService(),
+            new ResolvingDatamartService(),
+            authorizationService,
+            new UserService(NullLogger<UserService>.Instance, ctx))
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext
+                {
+                    User = CreateUser(roles: []),
+                },
+            },
+        };
+
+        var result = await controller.GetManagedFaculty("UNKNOWN-IAM", CancellationToken.None);
+
+        var ok = result.Should().BeOfType<OkObjectResult>().Which;
+        var envelope = ok.Value!;
+        var envelopeType = envelope.GetType();
+        envelopeType.GetProperty("projectManager")!.GetValue(envelope).Should().BeNull();
+        envelopeType.GetProperty("pis")!.GetValue(envelope)
+            .Should().BeAssignableTo<IEnumerable<object>>().Which.Should().BeEmpty();
+    }
+
+    [Fact]
     public void Project_routes_do_not_expose_employee_id_lookup_contracts()
     {
         var templates = typeof(ProjectController)
@@ -101,9 +187,9 @@ public sealed class ProjectControllerTests
 
     private sealed class ResolvingDatamartService : IDatamartService
     {
-        private readonly SearchablePersonRecord _person;
+        private readonly SearchablePersonRecord? _person;
 
-        public ResolvingDatamartService(SearchablePersonRecord person)
+        public ResolvingDatamartService(SearchablePersonRecord? person = null)
         {
             _person = person;
         }
@@ -120,7 +206,8 @@ public sealed class ProjectControllerTests
             string iamId,
             CancellationToken ct = default)
         {
-            return Task.FromResult(string.Equals(iamId, _person.IamId, StringComparison.OrdinalIgnoreCase)
+            return Task.FromResult(_person is not null &&
+                string.Equals(iamId, _person.IamId, StringComparison.OrdinalIgnoreCase)
                 ? _person
                 : null);
         }
@@ -129,7 +216,8 @@ public sealed class ProjectControllerTests
             string employeeId,
             CancellationToken ct = default)
         {
-            return Task.FromResult(string.Equals(employeeId, _person.EmployeeId, StringComparison.OrdinalIgnoreCase)
+            return Task.FromResult(_person is not null &&
+                string.Equals(employeeId, _person.EmployeeId, StringComparison.OrdinalIgnoreCase)
                 ? _person
                 : null);
         }
@@ -139,7 +227,7 @@ public sealed class ProjectControllerTests
             CancellationToken ct = default)
         {
             return Task.FromResult<IReadOnlyList<SearchablePersonRecord>>(
-                employeeIds.Contains(_person.EmployeeId, StringComparer.OrdinalIgnoreCase)
+                _person is not null && employeeIds.Contains(_person.EmployeeId, StringComparer.OrdinalIgnoreCase)
                     ? new[] { _person }
                     : Array.Empty<SearchablePersonRecord>());
         }

--- a/web/tests/server.tests/Controllers/ProjectControllerTests.cs
+++ b/web/tests/server.tests/Controllers/ProjectControllerTests.cs
@@ -28,7 +28,13 @@ public sealed class ProjectControllerTests
 
         var controller = new ProjectController(
             new ThrowingFinancialApiService(),
-            new ThrowingDatamartService(),
+            new ResolvingDatamartService(
+                new SearchablePersonRecord
+                {
+                    IamId = "IAM-PM",
+                    EmployeeId = "1000",
+                    Name = "Project Manager",
+                }),
             authorizationService,
             new UserService(NullLogger<UserService>.Instance, ctx))
         {
@@ -41,7 +47,7 @@ public sealed class ProjectControllerTests
             },
         };
 
-        var result = await controller.GetManagedFaculty("1000", CancellationToken.None);
+        var result = await controller.GetManagedFaculty("IAM-PM", CancellationToken.None);
 
         var ok = result.Should().BeOfType<OkObjectResult>().Which;
         var envelope = ok.Value!;
@@ -49,6 +55,24 @@ public sealed class ProjectControllerTests
         envelopeType.GetProperty("projectManager")!.GetValue(envelope).Should().BeNull();
         envelopeType.GetProperty("pis")!.GetValue(envelope)
             .Should().BeAssignableTo<IEnumerable<object>>().Which.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Project_routes_do_not_expose_employee_id_lookup_contracts()
+    {
+        var templates = typeof(ProjectController)
+            .GetMethods()
+            .SelectMany(method => method.GetCustomAttributes(typeof(HttpGetAttribute), inherit: false))
+            .Cast<HttpGetAttribute>()
+            .Select(attribute => attribute.Template)
+            .Where(template => template is not null)
+            .Select(template => template!)
+            .ToArray();
+
+        templates.Should().Contain("by-iam/{iamId}");
+        templates.Should().Contain("managed/by-iam/{iamId}");
+        templates.Should().NotContain("{employeeId}");
+        templates.Should().NotContain("managed/{employeeId}");
     }
 
     private static IAuthorizationService CreateAuthorizationService()
@@ -75,8 +99,58 @@ public sealed class ProjectControllerTests
         }
     }
 
-    private sealed class ThrowingDatamartService : IDatamartService
+    private sealed class ResolvingDatamartService : IDatamartService
     {
+        private readonly SearchablePersonRecord _person;
+
+        public ResolvingDatamartService(SearchablePersonRecord person)
+        {
+            _person = person;
+        }
+
+        public Task<IReadOnlyList<SearchablePersonRecord>> SearchPeopleAsync(
+            string query,
+            int limit,
+            CancellationToken ct = default)
+        {
+            return Task.FromResult<IReadOnlyList<SearchablePersonRecord>>(Array.Empty<SearchablePersonRecord>());
+        }
+
+        public Task<SearchablePersonRecord?> GetSearchablePersonByIamIdAsync(
+            string iamId,
+            CancellationToken ct = default)
+        {
+            return Task.FromResult(string.Equals(iamId, _person.IamId, StringComparison.OrdinalIgnoreCase)
+                ? _person
+                : null);
+        }
+
+        public Task<SearchablePersonRecord?> GetSearchablePersonByEmployeeIdAsync(
+            string employeeId,
+            CancellationToken ct = default)
+        {
+            return Task.FromResult(string.Equals(employeeId, _person.EmployeeId, StringComparison.OrdinalIgnoreCase)
+                ? _person
+                : null);
+        }
+
+        public Task<IReadOnlyList<SearchablePersonRecord>> GetSearchablePeopleByEmployeeIdsAsync(
+            IEnumerable<string> employeeIds,
+            CancellationToken ct = default)
+        {
+            return Task.FromResult<IReadOnlyList<SearchablePersonRecord>>(
+                employeeIds.Contains(_person.EmployeeId, StringComparer.OrdinalIgnoreCase)
+                    ? new[] { _person }
+                    : Array.Empty<SearchablePersonRecord>());
+        }
+
+        public Task<SearchablePersonRecord?> GetSearchablePersonByEmailAsync(
+            string email,
+            CancellationToken ct = default)
+        {
+            return Task.FromResult<SearchablePersonRecord?>(null);
+        }
+
         public Task<IReadOnlyList<FacultyPortfolioRecord>> GetFacultyPortfolioAsync(
             IEnumerable<string> projectNumbers,
             string? applicationUser = null,

--- a/web/tests/server.tests/Controllers/ProjectControllerTests.cs
+++ b/web/tests/server.tests/Controllers/ProjectControllerTests.cs
@@ -50,11 +50,9 @@ public sealed class ProjectControllerTests
         var result = await controller.GetManagedFaculty("IAM-PM", CancellationToken.None);
 
         var ok = result.Should().BeOfType<OkObjectResult>().Which;
-        var envelope = ok.Value!;
-        var envelopeType = envelope.GetType();
-        envelopeType.GetProperty("projectManager")!.GetValue(envelope).Should().BeNull();
-        envelopeType.GetProperty("pis")!.GetValue(envelope)
-            .Should().BeAssignableTo<IEnumerable<object>>().Which.Should().BeEmpty();
+        var envelope = ok.Value.Should().BeOfType<ProjectController.ManagedPisEnvelope>().Which;
+        envelope.ProjectManager.Should().BeNull();
+        envelope.Pis.Should().BeEmpty();
     }
 
     [Fact]
@@ -136,11 +134,9 @@ public sealed class ProjectControllerTests
         var result = await controller.GetManagedFaculty("UNKNOWN-IAM", CancellationToken.None);
 
         var ok = result.Should().BeOfType<OkObjectResult>().Which;
-        var envelope = ok.Value!;
-        var envelopeType = envelope.GetType();
-        envelopeType.GetProperty("projectManager")!.GetValue(envelope).Should().BeNull();
-        envelopeType.GetProperty("pis")!.GetValue(envelope)
-            .Should().BeAssignableTo<IEnumerable<object>>().Which.Should().BeEmpty();
+        var envelope = ok.Value.Should().BeOfType<ProjectController.ManagedPisEnvelope>().Which;
+        envelope.ProjectManager.Should().BeNull();
+        envelope.Pis.Should().BeEmpty();
     }
 
     [Fact]
@@ -157,8 +153,8 @@ public sealed class ProjectControllerTests
 
         templates.Should().Contain("by-iam/{iamId}");
         templates.Should().Contain("managed/by-iam/{iamId}");
-        templates.Should().NotContain("{employeeId}");
-        templates.Should().NotContain("managed/{employeeId}");
+        templates.Should().OnlyContain(template =>
+            !template.Contains("employeeId", StringComparison.OrdinalIgnoreCase));
     }
 
     private static IAuthorizationService CreateAuthorizationService()

--- a/web/tests/server.tests/Controllers/SearchControllerTests.cs
+++ b/web/tests/server.tests/Controllers/SearchControllerTests.cs
@@ -176,7 +176,7 @@ public sealed class SearchControllerTests
         var payload = result.Should().BeOfType<OkObjectResult>().Which.Value
             .Should().BeAssignableTo<IReadOnlyList<SearchController.SearchDirectoryPerson>>().Which;
 
-        payload.Should().HaveCount(2);
+        payload.Should().ContainSingle();
         payload.Select(p => p.IamId).Should().Contain("1000000002");
         payload.Select(p => p.Id).Should().Contain("1000000002");
         payload.Select(p => p.Name).Should().Contain("Edward Spang");
@@ -439,7 +439,17 @@ public sealed class SearchControllerTests
             int limit,
             CancellationToken ct = default)
         {
-            return Task.FromResult<IReadOnlyList<SearchablePersonRecord>>(_searchPeople.Take(limit).ToArray());
+            IEnumerable<SearchablePersonRecord> people = _searchPeople;
+            if (!string.IsNullOrWhiteSpace(query))
+            {
+                var normalizedQuery = query.Trim();
+                people = people.Where(p =>
+                    p.Name.Contains(normalizedQuery, StringComparison.OrdinalIgnoreCase) ||
+                    (p.Email?.Contains(normalizedQuery, StringComparison.OrdinalIgnoreCase) ?? false) ||
+                    p.IamId.Contains(normalizedQuery, StringComparison.OrdinalIgnoreCase));
+            }
+
+            return Task.FromResult<IReadOnlyList<SearchablePersonRecord>>(people.Take(limit).ToArray());
         }
 
         public Task<SearchablePersonRecord?> GetSearchablePersonByIamIdAsync(

--- a/web/tests/server.tests/Controllers/SearchControllerTests.cs
+++ b/web/tests/server.tests/Controllers/SearchControllerTests.cs
@@ -5,15 +5,15 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions;
 using Server.Controllers;
-using Server.Services;
 using Server.Tests;
 using server.Helpers;
-using server.core.Domain;
-using server.core.Services;
 using server.core.Data;
+using server.core.Domain;
+using server.core.Models;
+using server.core.Services;
 using server.tests.Fakes;
+using server.Services;
 
 namespace server.tests.Controllers;
 
@@ -28,8 +28,6 @@ public sealed class SearchControllerTests
         var controller = CreateController(
             ctx,
             authorizationService,
-            new FakeGraphService(),
-            new FakeIdentityService(),
             roles: []);
 
         var result = await controller.GetCatalog(CancellationToken.None);
@@ -49,9 +47,7 @@ public sealed class SearchControllerTests
         var controller = CreateController(
             ctx,
             authorizationService,
-            new FakeGraphService(),
-            new FakeIdentityService(),
-            roles: [server.core.Domain.Role.Names.AccrualViewer]);
+            roles: [Role.Names.AccrualViewer]);
 
         var result = await controller.GetCatalog(CancellationToken.None);
 
@@ -70,9 +66,7 @@ public sealed class SearchControllerTests
         var controller = CreateController(
             ctx,
             authorizationService,
-            new FakeGraphService(),
-            new FakeIdentityService(),
-            roles: [server.core.Domain.Role.Names.Admin]);
+            roles: [Role.Names.Admin]);
 
         var result = await controller.GetCatalog(CancellationToken.None);
 
@@ -91,8 +85,6 @@ public sealed class SearchControllerTests
         var controller = CreateController(
             ctx,
             authorizationService,
-            new FakeGraphService(),
-            new FakeIdentityService(),
             roles: []);
 
         var result = await controller.GetCatalog(CancellationToken.None);
@@ -112,9 +104,7 @@ public sealed class SearchControllerTests
         var controller = CreateController(
             ctx,
             authorizationService,
-            new FakeGraphService(),
-            new FakeIdentityService(),
-            roles: [server.core.Domain.Role.Names.AccrualViewer]);
+            roles: [Role.Names.AccrualViewer]);
 
         var result = await controller.GetCatalog(CancellationToken.None);
 
@@ -129,14 +119,21 @@ public sealed class SearchControllerTests
     {
         using AppDbContext ctx = TestDbContextFactory.CreateInMemory();
         var authorizationService = CreateAuthorizationService();
-        var graphService = new FakeGraphService(
-            searchResults: [new GraphUserSearchResult("id-1", "Elisabeth Forrestel", "elisabeth.forrestel@ucdavis.edu")]);
 
         var controller = CreateController(
             ctx,
             authorizationService,
-            graphService,
-            new FakeIdentityService(),
+            datamartService: new FakeDatamartService(
+                searchPeople:
+                [
+                    new SearchablePersonRecord
+                    {
+                        IamId = "1000000001",
+                        EmployeeId = "E0000001",
+                        Name = "Elisabeth Forrestel",
+                        Email = "elisabeth.forrestel@ucdavis.edu",
+                    },
+                ]),
             roles: []);
 
         var result = await controller.SearchPeople("elis", CancellationToken.None);
@@ -147,22 +144,32 @@ public sealed class SearchControllerTests
     }
 
     [Fact]
-    public async Task SearchPeople_returns_graph_results_for_financial_users()
+    public async Task SearchPeople_returns_datamart_people_for_financial_users()
     {
         using AppDbContext ctx = TestDbContextFactory.CreateInMemory();
         var authorizationService = CreateAuthorizationService();
-        var graphService = new FakeGraphService(
-            searchResults:
-            [
-                new GraphUserSearchResult("id-1", "Elisabeth Forrestel", "elisabeth.forrestel@ucdavis.edu"),
-                new GraphUserSearchResult("id-2", "Edward Spang", "esspang@ucdavis.edu"),
-            ]);
 
         var controller = CreateController(
             ctx,
             authorizationService,
-            graphService,
-            new FakeIdentityService(),
+            datamartService: new FakeDatamartService(
+                searchPeople:
+                [
+                    new SearchablePersonRecord
+                    {
+                        IamId = "1000000001",
+                        EmployeeId = "E0000001",
+                        Name = "Elisabeth Forrestel",
+                        Email = "elisabeth.forrestel@ucdavis.edu",
+                    },
+                    new SearchablePersonRecord
+                    {
+                        IamId = "1000000002",
+                        EmployeeId = "E0000002",
+                        Name = "Edward Spang",
+                        Email = "esspang@ucdavis.edu",
+                    },
+                ]),
             roles: [Role.Names.FinancialViewer]);
 
         var result = await controller.SearchPeople("spang", CancellationToken.None);
@@ -170,8 +177,41 @@ public sealed class SearchControllerTests
             .Should().BeAssignableTo<IReadOnlyList<SearchController.SearchDirectoryPerson>>().Which;
 
         payload.Should().HaveCount(2);
+        payload.Select(p => p.IamId).Should().Contain("1000000002");
+        payload.Select(p => p.Id).Should().Contain("1000000002");
         payload.Select(p => p.Name).Should().Contain("Edward Spang");
         payload.SelectMany(p => p.Keywords).Should().Contain("esspang@ucdavis.edu");
+        payload.SelectMany(p => p.Keywords).Should().NotContain("E0000002");
+    }
+
+    [Fact]
+    public async Task SearchPeople_reports_is_project_manager_when_person_manages_projects()
+    {
+        using AppDbContext ctx = TestDbContextFactory.CreateInMemory();
+        var authorizationService = CreateAuthorizationService();
+
+        var controller = CreateController(
+            ctx,
+            authorizationService,
+            datamartService: new FakeDatamartService(
+                searchPeople:
+                [
+                    new SearchablePersonRecord
+                    {
+                        IamId = "1000000003",
+                        EmployeeId = "PM000003",
+                        Name = "Patty Manager",
+                        Email = "patty@ucdavis.edu",
+                    },
+                ]),
+            roles: [Role.Names.FinancialViewer],
+            projectManagerEmployeeIds: ["PM000003"]);
+
+        var result = await controller.SearchPeople("patty", CancellationToken.None);
+        var payload = result.Should().BeOfType<OkObjectResult>().Which.Value
+            .Should().BeAssignableTo<IReadOnlyList<SearchController.SearchDirectoryPerson>>().Which;
+
+        payload.Should().ContainSingle().Which.IsProjectManager.Should().BeTrue();
     }
 
     [Fact]
@@ -179,19 +219,20 @@ public sealed class SearchControllerTests
     {
         using AppDbContext ctx = TestDbContextFactory.CreateInMemory();
         var authorizationService = CreateAuthorizationService();
-        var graphService = new FakeGraphService(
-            searchResults: Enumerable.Range(1, 7)
-                .Select(i => new GraphUserSearchResult(
-                    $"id-{i}",
-                    $"Person {i}",
-                    $"person{i}@ucdavis.edu"))
-                .ToArray());
 
         var controller = CreateController(
             ctx,
             authorizationService,
-            graphService,
-            new FakeIdentityService(),
+            datamartService: new FakeDatamartService(
+                searchPeople: Enumerable.Range(1, 7)
+                    .Select(i => new SearchablePersonRecord
+                    {
+                        IamId = $"100000000{i}",
+                        EmployeeId = $"E000000{i}",
+                        Name = $"Person {i}",
+                        Email = $"person{i}@ucdavis.edu",
+                    })
+                    .ToArray()),
             roles: [Role.Names.FinancialViewer]);
 
         var result = await controller.SearchPeople("person", CancellationToken.None);
@@ -199,96 +240,150 @@ public sealed class SearchControllerTests
             .Should().BeAssignableTo<IReadOnlyList<SearchController.SearchDirectoryPerson>>().Which;
 
         payload.Should().HaveCount(5);
-        payload.Select(p => p.Id).Should().ContainInOrder("id-1", "id-2", "id-3", "id-4", "id-5");
+        payload.Select(p => p.IamId).Should().ContainInOrder(
+            "1000000001",
+            "1000000002",
+            "1000000003",
+            "1000000004",
+            "1000000005");
     }
 
     [Fact]
-    public async Task ResolvePersonByDirectoryId_returns_employee_id_when_identity_is_found()
+    public async Task ResolveProjectPi_returns_pi_iam_id_when_pi_email_resolves()
     {
         using AppDbContext ctx = TestDbContextFactory.CreateInMemory();
         var authorizationService = CreateAuthorizationService();
-        var graphService = new FakeGraphService(
-            profiles: new Dictionary<string, GraphUserProfile>
-            {
-                ["id-esspang"] = new GraphUserProfile(
-                    Id: "id-esspang",
-                    DisplayName: "Edward Spang",
-                    Email: "esspang@ucdavis.edu",
-                    IamId: "IAM-ESSPANG"),
-            });
-        var identityService = new FakeIdentityService(
-            identities: new Dictionary<string, IamIdentity>
-            {
-                ["IAM-ESSPANG"] = new IamIdentity("IAM-ESSPANG", "200123", "Edward Spang"),
-            });
 
         var controller = CreateController(
             ctx,
             authorizationService,
-            graphService,
-            identityService,
+            datamartService: new FakeDatamartService(
+                searchPeople:
+                [
+                    new SearchablePersonRecord
+                    {
+                        IamId = "IAM-PI",
+                        EmployeeId = "EPI",
+                        Name = "Pat PI",
+                        Email = "pi@ucdavis.edu",
+                    },
+                    new SearchablePersonRecord
+                    {
+                        IamId = "IAM-PM",
+                        EmployeeId = "EPM",
+                        Name = "Morgan PM",
+                        Email = "pm@ucdavis.edu",
+                    },
+                ]),
+            financialApiService: new FakeFinancialApiService(
+                [],
+                new Dictionary<string, IReadOnlyList<FakeFinancialProjectTeamMember>>
+                {
+                    ["ABC123"] =
+                    [
+                        new FakeFinancialProjectTeamMember(
+                            PpmRole.PrincipalInvestigator,
+                            "Pat PI",
+                            "pi@ucdavis.edu"),
+                        new FakeFinancialProjectTeamMember(
+                            PpmRole.ProjectManager,
+                            "Morgan PM",
+                            "pm@ucdavis.edu"),
+                    ],
+                }),
             roles: [Role.Names.FinancialViewer]);
 
-        var result = await controller.ResolvePersonByDirectoryId("id-esspang", CancellationToken.None);
-        var payload = result.Should().BeOfType<OkObjectResult>().Which.Value
-            .Should().BeOfType<SearchController.ResolveDirectoryPersonResponse>().Which;
+        var result = await controller.ResolveProjectPi("abc123", CancellationToken.None);
 
-        payload.EmployeeId.Should().Be("200123");
-        payload.Name.Should().Be("Edward Spang");
-        payload.IsProjectManager.Should().BeFalse();
+        var payload = result.Should().BeOfType<OkObjectResult>().Which.Value
+            .Should().BeOfType<SearchController.ResolveProjectPiResponse>().Which;
+        payload.IamId.Should().Be("IAM-PI");
+        payload.ProjectNumber.Should().Be("ABC123");
     }
 
     [Fact]
-    public async Task ResolvePersonByDirectoryId_reports_is_project_manager_when_employee_manages_projects()
+    public async Task ResolveProjectPi_falls_back_to_pm_when_project_is_orphaned()
     {
         using AppDbContext ctx = TestDbContextFactory.CreateInMemory();
         var authorizationService = CreateAuthorizationService();
-        var graphService = new FakeGraphService(
-            profiles: new Dictionary<string, GraphUserProfile>
-            {
-                ["id-pm"] = new GraphUserProfile(
-                    Id: "id-pm",
-                    DisplayName: "Patty Manager",
-                    Email: "pmanager@ucdavis.edu",
-                    IamId: "IAM-PM"),
-            });
-        var identityService = new FakeIdentityService(
-            identities: new Dictionary<string, IamIdentity>
-            {
-                ["IAM-PM"] = new IamIdentity("IAM-PM", "PM-7001", "Patty Manager"),
-            });
 
         var controller = CreateController(
             ctx,
             authorizationService,
-            graphService,
-            identityService,
-            roles: [Role.Names.FinancialViewer],
-            projectManagerEmployeeIds: ["PM-7001"]);
+            datamartService: new FakeDatamartService(
+                searchPeople:
+                [
+                    new SearchablePersonRecord
+                    {
+                        IamId = "IAM-PM",
+                        EmployeeId = "EPM",
+                        Name = "Morgan PM",
+                        Email = "pm@ucdavis.edu",
+                    },
+                ]),
+            financialApiService: new FakeFinancialApiService(
+                [],
+                new Dictionary<string, IReadOnlyList<FakeFinancialProjectTeamMember>>
+                {
+                    ["ABC123"] =
+                    [
+                        new FakeFinancialProjectTeamMember(
+                            PpmRole.ProjectManager,
+                            "Morgan PM",
+                            "pm@ucdavis.edu"),
+                    ],
+                }),
+            roles: [Role.Names.FinancialViewer]);
 
-        var result = await controller.ResolvePersonByDirectoryId("id-pm", CancellationToken.None);
+        var result = await controller.ResolveProjectPi("ABC123", CancellationToken.None);
+
         var payload = result.Should().BeOfType<OkObjectResult>().Which.Value
-            .Should().BeOfType<SearchController.ResolveDirectoryPersonResponse>().Which;
-
-        payload.EmployeeId.Should().Be("PM-7001");
-        payload.IsProjectManager.Should().BeTrue();
+            .Should().BeOfType<SearchController.ResolveProjectPiResponse>().Which;
+        payload.IamId.Should().Be("IAM-PM");
+        payload.ProjectNumber.Should().Be("ABC123");
     }
 
     [Fact]
-    public async Task ResolvePersonByDirectoryId_forbids_non_financial_users()
+    public async Task ResolveProjectPi_does_not_fallback_to_pm_when_pi_exists_but_cannot_resolve()
     {
         using AppDbContext ctx = TestDbContextFactory.CreateInMemory();
         var authorizationService = CreateAuthorizationService();
+
         var controller = CreateController(
             ctx,
             authorizationService,
-            new FakeGraphService(),
-            new FakeIdentityService(),
-            roles: []);
+            datamartService: new FakeDatamartService(
+                searchPeople:
+                [
+                    new SearchablePersonRecord
+                    {
+                        IamId = "IAM-PM",
+                        EmployeeId = "EPM",
+                        Name = "Morgan PM",
+                        Email = "pm@ucdavis.edu",
+                    },
+                ]),
+            financialApiService: new FakeFinancialApiService(
+                [],
+                new Dictionary<string, IReadOnlyList<FakeFinancialProjectTeamMember>>
+                {
+                    ["ABC123"] =
+                    [
+                        new FakeFinancialProjectTeamMember(
+                            PpmRole.PrincipalInvestigator,
+                            "Pat PI",
+                            "missing-pi@ucdavis.edu"),
+                        new FakeFinancialProjectTeamMember(
+                            PpmRole.ProjectManager,
+                            "Morgan PM",
+                            "pm@ucdavis.edu"),
+                    ],
+                }),
+            roles: [Role.Names.FinancialViewer]);
 
-        var result = await controller.ResolvePersonByDirectoryId("id-1", CancellationToken.None);
+        var result = await controller.ResolveProjectPi("ABC123", CancellationToken.None);
 
-        result.Should().BeOfType<ForbidResult>();
+        result.Should().BeOfType<NotFoundResult>();
     }
 
     private static IAuthorizationService CreateAuthorizationService()
@@ -303,9 +398,9 @@ public sealed class SearchControllerTests
     private static SearchController CreateController(
         AppDbContext ctx,
         IAuthorizationService authorizationService,
-        IGraphService graphService,
-        IIdentityService identityService,
         IReadOnlyList<string> roles,
+        IDatamartService? datamartService = null,
+        IFinancialApiService? financialApiService = null,
         IEnumerable<string>? projectManagerEmployeeIds = null)
     {
         var httpContext = new DefaultHttpContext
@@ -315,11 +410,9 @@ public sealed class SearchControllerTests
 
         return new SearchController(
             ctx,
-            new FakeFinancialApiService(projectManagerEmployeeIds ?? Array.Empty<string>()),
+            financialApiService ?? new FakeFinancialApiService(projectManagerEmployeeIds ?? Array.Empty<string>()),
             authorizationService,
-            graphService,
-            identityService,
-            NullLogger<SearchController>.Instance)
+            datamartService ?? new FakeDatamartService())
         {
             ControllerContext = new ControllerContext { HttpContext = httpContext },
         };
@@ -332,75 +425,99 @@ public sealed class SearchControllerTests
         return new ClaimsPrincipal(identity);
     }
 
-    private sealed class FakeGraphService : IGraphService
+    private sealed class FakeDatamartService : IDatamartService
     {
-        private readonly IReadOnlyList<GraphUserSearchResult> _searchResults;
-        private readonly IReadOnlyDictionary<string, GraphUserProfile> _profiles;
+        private readonly IReadOnlyList<SearchablePersonRecord> _searchPeople;
 
-        public FakeGraphService(
-            IReadOnlyList<GraphUserSearchResult>? searchResults = null,
-            IReadOnlyDictionary<string, GraphUserProfile>? profiles = null)
+        public FakeDatamartService(IReadOnlyList<SearchablePersonRecord>? searchPeople = null)
         {
-            _searchResults = searchResults ?? [];
-            _profiles = profiles ?? new Dictionary<string, GraphUserProfile>();
+            _searchPeople = searchPeople ?? [];
         }
 
-        public Task<GraphUserPhoto?> GetMePhotoAsync(ClaimsPrincipal principal, CancellationToken cancellationToken = default)
-        {
-            return Task.FromResult<GraphUserPhoto?>(null);
-        }
-
-        public Task<IReadOnlyList<GraphUserSearchResult>> SearchUsersAsync(
-            ClaimsPrincipal principal,
+        public Task<IReadOnlyList<SearchablePersonRecord>> SearchPeopleAsync(
             string query,
-            CancellationToken cancellationToken = default)
+            int limit,
+            CancellationToken ct = default)
         {
-            return Task.FromResult(_searchResults);
+            return Task.FromResult<IReadOnlyList<SearchablePersonRecord>>(_searchPeople.Take(limit).ToArray());
         }
 
-        public Task<GraphUserProfile?> FindUserByEmailAsync(
-            ClaimsPrincipal principal,
+        public Task<SearchablePersonRecord?> GetSearchablePersonByIamIdAsync(
+            string iamId,
+            CancellationToken ct = default)
+        {
+            return Task.FromResult(_searchPeople.FirstOrDefault(p =>
+                string.Equals(p.IamId, iamId, StringComparison.OrdinalIgnoreCase)));
+        }
+
+        public Task<SearchablePersonRecord?> GetSearchablePersonByEmployeeIdAsync(
+            string employeeId,
+            CancellationToken ct = default)
+        {
+            return Task.FromResult(_searchPeople.FirstOrDefault(p =>
+                string.Equals(p.EmployeeId, employeeId, StringComparison.OrdinalIgnoreCase)));
+        }
+
+        public Task<IReadOnlyList<SearchablePersonRecord>> GetSearchablePeopleByEmployeeIdsAsync(
+            IEnumerable<string> employeeIds,
+            CancellationToken ct = default)
+        {
+            var employeeIdSet = employeeIds.ToHashSet(StringComparer.OrdinalIgnoreCase);
+            return Task.FromResult<IReadOnlyList<SearchablePersonRecord>>(
+                _searchPeople.Where(p => employeeIdSet.Contains(p.EmployeeId)).ToArray());
+        }
+
+        public Task<SearchablePersonRecord?> GetSearchablePersonByEmailAsync(
             string email,
-            CancellationToken cancellationToken = default)
+            CancellationToken ct = default)
         {
-            var profile = _profiles.Values.FirstOrDefault(p =>
-                string.Equals(p.Email, email, StringComparison.OrdinalIgnoreCase) ||
-                GraphService.EnumerateEmailCandidates(email).Any(candidate =>
-                    string.Equals(p.Email, candidate, StringComparison.OrdinalIgnoreCase)));
-
-            return Task.FromResult(profile);
+            return Task.FromResult(_searchPeople.FirstOrDefault(p =>
+                string.Equals(p.Email, email, StringComparison.OrdinalIgnoreCase)));
         }
 
-        public Task<GraphUserProfile?> GetUserProfileAsync(
-            ClaimsPrincipal principal,
-            string userObjectId,
-            CancellationToken cancellationToken = default)
+        public Task<IReadOnlyList<EmployeeAccrualBalanceRecord>> GetEmployeeAccrualBalancesAsync(
+            DateTime startDate,
+            string? applicationUser = null,
+            string? emulatingUser = null,
+            CancellationToken ct = default)
         {
-            return Task.FromResult(_profiles.TryGetValue(userObjectId, out var profile)
-                ? profile
-                : null);
-        }
-    }
-
-    private sealed class FakeIdentityService : IIdentityService
-    {
-        private readonly IReadOnlyDictionary<string, IamIdentity> _identities;
-
-        public FakeIdentityService(IReadOnlyDictionary<string, IamIdentity>? identities = null)
-        {
-            _identities = identities ?? new Dictionary<string, IamIdentity>();
+            throw new NotImplementedException();
         }
 
-        public Task<IamIdentity?> GetByIamId(string iamId)
+        public Task<IReadOnlyList<FacultyPortfolioRecord>> GetFacultyPortfolioAsync(
+            IEnumerable<string> projectNumbers,
+            string? applicationUser = null,
+            string? emulatingUser = null,
+            CancellationToken ct = default)
         {
-            return Task.FromResult(_identities.TryGetValue(iamId, out var identity)
-                ? identity
-                : null);
+            throw new NotImplementedException();
         }
 
-        public Task<string?> GetKerberosByIamId(string iamId)
+        public Task<IReadOnlyList<PositionBudgetRecord>> GetPositionBudgetsAsync(
+            IEnumerable<string> projectNumbers,
+            string? applicationUser = null,
+            string? emulatingUser = null,
+            CancellationToken ct = default)
         {
-            return Task.FromResult<string?>(null);
+            throw new NotImplementedException();
+        }
+
+        public Task<IReadOnlyList<GLPPMReconciliationRecord>> GetGLPPMReconciliationAsync(
+            IEnumerable<string> projectNumbers,
+            string? applicationUser = null,
+            string? emulatingUser = null,
+            CancellationToken ct = default)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<IReadOnlyList<GLTransactionRecord>> GetGLTransactionListingsAsync(
+            IEnumerable<string> projectNumbers,
+            string? applicationUser = null,
+            string? emulatingUser = null,
+            CancellationToken ct = default)
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/web/tests/server.tests/Fakes/FakeFinancialApi.cs
+++ b/web/tests/server.tests/Fakes/FakeFinancialApi.cs
@@ -13,15 +13,26 @@ namespace server.tests.Fakes;
 public sealed class FakeFinancialApiService : IFinancialApiService
 {
     private readonly HashSet<string> _projectManagerEmployeeIds;
+    private readonly Dictionary<string, IReadOnlyList<FakeFinancialProjectTeamMember>> _projectTeamMembersByProjectNumber;
 
     public FakeFinancialApiService()
         : this(Array.Empty<string>()) { }
 
     public FakeFinancialApiService(IEnumerable<string> projectManagerEmployeeIds)
+        : this(projectManagerEmployeeIds, null) { }
+
+    public FakeFinancialApiService(
+        IEnumerable<string> projectManagerEmployeeIds,
+        IReadOnlyDictionary<string, IReadOnlyList<FakeFinancialProjectTeamMember>>? projectTeamMembersByProjectNumber)
     {
         _projectManagerEmployeeIds = new HashSet<string>(
             projectManagerEmployeeIds,
             StringComparer.OrdinalIgnoreCase);
+        _projectTeamMembersByProjectNumber = projectTeamMembersByProjectNumber is null
+            ? new Dictionary<string, IReadOnlyList<FakeFinancialProjectTeamMember>>(StringComparer.OrdinalIgnoreCase)
+            : new Dictionary<string, IReadOnlyList<FakeFinancialProjectTeamMember>>(
+                projectTeamMembersByProjectNumber,
+                StringComparer.OrdinalIgnoreCase);
     }
 
     public IAggieEnterpriseClient GetClient()
@@ -33,10 +44,20 @@ public sealed class FakeFinancialApiService : IFinancialApiService
                 return new FakePpmProjectByProjectTeamMemberEmployeeIdQuery(_projectManagerEmployeeIds);
             }
 
+            if (method.Name == "get_PpmProjectTeamMembers")
+            {
+                return new FakePpmProjectTeamMembersQuery(_projectTeamMembersByProjectNumber);
+            }
+
             throw new NotImplementedException($"{method.Name} is not implemented for this fake.");
         });
     }
 }
+
+public sealed record FakeFinancialProjectTeamMember(
+    string RoleName,
+    string Name,
+    string? Email);
 
 internal sealed class FakePpmProjectByProjectTeamMemberEmployeeIdQuery : IPpmProjectByProjectTeamMemberEmployeeIdQuery
 {
@@ -83,6 +104,85 @@ internal sealed class FakePpmProjectByProjectTeamMemberEmployeeIdQuery : IPpmPro
         ExecutionStrategy? strategy = null)
     {
         throw new NotImplementedException();
+    }
+}
+
+internal sealed class FakePpmProjectTeamMembersQuery : IPpmProjectTeamMembersQuery
+{
+    private readonly IReadOnlyDictionary<string, IReadOnlyList<FakeFinancialProjectTeamMember>> _projectTeamMembersByProjectNumber;
+
+    public FakePpmProjectTeamMembersQuery(
+        IReadOnlyDictionary<string, IReadOnlyList<FakeFinancialProjectTeamMember>> projectTeamMembersByProjectNumber)
+    {
+        _projectTeamMembersByProjectNumber = projectTeamMembersByProjectNumber;
+    }
+
+    public Type ResultType => typeof(IPpmProjectTeamMembersResult);
+
+    public OperationRequest Create(IReadOnlyDictionary<string, object?>? variables)
+    {
+        return new OperationRequest(
+            "FakePpmProjectTeamMembers",
+            ProxyFactory.CreateProxy<IDocument>((_, _) => throw new NotImplementedException()),
+            variables ?? new Dictionary<string, object?>(),
+            new Dictionary<string, Upload?>(),
+            default);
+    }
+
+    public Task<IOperationResult<IPpmProjectTeamMembersResult>> ExecuteAsync(
+        string projectNumber,
+        string? roleName,
+        CancellationToken cancellationToken)
+    {
+        _projectTeamMembersByProjectNumber.TryGetValue(projectNumber, out var allMembers);
+        var members = (allMembers ?? [])
+            .Where(member => roleName is null || string.Equals(member.RoleName, roleName, StringComparison.OrdinalIgnoreCase))
+            .Select(CreateTeamMember)
+            .ToArray();
+
+        var project = ProxyFactory.CreateProxy<IPpmProjectTeamMembers_PpmProjectByNumber>((method, _) =>
+            method.Name switch
+            {
+                "get_TeamMembers" => members,
+                _ => throw new NotImplementedException($"{method.Name} is not implemented for this fake."),
+            });
+        var result = ProxyFactory.CreateProxy<IPpmProjectTeamMembersResult>((method, _) =>
+            method.Name switch
+            {
+                "get_PpmProjectByNumber" => project,
+                _ => throw new NotImplementedException($"{method.Name} is not implemented for this fake."),
+            });
+
+        return Task.FromResult<IOperationResult<IPpmProjectTeamMembersResult>>(
+            new FakeOperationResult<IPpmProjectTeamMembersResult>(result));
+    }
+
+    public IObservable<IOperationResult<IPpmProjectTeamMembersResult>> Watch(
+        string projectNumber,
+        string? roleName,
+        ExecutionStrategy? strategy = null)
+    {
+        throw new NotImplementedException();
+    }
+
+    private static IPpmProjectTeamMembers_PpmProjectByNumber_TeamMembers CreateTeamMember(
+        FakeFinancialProjectTeamMember member)
+    {
+        var person = ProxyFactory.CreateProxy<IPpmProjectTeamMembers_PpmProjectByNumber_TeamMembers_Person>((method, _) =>
+            method.Name switch
+            {
+                "get_Email" => member.Email,
+                _ => throw new NotImplementedException($"{method.Name} is not implemented for this fake."),
+            });
+
+        return ProxyFactory.CreateProxy<IPpmProjectTeamMembers_PpmProjectByNumber_TeamMembers>((method, _) =>
+            method.Name switch
+            {
+                "get_Name" => member.Name,
+                "get_Person" => person,
+                "get_RoleName" => member.RoleName,
+                _ => throw new NotImplementedException($"{method.Name} is not implemented for this fake."),
+            });
     }
 }
 


### PR DESCRIPTION
replace all employeeID lookups, routes, and api endpoints to use IamID.  Roberto "People" table required.  Search now uses this people table as well instead of entra.

Once we can join directly against projects we can tighten this up a little more, but as-is I think it's much better already.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added core identity terminology and rules for identifiers, relationships, and navigation/display constraints.

* **Refactor**
  * App routing, project/personnel pages, alerts, and command-palette search now use IAM-based identifiers for navigation and resolution.
  * Search and project/team lookups simplified to return IAM-based results; project links and personnel views now route using IAM IDs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->