### PR TITLE
Flag GL/PPM discrepancy alerts per chart string, not per project

### DIFF
--- a/web/client/src/queries/project.ts
+++ b/web/client/src/queries/project.ts
@@ -233,18 +233,12 @@ export function useProjectDiscrepancyState(projectCodes: string[]) {
       return new Set<string>();
     }
 
-    // Sum glActualAmount + ppmBudBal per project,
+    // Flag a project if any chart string row is out of balance,
     // matching the per-row formula on the reconciliation page.
-    const byProject = new Map<string, number>();
-    for (const r of data) {
-      const diff = r.glActualAmount + r.ppmBudBal;
-      byProject.set(r.project, (byProject.get(r.project) ?? 0) + diff);
-    }
-
     const result = new Set<string>();
-    for (const [project, total] of byProject) {
-      if (Math.abs(total) > 0.005) {
-        result.add(project);
+    for (const r of data) {
+      if (Math.abs(r.glActualAmount + r.ppmBudBal) > 0.005) {
+        result.add(r.project);
       }
     }
     return result;


### PR DESCRIPTION
## Problem

A department reported that project **FPAPLS1819** shows a GL/PPM discrepancy on the AD-419 GL/PPM Reconciliation report and the AE report, but no alert appears on the Walter project details page.

Gwen identified the cause: the project has no **net** out-of-balance, but individual chart strings are out of balance in offsetting directions.

## Cause

The alert hook (`useProjectDiscrepancyState`) summed `glActualAmount + ppmBudBal` across all chart strings before applying the $0.005 threshold, so offsetting imbalances canceled out and suppressed the alert. The reconciliation report applies the same threshold **per row**, so it correctly flagged the chart strings.

## Fix

Flag a project when **any single chart string row** exceeds the threshold — the exact check the reconciliation page uses (`hasDiscrepancy` in `reports/reconciliation/$projectNumber/index.tsx`). Both screens read the same `usp_GetGLPPMReconciliation` data, so the alert now fires if and only if the report would highlight at least one row.

Note: this makes the alert strictly more sensitive — projects whose discrepancies previously netted to ~zero will now show the warning.

## Testing

- `tsc -b && vite build` passes
- All 187 client tests pass
- To verify manually: https://walter.ucdavis.edu/projects/10210693/FPAPLS1819 should show the discrepancy alert once deployed (the reconciliation report at /reports/reconciliation/FPAPLS1819 already shows the out-of-balance rows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GL/PPM reconciliation discrepancy detection to identify inconsistencies at a more granular level, enabling earlier flagging of project issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->