### PR TITLE
Add project projection/burndown sproc with local GL summary table

### DIFF
--- a/datamart/Scripts/Script.PostDeployment.sql
+++ b/datamart/Scripts/Script.PostDeployment.sql
@@ -18,6 +18,7 @@ GRANT EXECUTE ON [dbo].[usp_GetFacultyDeptPortfolio] TO [WalterAppRole];
 GRANT EXECUTE ON [dbo].[usp_GetFacultyDeptPortfolioElzar] TO [WalterAppRole];
 GRANT EXECUTE ON [dbo].[usp_GetPPMProjectSummaryElzar] TO [WalterAppRole];
 GRANT EXECUTE ON [dbo].[usp_GetProjectSummary] TO [WalterAppRole];
+GRANT EXECUTE ON [dbo].[usp_GetProjectProjection] TO [WalterAppRole];
 GRANT EXECUTE ON [dbo].[usp_GetGLProjectSummaryElzar] TO [WalterAppRole];
 GRANT EXECUTE ON [dbo].[usp_GetGLPPMReconciliation] TO [WalterAppRole];
 GRANT EXECUTE ON [dbo].[usp_GetGLTransactionListings] TO [WalterAppRole];
@@ -46,6 +47,8 @@ GRANT SELECT ON [dbo].[PpmPeople] TO [WalterAppRole];
 GRANT SELECT ON [dbo].[PpmPersonRoles] TO [WalterAppRole];
 GRANT SELECT ON [dbo].[PpmProjects] TO [WalterAppRole];
 GRANT SELECT ON [dbo].[PpmProjectAwards] TO [WalterAppRole];
+GRANT SELECT ON [dbo].[GlProjectMonthlyActuals] TO [WalterAppRole];
+GRANT SELECT ON [dbo].[ExpenditureTypeByAccount] TO [WalterAppRole];
 
 -- Grant pipeline role permissions
 GRANT INSERT, SELECT, UPDATE, DELETE ON [dbo].[FacultyDeptPortfolio] TO [WalterPipelineRole];
@@ -67,6 +70,11 @@ GRANT INSERT, SELECT, UPDATE, DELETE ON [dbo].[PpmPeople_Staging] TO [WalterPipe
 GRANT INSERT, SELECT, UPDATE, DELETE ON [dbo].[PpmPersonRoles_Staging] TO [WalterPipelineRole];
 GRANT INSERT, SELECT, UPDATE, DELETE ON [dbo].[PpmProjects_Staging] TO [WalterPipelineRole];
 GRANT INSERT, SELECT, UPDATE, DELETE ON [dbo].[PpmProjectAwards_Staging] TO [WalterPipelineRole];
+-- AE_DWH copy job loads GlProjectMonthlyActuals_Staging, then usp_SwapStagingTable snapshot-swaps
+-- it into the final table. The final-table DML grant is required because the swap runs dynamic SQL,
+-- which does not honor ownership chaining.
+GRANT INSERT, SELECT, UPDATE, DELETE ON [dbo].[GlProjectMonthlyActuals] TO [WalterPipelineRole];
+GRANT INSERT, SELECT, UPDATE, DELETE ON [dbo].[GlProjectMonthlyActuals_Staging] TO [WalterPipelineRole];
 
 
 

--- a/datamart/StoredProcedures/usp_GetProjectProjection.sql
+++ b/datamart/StoredProcedures/usp_GetProjectProjection.sql
@@ -1,0 +1,206 @@
+-- Monthly per-expenditure-category budget burndown for a single project.
+-- Returns two result sets:
+--   1. Per-category budget header (budget, spent-to-date, committed, current remaining).
+--   2. Period x category grid: 3 trailing actual months, the current (blended) month, and 12
+--      projected months, each with actual spend, projected spend, and the running budget
+--      remaining (burndown).
+-- All inputs are local: GL actuals from dbo.GlProjectMonthlyActuals, the natural-account ->
+-- category crosswalk from dbo.ExpenditureTypeByAccount, personnel from dbo.PositionBudgets +
+-- dbo.CompositeBenefitRates, and the budget baseline from dbo.FacultyDeptPortfolio.
+CREATE PROCEDURE dbo.usp_GetProjectProjection
+    @ProjectId       NVARCHAR(15),
+    @ApplicationName NVARCHAR(128) = NULL,
+    @ApplicationUser NVARCHAR(256) = NULL,
+    @EmulatingUser   NVARCHAR(256) = NULL
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    DECLARE @StartTime      DATETIME2 = SYSDATETIME();
+    DECLARE @RowCount       INT;
+    DECLARE @Duration_MS    INT;
+    DECLARE @ErrorMsg       NVARCHAR(MAX);
+    DECLARE @ParametersJSON NVARCHAR(MAX);
+
+    -- "Now" anchors the whole window: 3 trailing actual months, the current (blended) month,
+    -- and 12 projected months. Current-month non-personnel projection is prorated by the days
+    -- remaining in the month.
+    DECLARE @Today          DATE = CAST(GETDATE() AS DATE);
+    DECLARE @CurrMonthStart DATE = DATEFROMPARTS(YEAR(@Today), MONTH(@Today), 1);
+    DECLARE @DaysInMonth    INT  = DAY(EOMONTH(@Today));
+    DECLARE @RemainingDays  INT  = @DaysInMonth - DAY(@Today);
+
+    EXEC dbo.usp_SanitizeInputString @ApplicationName OUTPUT;
+    EXEC dbo.usp_SanitizeInputString @ApplicationUser OUTPUT;
+
+    BEGIN TRY
+        -- Build parameters JSON before validation so a bad project id is still logged by the CATCH.
+        SET @ParametersJSON = (
+            SELECT @ProjectId AS ProjectId,
+                   COALESCE(@ApplicationName, APP_NAME()) AS ApplicationName
+            FOR JSON PATH, WITHOUT_ARRAY_WRAPPER
+        );
+
+        EXEC dbo.usp_ValidateAggieEnterpriseProject @ProjectId;
+
+        /* Period dimension: offsets -3..+12 from the current month. */
+        DROP TABLE IF EXISTS #periods;
+        SELECT
+            DATEADD(MONTH, n, @CurrMonthStart) AS MonthStart,
+            FORMAT(DATEADD(MONTH, n, @CurrMonthStart), 'MMM-yy') AS DisplayPeriod,
+            CASE WHEN n < 0 THEN 'actual' WHEN n = 0 THEN 'blended' ELSE 'projected' END AS Kind
+        INTO #periods
+        FROM (VALUES (-3),(-2),(-1),(0),(1),(2),(3),(4),(5),(6),(7),(8),(9),(10),(11),(12)) v(n);
+
+        /* GL actuals, filtered to expense accounts (parent rollup '5%') and mapped from natural
+           account to expenditure category. Unmapped expense accounts fall into
+           '99 - Uncategorized' so nothing silently disappears. PeriodName ('Mmm-yy') is matched
+           to the period dimension's DisplayPeriod downstream. */
+        DROP TABLE IF EXISTS #gl;
+        SELECT COALESCE(x.ExpenditureCategory, '99 - Uncategorized') AS ExpenditureCategory,
+               a.PeriodName,
+               SUM(a.ActualAmount) AS ActualAmount
+        INTO #gl
+        FROM dbo.GlProjectMonthlyActuals a
+        LEFT JOIN dbo.ExpenditureTypeByAccount x ON x.NaturalAccount = a.NaturalAccount
+        WHERE a.ProjectId = @ProjectId
+          AND a.ParentLevel0Code LIKE '5%'
+        GROUP BY COALESCE(x.ExpenditureCategory, '99 - Uncategorized'), a.PeriodName;
+
+        /* Per-category budget baseline (anchor for the burndown). PpmBudBal already nets
+           commitments, consistent with excluding commitments from spend. */
+        DROP TABLE IF EXISTS #budget;
+        SELECT f.ExpenditureCategoryName AS ExpenditureCategory,
+               SUM(f.PpmBudget)      AS Budget,
+               SUM(f.PpmExpenses)    AS SpentToDate,
+               SUM(f.PpmCommitments) AS Committed,
+               SUM(f.PpmBudBal)      AS RemainingNow
+        INTO #budget
+        FROM dbo.FacultyDeptPortfolio f
+        WHERE f.ProjectNumber = @ProjectId
+        GROUP BY f.ExpenditureCategoryName;
+
+        /* Category set = anything with GL spend, a budget line, or that is personnel. */
+        DROP TABLE IF EXISTS #cats;
+        SELECT c.ExpenditureCategory,
+               CASE WHEN c.ExpenditureCategory IN ('01 - Salaries and Wages','02 - Fringe Benefits')
+                    THEN 1 ELSE 0 END AS IsPersonnel
+        INTO #cats
+        FROM (SELECT ExpenditureCategory FROM #gl
+              UNION SELECT ExpenditureCategory FROM #budget
+              UNION SELECT '01 - Salaries and Wages'
+              UNION SELECT '02 - Fringe Benefits') c;
+
+        /* Personnel projection for the current + future months. Salary is this project's share:
+           MonthlyRate (1.0-FTE rate) * Fte * DistributionPercent. Fringe loads CBR + vacation
+           accrual (both stored as fractions). A position contributes only while its funding
+           window is open and its job has not ended; a NULL end date means funded indefinitely. */
+        DROP TABLE IF EXISTS #pers;
+        SELECT p.MonthStart,
+               SUM(pb.MonthlyRate * pb.Fte * pb.DistributionPercent / 100.0) AS Salary,
+               SUM(pb.MonthlyRate * pb.Fte * pb.DistributionPercent / 100.0
+                   * (COALESCE(cbr.CBR, 0) + COALESCE(cbr.VacationAccrual, 0))) AS Fringe
+        INTO #pers
+        FROM #periods p
+        JOIN dbo.PositionBudgets pb ON pb.ProjectId = @ProjectId
+           AND (pb.FundingEffectiveDate IS NULL OR pb.FundingEffectiveDate <= EOMONTH(p.MonthStart))
+           AND (pb.FundingEndDate       IS NULL OR pb.FundingEndDate       >= p.MonthStart)
+           AND (pb.ExpectedEndDate      IS NULL OR pb.ExpectedEndDate      >= p.MonthStart)
+        LEFT JOIN dbo.CompositeBenefitRates cbr ON cbr.JobCode = pb.JobCode
+        WHERE p.Kind IN ('blended','projected')
+        GROUP BY p.MonthStart;
+
+        /* Non-personnel projection = average of the 3 trailing actual months (divided by 3 even
+           when a category posted in fewer of them). */
+        DROP TABLE IF EXISTS #navg;
+        SELECT g.ExpenditureCategory, SUM(g.ActualAmount) / 3.0 AS AvgAmount
+        INTO #navg
+        FROM #gl g
+        JOIN #periods p ON p.DisplayPeriod = g.PeriodName AND p.Kind = 'actual'
+        JOIN #cats c ON c.ExpenditureCategory = g.ExpenditureCategory AND c.IsPersonnel = 0
+        GROUP BY g.ExpenditureCategory;
+
+        /* Spend per period x category. Current month: non-personnel = booked actuals + prorated
+           remainder; personnel = whole-month budget (mid-month payroll actuals ignored). */
+        DROP TABLE IF EXISTS #spend;
+        SELECT p.MonthStart, p.DisplayPeriod, p.Kind, c.ExpenditureCategory, c.IsPersonnel,
+            CAST(CASE
+                WHEN p.Kind = 'actual'                        THEN COALESCE(g.ActualAmount, 0)
+                WHEN p.Kind = 'blended' AND c.IsPersonnel = 0 THEN COALESCE(g.ActualAmount, 0)
+                ELSE 0 END AS DECIMAL(18,2)) AS ActualAmount,
+            CAST(CASE
+                WHEN c.IsPersonnel = 1 AND p.Kind IN ('blended','projected')
+                    THEN COALESCE(CASE WHEN c.ExpenditureCategory = '01 - Salaries and Wages'
+                                       THEN pr.Salary ELSE pr.Fringe END, 0)
+                WHEN c.IsPersonnel = 0 AND p.Kind = 'projected'
+                    THEN COALESCE(na.AvgAmount, 0)
+                WHEN c.IsPersonnel = 0 AND p.Kind = 'blended'
+                    THEN COALESCE(na.AvgAmount, 0) * @RemainingDays / @DaysInMonth
+                ELSE 0 END AS DECIMAL(18,2)) AS ProjectedAmount
+        INTO #spend
+        FROM #periods p
+        CROSS JOIN #cats c
+        LEFT JOIN #gl   g  ON g.ExpenditureCategory = c.ExpenditureCategory AND g.PeriodName = p.DisplayPeriod
+        LEFT JOIN #pers pr ON pr.MonthStart = p.MonthStart
+        LEFT JOIN #navg na ON na.ExpenditureCategory = c.ExpenditureCategory;
+
+        /* Result 1: per-category budget header. */
+        SELECT b.ExpenditureCategory,
+               CASE WHEN b.ExpenditureCategory IN ('01 - Salaries and Wages','02 - Fringe Benefits')
+                    THEN 1 ELSE 0 END AS IsPersonnel,
+               b.Budget, b.SpentToDate, b.Committed, b.RemainingNow
+        FROM #budget b
+        ORDER BY b.ExpenditureCategory;
+
+        /* Result 2: period x category grid with the running burndown. Remaining is anchored at
+           the current balance (RemainingNow) as of the last actual month, then integrated
+           backward (history) and forward (projection). */
+        SELECT
+            CONVERT(CHAR(7), s.MonthStart, 126) AS [Month],   -- 'YYYY-MM'
+            s.DisplayPeriod,
+            s.Kind,
+            s.ExpenditureCategory,
+            s.IsPersonnel,
+            s.ActualAmount,
+            s.ProjectedAmount,
+            CAST(COALESCE(b.RemainingNow, 0)
+                 + SUM(CASE WHEN s.Kind = 'actual' THEN s.ActualAmount + s.ProjectedAmount ELSE 0 END)
+                       OVER (PARTITION BY s.ExpenditureCategory)
+                 - SUM(s.ActualAmount + s.ProjectedAmount)
+                       OVER (PARTITION BY s.ExpenditureCategory ORDER BY s.MonthStart ROWS UNBOUNDED PRECEDING)
+                 AS DECIMAL(18,2)) AS Remaining
+        FROM #spend s
+        LEFT JOIN #budget b ON b.ExpenditureCategory = s.ExpenditureCategory
+        ORDER BY s.ExpenditureCategory, s.MonthStart;
+
+        SET @RowCount = @@ROWCOUNT;
+        SET @Duration_MS = DATEDIFF(MILLISECOND, @StartTime, SYSDATETIME());
+
+        EXEC [dbo].[usp_LogProcedureExecution]
+            @ProcedureName = 'dbo.usp_GetProjectProjection',
+            @Duration_MS = @Duration_MS,
+            @RowCount = @RowCount,
+            @Parameters = @ParametersJSON,
+            @ApplicationName = @ApplicationName,
+            @ApplicationUser = @ApplicationUser,
+            @EmulatingUser = @EmulatingUser,
+            @Success = 1;
+    END TRY
+    BEGIN CATCH
+        SET @Duration_MS = DATEDIFF(MILLISECOND, @StartTime, SYSDATETIME());
+        SET @ErrorMsg = ERROR_MESSAGE();
+
+        EXEC [dbo].[usp_LogProcedureExecution]
+            @ProcedureName = 'dbo.usp_GetProjectProjection',
+            @Duration_MS = @Duration_MS,
+            @Parameters = @ParametersJSON,
+            @ApplicationName = @ApplicationName,
+            @ApplicationUser = @ApplicationUser,
+            @EmulatingUser = @EmulatingUser,
+            @Success = 0,
+            @ErrorMessage = @ErrorMsg;
+
+        THROW;
+    END CATCH
+END;
+GO

--- a/datamart/StoredProcedures/usp_SwapStagingTable.sql
+++ b/datamart/StoredProcedures/usp_SwapStagingTable.sql
@@ -25,6 +25,7 @@ BEGIN
 
     INSERT INTO @AllowedTables ([TableName])
     VALUES
+        (N'GlProjectMonthlyActuals'),
         (N'People'),
         (N'PpmAwards'),
         (N'PpmPeople'),

--- a/datamart/Tables/ExpenditureTypeByAccount.sql
+++ b/datamart/Tables/ExpenditureTypeByAccount.sql
@@ -1,0 +1,13 @@
+-- Crosswalk from GL natural account to its expenditure category.
+-- Used to bucket GL transactions (and the projections feature) into the fixed set of
+-- expenditure categories (e.g. '01 - Salaries and Wages', '02 - Fringe Benefits', ...).
+-- GL aggregation runs in Redshift via OPENQUERY by natural account; this local table maps
+-- ACCOUNT -> ExpenditureCategory after the OPENQUERY, so it is not joined inside Redshift.
+create table dbo.ExpenditureTypeByAccount
+(
+    NaturalAccount      nvarchar(6)   not null,
+    ExpenditureCategory nvarchar(200) not null,
+    constraint PK_ExpenditureTypeByAccount
+        primary key (NaturalAccount)
+)
+go

--- a/datamart/Tables/GlProjectMonthlyActuals.sql
+++ b/datamart/Tables/GlProjectMonthlyActuals.sql
@@ -1,0 +1,18 @@
+-- Local landing table for GL actuals summarized by project, GL period, and natural account,
+-- with the account's top-level rollup. Populated by the AE_DWH copy job from the Redshift
+-- transactional_listing_report (all accounts; the period string is landed as-is). Replaces the
+-- live OPENQUERY used by the projection logic. Consumed by usp_GetProjectProjection, which
+-- filters to expense (ParentLevel0Code '5%'), maps natural account to expenditure category via
+-- dbo.ExpenditureTypeByAccount, and matches PeriodName to the calendar months it projects over.
+create table dbo.GlProjectMonthlyActuals
+(
+    ProjectId        nvarchar(15)   not null,
+    PeriodName       nvarchar(15)   not null,  -- GL period as landed, e.g. 'Mar-26'
+    NaturalAccount   nvarchar(10)   not null,
+    ParentLevel0Code nvarchar(15),             -- erp_account parent rollup; expense accounts are '5%'
+    ActualAmount     decimal(18, 2) not null,
+    LoadedAt         datetime2(3)   not null,
+    constraint PK_GlProjectMonthlyActuals
+        primary key (ProjectId, PeriodName, NaturalAccount)
+)
+go

--- a/datamart/Tables/Staging/GlProjectMonthlyActuals_Staging.sql
+++ b/datamart/Tables/Staging/GlProjectMonthlyActuals_Staging.sql
@@ -1,0 +1,15 @@
+-- Staging table for dbo.GlProjectMonthlyActuals. The AE_DWH copy job fully loads this table,
+-- then dbo.usp_SwapStagingTable snapshot-swaps it into the final table in one transaction so
+-- readers never see a partially loaded GL set. Columns and nullability must match the final
+-- table exactly (the swap's schema-compatibility check enforces this); the PK is intentionally
+-- omitted.
+create table dbo.GlProjectMonthlyActuals_Staging
+(
+    ProjectId        nvarchar(15)   not null,
+    PeriodName       nvarchar(15)   not null,
+    NaturalAccount   nvarchar(10)   not null,
+    ParentLevel0Code nvarchar(15),
+    ActualAmount     decimal(18, 2) not null,
+    LoadedAt         datetime2(3)   not null
+)
+go


### PR DESCRIPTION
## What

Adds the datamart objects for the **project projection / budget burndown** feature: a per-expenditure-category monthly burndown for a single project, computed entirely from local tables.

`usp_GetProjectProjection` returns two result sets — a per-category budget header and a period × category grid (3 trailing actual months, a blended current month, and 12 projected months) with actual spend, projected spend, and the running budget remaining.

## Objects

- **`usp_GetProjectProjection`** — projection/burndown sproc. Personnel from `PositionBudgets` + `CompositeBenefitRates` (`MonthlyRate × Fte × DistributionPercent`, fringe via CBR); non-personnel from a 3-month average; current month prorated; burndown anchored on `FacultyDeptPortfolio.PpmBudBal` per category. Filters expense via `ParentLevel0Code LIKE '5%'`.
- **`GlProjectMonthlyActuals`** (+ `_Staging`) — local landing table for GL actuals by project / GL period / natural account, with the account's parent-level rollup. Loaded by the AE_DWH copy job and snapshot-swapped via `usp_SwapStagingTable` (zero-downtime), replacing the live OPENQUERY hop.
- **`ExpenditureTypeByAccount`** — natural-account → expenditure-category crosswalk.
- **`usp_SwapStagingTable`** — allowlisted `GlProjectMonthlyActuals` for the swap.
- **PostDeployment** — `WalterAppRole` execute/select grants and `WalterPipelineRole` DML grants on the GL final + staging tables.

## Pipeline contract

Copy job loads `GlProjectMonthlyActuals_Staging` from Bronze (period string and `parent_level_0_code` landed as-is), then a Script activity runs `EXEC dbo.usp_SwapStagingTable @TableName = 'GlProjectMonthlyActuals'`.

## Notes / follow-ups

- DACPAC build not validated locally (a Microsoft.Build.Sql vs .NET SDK 10 toolchain mismatch) — relying on CI for the authoritative build.
- `ExpenditureTypeByAccount` rows exist in WalterDev only; Test/Prod need the crosswalk seeded.
- Frontend wiring is separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Project budget projections now available with monthly category-level analysis, actual spend, commitments, and remaining balance tracking
  * GL project actuals data infrastructure enables comprehensive expenditure tracking and financial reporting
  * Expenditure category mapping provides consistent GL account classifications

<!-- end of auto-generated comment: release notes by coderabbit.ai -->