### PR TITLE
vacation clean up

### DIFF
--- a/web/client/src/components/accrual/VacationAccrualAbout.tsx
+++ b/web/client/src/components/accrual/VacationAccrualAbout.tsx
@@ -2,7 +2,9 @@ import {
   ArrowLongLeftIcon,
   CalculatorIcon,
   ChartBarIcon,
+  CheckCircleIcon,
   InformationCircleIcon,
+  ScaleIcon,
 } from '@heroicons/react/24/outline';
 import { Link } from '@tanstack/react-router';
 import { type AccrualAssumptionsResponse } from '@/queries/accrual.ts';
@@ -30,23 +32,43 @@ function AssumptionsTable({
   title: string;
 }) {
   return (
-    <section className="card bg-base-100 border border-main-border shadow-sm">
-      <div className="card-body gap-4">
-        <h2 className="card-title">{title}</h2>
-        <div className="overflow-x-auto">
-          <table className="table table-zebra">
-            <tbody>
-              {rows.map((row) => (
-                <tr key={row.label}>
-                  <th className="font-semibold">{row.label}</th>
-                  <td>{row.value}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
+    <section>
+      <h2 className="h2">{title}</h2>
+      <div className="fancy-data">
+        <table className="table walter-table walter-subtable">
+          <tbody>
+            {rows.map((row) => (
+              <tr key={row.label}>
+                <th className="w-1/2 font-semibold">{row.label}</th>
+                <td>{row.value}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
       </div>
     </section>
+  );
+}
+
+function ReportNote({
+  children,
+  Icon,
+  iconClassName,
+  title,
+}: {
+  children: string;
+  Icon: typeof CalculatorIcon;
+  iconClassName: string;
+  title: string;
+}) {
+  return (
+    <div className="flex min-w-0 gap-3">
+      <Icon className={`mt-1 h-5 w-5 shrink-0 ${iconClassName}`} />
+      <div>
+        <h3 className="stat-label-lg">{title}</h3>
+        <p className="mt-1 text-sm text-base-content/70">{children}</p>
+      </div>
+    </div>
   );
 }
 
@@ -76,104 +98,109 @@ export function VacationAccrualAbout({
     label: row.label,
     value: `${compactPercentFormatter.format(row.rate * 100)}% composite benefits load`,
   }));
+  const backLink = departmentCode ? (
+    <Link
+      className="mb-3 inline-flex items-center gap-2 text-sm font-bold text-primary no-underline"
+      params={{ departmentCode }}
+      to="/accruals/department/$departmentCode"
+    >
+      <ArrowLongLeftIcon className="h-4 w-4" />
+      Back to Department
+    </Link>
+  ) : (
+    <Link
+      className="mb-3 inline-flex items-center gap-2 text-sm font-bold text-primary no-underline"
+      to="/accruals/overview"
+    >
+      <ArrowLongLeftIcon className="h-4 w-4" />
+      Back to Overview
+    </Link>
+  );
 
   return (
     <main className="mt-8">
       <div className="container">
-        <div className="mx-auto space-y-8">
-          <section className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
-            <div className="space-y-3">
-              <div className="space-y-2">
-                <h1 className="h1">About This Vacation Accrual Report</h1>
-                <p className="max-w-3xl text-lg text-base-content/70">
-                  This page summarizes the current assumptions behind the
-                  vacation accrual overview, with a focus on how estimated lost
-                  cost is calculated for employees who are near or at their
-                  accrual cap.
-                </p>
+        <section className="section-margin">
+          {backLink}
+          <div className="space-y-2">
+            <h1 className="h1">About This Report</h1>
+            <h3 className="subtitle">
+              Vacation accrual assumptions and cost model
+            </h3>
+          </div>
+
+          <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
+            <ReportNote
+              Icon={CalculatorIcon}
+              iconClassName="text-primary"
+              title="Cost Model"
+            >
+              monthly accrual hours x hourly rate x (1 + benefits load)
+            </ReportNote>
+            <ReportNote
+              Icon={ScaleIcon}
+              iconClassName="text-error"
+              title="At Cap Threshold"
+            >
+              {`${percentFormatter.format(data.atCapThresholdPct)}% and above is treated as at cap.`}
+            </ReportNote>
+            <ReportNote
+              Icon={InformationCircleIcon}
+              iconClassName="text-info"
+              title="Scope"
+            >
+              These assumptions make the report directionally useful; they do
+              not replace detailed payroll accounting.
+            </ReportNote>
+          </div>
+        </section>
+
+        <section className="section-margin">
+          <div className="mb-4">
+            <h2 className="h2">Lost Cost Formula</h2>
+            <p className="mt-1">
+              Lost cost per employee is estimated only when the employee is
+              classified as at cap.
+            </p>
+          </div>
+
+          <div className="grid gap-6 grid-cols-1">
+            <div>
+              <div className="rounded bg-base-100 px-4 py-3 font-mono text-sm md:text-base">
+                monthly accrual hours x hourly rate x (1 + benefits load)
               </div>
+              <p className="mt-4 text-sm text-base-content/70">
+                The report treats this as an estimated unrecoverable accrual
+                cost for the latest month-end snapshot. It is a planning
+                estimate, not a payroll posting.
+              </p>
             </div>
 
-            {departmentCode ? (
-              <Link
-                className="btn btn-outline"
-                params={{ departmentCode }}
-                to="/accruals/department/$departmentCode"
-              >
-                <ArrowLongLeftIcon className="h-4 w-4" />
-                Back to Department
-              </Link>
-            ) : (
-              <Link className="btn btn-outline" to="/accruals/overview">
-                <ArrowLongLeftIcon className="h-4 w-4" />
-                Back to Overview
-              </Link>
-            )}
-          </section>
-
-          <section className="grid gap-4 lg:grid-cols-3">
-            <section className="card bg-base-100 border border-main-border shadow-sm lg:col-span-2">
-              <div className="card-body gap-4">
-                <div className="flex items-center gap-2 text-sm font-semibold tracking-[0.14em] uppercase text-base-content/60">
-                  <CalculatorIcon className="h-5 w-5 text-primary" />
-                  <span>Lost Cost Formula</span>
-                </div>
-                <p className="text-base-content/75">
-                  Lost cost per employee is estimated only when the employee is
-                  classified as at cap.
-                </p>
-                <div className="rounded-box bg-base-200/60 px-5 py-4 font-mono text-sm md:text-base">
-                  monthly accrual hours × hourly rate × (1 + benefits load)
-                </div>
-                <p className="text-sm text-base-content/70">
-                  The report treats this as an estimated unrecoverable accrual
-                  cost for the latest month-end snapshot. It is a planning
-                  estimate, not a payroll posting.
-                </p>
+            <div className="space-y-3 text-sm text-base-content/75">
+              <div className="flex gap-2">
+                <CheckCircleIcon className="mt-0.5 h-4 w-4 shrink-0 text-success" />
+                <span>
+                  Monthly accrual hours come from the latest positive accrual
+                  history when available.
+                </span>
               </div>
-            </section>
-
-            <section className="card bg-base-100 border border-main-border shadow-sm">
-              <div className="card-body gap-4">
-                <div className="flex items-center gap-2 text-sm font-semibold tracking-[0.14em] uppercase text-base-content/60">
-                  <InformationCircleIcon className="h-5 w-5 text-info" />
-                  <span>Scope</span>
-                </div>
-                <p className="text-sm text-base-content/75">
-                  Current assumptions apply to the accrual report only. They are
-                  intended to make the report understandable and directionally
-                  useful, not to replace detailed payroll accounting.
-                </p>
+              <div className="flex gap-2">
+                <ChartBarIcon className="mt-0.5 h-4 w-4 shrink-0 text-accent" />
+                <span>
+                  Waste rate is lost cost divided by estimated monthly accrual
+                  charges.
+                </span>
               </div>
-            </section>
-          </section>
+            </div>
+          </div>
+        </section>
 
-          <section className="grid gap-4 xl:grid-cols-2">
+        <section className="section-margin">
+          <div className="grid gap-8 xl:grid-cols-2">
             <AssumptionsTable rows={thresholdRows} title="Status Thresholds" />
             <AssumptionsTable rows={benefitsRows} title="Benefits Loads" />
-          </section>
-
-          <section>
-            <section className="card bg-base-100 border border-main-border shadow-sm">
-              <div className="card-body gap-4">
-                <div className="flex items-center gap-2 text-sm font-semibold tracking-[0.14em] uppercase text-base-content/60">
-                  <ChartBarIcon className="h-5 w-5 text-accent" />
-                  <span>Other Notes</span>
-                </div>
-                <p className="text-sm text-base-content/75">
-                  Monthly accrual hours come from the latest positive accrual
-                  history when available. The department detail shows the
-                  employee-level accrual and cap values that drive the report.
-                </p>
-                <p className="text-sm text-base-content/75">
-                  Waste rate on the overview is shown as lost cost divided by
-                  estimated monthly accrual charges. Because lost cost includes
-                  benefits load, that percentage can exceed 100% in some cases.
-                </p>
-              </div>
-            </section>
-          </section>
-        </div>
+          </div>
+        </section>
       </div>
     </main>
   );

--- a/web/client/src/components/accrual/VacationAccrualAbout.tsx
+++ b/web/client/src/components/accrual/VacationAccrualAbout.tsx
@@ -80,14 +80,11 @@ export function VacationAccrualAbout({
   return (
     <main className="mt-8">
       <div className="container">
-        <div className="mx-auto max-w-6xl space-y-8">
+        <div className="mx-auto space-y-8">
           <section className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
             <div className="space-y-3">
-              <div className="badge badge-outline badge-primary">
-                Vacation Accruals
-              </div>
               <div className="space-y-2">
-                <h1 className="h1">About This Report</h1>
+                <h1 className="h1">About This Vacation Accrual Reports</h1>
                 <p className="max-w-3xl text-lg text-base-content/70">
                   This page summarizes the current assumptions behind the
                   vacation accrual overview, with a focus on how estimated lost

--- a/web/client/src/components/accrual/VacationAccrualAbout.tsx
+++ b/web/client/src/components/accrual/VacationAccrualAbout.tsx
@@ -84,7 +84,7 @@ export function VacationAccrualAbout({
           <section className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
             <div className="space-y-3">
               <div className="space-y-2">
-                <h1 className="h1">About This Vacation Accrual Reports</h1>
+                <h1 className="h1">About This Vacation Accrual Report</h1>
                 <p className="max-w-3xl text-lg text-base-content/70">
                   This page summarizes the current assumptions behind the
                   vacation accrual overview, with a focus on how estimated lost

--- a/web/client/src/components/accrual/VacationAccrualDepartmentDetail.tsx
+++ b/web/client/src/components/accrual/VacationAccrualDepartmentDetail.tsx
@@ -682,7 +682,6 @@ export function VacationAccrualDepartmentDetail({
               columns={employeeColumns}
               data={filteredEmployees}
               defaultColumnSize={140}
-              expandable={false}
               footerRowClassName="totaltr bg-base-200/70"
               getRowProps={(row) => {
                 const status = getEmployeeStatus(

--- a/web/client/src/components/accrual/VacationAccrualDepartmentDetail.tsx
+++ b/web/client/src/components/accrual/VacationAccrualDepartmentDetail.tsx
@@ -539,7 +539,7 @@ export function VacationAccrualDepartmentDetail({
   return (
     <main className="mt-8">
       <div className="container">
-        <div className="mx-auto max-w-7xl">
+        <div className="mx-auto">
           <section className="section-margin">
             <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
               <div className="min-w-0">

--- a/web/client/src/components/accrual/VacationAccrualDepartmentSelector.tsx
+++ b/web/client/src/components/accrual/VacationAccrualDepartmentSelector.tsx
@@ -90,13 +90,6 @@ export function VacationAccrualDepartmentSelector({
 
   const departments = sortDepartments(data.departmentBreakdown);
   const departmentRows: DepartmentSelectorRow[] = [
-    {
-      department: 'View All',
-      departmentCode: '',
-      employees: data.totalEmployees,
-      kind: 'overview',
-      subtitle: 'All departments overview',
-    },
     ...departments.map((department) => ({
       department: department.department,
       departmentCode: department.departmentCode,
@@ -104,12 +97,19 @@ export function VacationAccrualDepartmentSelector({
       kind: 'department' as const,
       subtitle: department.departmentCode,
     })),
+    {
+      department: 'View All',
+      departmentCode: '',
+      employees: data.totalEmployees,
+      kind: 'overview',
+      subtitle: 'All departments overview',
+    },
   ];
 
   return (
     <main className="mt-8">
       <div className="container">
-        <div className="mx-auto max-w-5xl">
+        <div className="mx-auto">
           <section className="section-margin">
             <div className="space-y-2">
               <h1 className="h1">Vacation accruals</h1>
@@ -125,7 +125,11 @@ export function VacationAccrualDepartmentSelector({
                 defaultColumnSize={220}
                 filterPlaceholder="Search departments..."
                 globalFilter="left"
-                initialState={{ pagination: { pageSize: 25 } }}
+                initialState={{
+                  pagination: {
+                    pageSize: departmentRows.length,
+                  },
+                }}
                 tableClassName="table-cardgrid"
               />
             </div>

--- a/web/client/src/components/accrual/VacationAccrualDepartmentSelector.tsx
+++ b/web/client/src/components/accrual/VacationAccrualDepartmentSelector.tsx
@@ -48,7 +48,7 @@ const departmentColumns: ColumnDef<DepartmentSelectorRow>[] = [
       const content = (
         <span className="flex min-h-28 flex-col justify-between gap-4">
           <span className="space-y-1">
-            <span className="block text-sm text-base-content/60">
+            <span className="block text-sm text-base-content/70">
               {row.subtitle}
             </span>
             <span className="block font-proxima-bold text-lg leading-tight">

--- a/web/client/src/components/accrual/VacationAccrualDepartmentSelector.tsx
+++ b/web/client/src/components/accrual/VacationAccrualDepartmentSelector.tsx
@@ -1,17 +1,22 @@
-import {
-  ArrowRightIcon,
-  BuildingOffice2Icon,
-  Squares2X2Icon,
-} from '@heroicons/react/24/outline';
 import { Link } from '@tanstack/react-router';
+import { type ColumnDef } from '@tanstack/react-table';
 import { PageEmpty } from '@/components/states/PageEmpty.tsx';
 import {
   type AccrualDepartmentBreakdownRow,
   type AccrualOverviewResponse,
 } from '@/queries/accrual.ts';
+import { DataTable } from '@/shared/DataTable.tsx';
 
 interface VacationAccrualDepartmentSelectorProps {
   data: AccrualOverviewResponse;
+}
+
+interface DepartmentSelectorRow {
+  department: string;
+  departmentCode: string;
+  employees: number;
+  kind: 'department' | 'overview';
+  subtitle: string;
 }
 
 function sortDepartments(
@@ -31,6 +36,49 @@ function sortDepartments(
   });
 }
 
+const departmentColumns: ColumnDef<DepartmentSelectorRow>[] = [
+  {
+    accessorFn: (row) =>
+      `${row.department} ${row.departmentCode} ${row.employees}`,
+    cell: (info) => {
+      const row = info.row.original;
+      const employeeLabel = `${row.employees.toLocaleString('en-US')} employee${
+        row.employees === 1 ? '' : 's'
+      }`;
+      const content = (
+        <span className="flex min-h-28 flex-col justify-between gap-4">
+          <span className="space-y-1">
+            <span className="block text-sm text-base-content/60">
+              {row.subtitle}
+            </span>
+            <span className="block font-proxima-bold text-lg leading-tight">
+              {row.department}
+            </span>
+          </span>
+          <span className="block text-sm font-semibold text-base-content/75">
+            {employeeLabel}
+          </span>
+        </span>
+      );
+
+      if (row.kind === 'overview') {
+        return <Link to="/accruals/overview">{content}</Link>;
+      }
+
+      return (
+        <Link
+          params={{ departmentCode: row.departmentCode }}
+          to="/accruals/department/$departmentCode"
+        >
+          {content}
+        </Link>
+      );
+    },
+    header: 'Department',
+    id: 'department',
+  },
+];
+
 export function VacationAccrualDepartmentSelector({
   data,
 }: VacationAccrualDepartmentSelectorProps) {
@@ -41,6 +89,22 @@ export function VacationAccrualDepartmentSelector({
   }
 
   const departments = sortDepartments(data.departmentBreakdown);
+  const departmentRows: DepartmentSelectorRow[] = [
+    {
+      department: 'View All',
+      departmentCode: '',
+      employees: data.totalEmployees,
+      kind: 'overview',
+      subtitle: 'All departments overview',
+    },
+    ...departments.map((department) => ({
+      department: department.department,
+      departmentCode: department.departmentCode,
+      employees: department.headcount,
+      kind: 'department' as const,
+      subtitle: department.departmentCode,
+    })),
+  ];
 
   return (
     <main className="mt-8">
@@ -48,61 +112,22 @@ export function VacationAccrualDepartmentSelector({
         <div className="mx-auto max-w-5xl">
           <section className="section-margin">
             <div className="space-y-2">
-              <div className="badge badge-outline badge-primary">
-                Vacation Accruals
-              </div>
-              <h1 className="h1">Select a Department</h1>
+              <h1 className="h1">Vacation accruals</h1>
               <p className="max-w-3xl text-lg text-base-content/70">
                 Choose a department to open its vacation accrual detail.
               </p>
             </div>
 
-            <div className="mt-8 overflow-hidden rounded-md border border-main-border bg-base-100">
-              <div className="divide-y divide-main-border">
-                {departments.map((department) => (
-                  <Link
-                    className="group flex min-h-16 items-center gap-4 px-4 py-3 text-base-content no-underline transition-colors hover:bg-base-200 focus:outline-none focus-visible:bg-base-200"
-                    key={department.departmentCode}
-                    params={{ departmentCode: department.departmentCode }}
-                    to="/accruals/department/$departmentCode"
-                  >
-                    <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded bg-primary/10 text-primary">
-                      <BuildingOffice2Icon className="h-5 w-5" />
-                    </span>
-                    <span className="min-w-0 flex-1">
-                      <span className="block truncate font-proxima-bold text-lg">
-                        {department.department}
-                      </span>
-                      <span className="text-sm text-base-content/60">
-                        Department {department.departmentCode}
-                      </span>
-                    </span>
-                    <span className="hidden text-sm text-base-content/60 sm:block">
-                      {department.headcount.toLocaleString('en-US')}{' '}
-                      employees
-                    </span>
-                    <ArrowRightIcon className="h-5 w-5 shrink-0 text-base-content/45 transition-transform group-hover:translate-x-1" />
-                  </Link>
-                ))}
-
-                <Link
-                  className="group flex min-h-16 items-center gap-4 bg-base-200/70 px-4 py-3 text-base-content no-underline transition-colors hover:bg-base-300 focus:outline-none focus-visible:bg-base-300"
-                  to="/accruals/overview"
-                >
-                  <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded bg-secondary/20 text-base-content">
-                    <Squares2X2Icon className="h-5 w-5" />
-                  </span>
-                  <span className="min-w-0 flex-1">
-                    <span className="block font-proxima-bold text-lg">
-                      All departments overview
-                    </span>
-                    <span className="text-sm text-base-content/60">
-                      Open the college-wide accrual summary
-                    </span>
-                  </span>
-                  <ArrowRightIcon className="h-5 w-5 shrink-0 text-base-content/45 transition-transform group-hover:translate-x-1" />
-                </Link>
-              </div>
+            <div className="mt-8">
+              <DataTable
+                columns={departmentColumns}
+                data={departmentRows}
+                defaultColumnSize={220}
+                filterPlaceholder="Search departments..."
+                globalFilter="left"
+                initialState={{ pagination: { pageSize: 25 } }}
+                tableClassName="table-cardgrid"
+              />
             </div>
           </section>
         </div>

--- a/web/client/src/components/alerts/PiProjectAlerts.tsx
+++ b/web/client/src/components/alerts/PiProjectAlerts.tsx
@@ -32,8 +32,7 @@ export function usePiProjectAlerts(
 
   const firstError = projectsQueries.find((q) => q.isError);
   const allLoaded = projectsQueries.every((q) => q.isSuccess);
-  const isLoading =
-    navigablePis.length > 0 && !allLoaded && !firstError;
+  const isLoading = navigablePis.length > 0 && !allLoaded && !firstError;
 
   let alerts: PiProjectAlert[] = [];
   if (allLoaded && navigablePis.length > 0) {
@@ -91,9 +90,7 @@ export function PiProjectAlerts({
   if (isError) {
     return (
       <div className="alert alert-error mt-8">
-        <span>
-          Unable to load alerts: {error?.message ?? 'Unknown error'}
-        </span>
+        <span>Unable to load alerts: {error?.message ?? 'Unknown error'}</span>
       </div>
     );
   }
@@ -109,13 +106,11 @@ export function PiProjectAlerts({
   }
 
   if (alerts.length === 0) {
-    return <p className="mt-4 text-base-content/60">No alerts</p>;
+    return <p className="mt-4 text-base-content/70">No alerts</p>;
   }
 
   const iamIdByEmployeeId = new Map(
-    managedPis
-      .filter((pi) => pi.iamId)
-      .map((pi) => [pi.employeeId, pi.iamId!])
+    managedPis.filter((pi) => pi.iamId).map((pi) => [pi.employeeId, pi.iamId!])
   );
 
   return (

--- a/web/client/src/components/project/RecentActivity.tsx
+++ b/web/client/src/components/project/RecentActivity.tsx
@@ -80,7 +80,7 @@ function Card({
           <div className="grid grid-cols-2 gap-2 pt-2">
             {model.footer.map((f) => (
               <div key={f.label}>
-                <div className="text-xs font-semibold text-base-content/60">
+                <div className="text-xs font-semibold text-base-content/70">
                   {f.label}
                 </div>
                 <div className="text-sm font-semibold">{f.value}</div>

--- a/web/client/src/main.css
+++ b/web/client/src/main.css
@@ -56,7 +56,7 @@
   @apply text-2xl font-proxima-bold;
 }
 .h3 {
-  @apply text-base font-proxima-bold uppercase text-base-content/60;
+  @apply text-base font-proxima-bold uppercase text-base-content/70;
 }
 .stat-value {
   @apply text-lg font-medium;
@@ -71,7 +71,7 @@
   @apply font-proxima-bold text-lg;
 }
 .subtitle {
-  @apply text-lg font-proxima-bold uppercase text-base-content/60;
+  @apply text-lg font-proxima-bold uppercase text-base-content/70;
 }
 .section-margin {
   @apply mb-20;
@@ -96,7 +96,7 @@
     @apply mt-4 mb-8 px-6 py-4 border rounded-md bg-light-bg-200 border-main-border;
   }
   .nav-link {
-    @apply border-b-2 border-base-200 transition text-base-content/60 hover:text-base-content;
+    @apply border-b-2 border-base-200 transition text-base-content/70 hover:text-base-content;
   }
 
   .nav-link[data-status='active'] {
@@ -129,7 +129,7 @@
   }
 
   [cmdk-group-heading] {
-    @apply px-2 py-2 text-xs uppercase text-base-content/60;
+    @apply px-2 py-2 text-xs uppercase text-base-content/70;
   }
 
   [cmdk-item] {

--- a/web/client/src/routes/(authenticated)/admin/users.tsx
+++ b/web/client/src/routes/(authenticated)/admin/users.tsx
@@ -43,7 +43,10 @@ function RouteComponent() {
     query: debouncedQuery,
   });
 
-  const searchResults = useMemo(() => searchQuery.data ?? [], [searchQuery.data]);
+  const searchResults = useMemo(
+    () => searchQuery.data ?? [],
+    [searchQuery.data]
+  );
   const selectedUser = useMemo(
     () => searchResults.find((u) => u.id === selectedUserId) ?? null,
     [searchResults, selectedUserId]
@@ -61,11 +64,11 @@ function RouteComponent() {
           ['admin', 'users', selectedUserId, 'roles'],
           (old: UserRolesResponse | undefined) => ({
             ...old,
-            name: data.user.name,
             email: data.user.email,
             employeeId: data.user.employeeId,
-            kerberos: data.user.kerberos,
             iamId: data.user.iamId,
+            kerberos: data.user.kerberos,
+            name: data.user.name,
             roles: data.user.roles,
           })
         );
@@ -194,7 +197,7 @@ function RouteComponent() {
                           <div className="min-w-0">
                             <div className="truncate">{label}</div>
                             {secondary ? (
-                              <div className="truncate text-xs text-base-content/60">
+                              <div className="truncate text-xs text-base-content/70">
                                 {secondary}
                               </div>
                             ) : null}
@@ -270,7 +273,7 @@ function RouteComponent() {
                     </span>
                   </div>
                 ) : currentRoles.length === 0 ? (
-                  <div className="text-sm text-base-content/60">
+                  <div className="text-sm text-base-content/70">
                     No roles assigned.
                   </div>
                 ) : (

--- a/web/client/src/routes/(authenticated)/index.tsx
+++ b/web/client/src/routes/(authenticated)/index.tsx
@@ -38,8 +38,7 @@ function RouteComponent() {
 
   const userProjectsQuery = useQuery({
     ...projectsDetailQueryOptions(user.iamId),
-    enabled:
-      Boolean(user.iamId) && !isPending && !isError && !isProjectManager,
+    enabled: Boolean(user.iamId) && !isPending && !isError && !isProjectManager,
   });
 
   const isPrincipalInvestigator =
@@ -248,7 +247,7 @@ function RouteComponent() {
               </div>
             )}
             {isPrincipalInvestigator && piAlerts.length === 0 && (
-              <p className="mt-4 text-base-content/60">No alerts</p>
+              <p className="mt-4 text-base-content/70">No alerts</p>
             )}
           </div>
         )}

--- a/web/client/src/routes/(authenticated)/personnel.tsx
+++ b/web/client/src/routes/(authenticated)/personnel.tsx
@@ -71,7 +71,7 @@ function RouteComponent() {
   return (
     <div className="container">
       <h1 className="h1 mt-8">{user.name}&apos;s Personnel</h1>
-      <h3 className="subtitle mb-4">
+      <h3 className="subtitle mb-1">
         {uniqueEmployees} employees across {uniqueProjects} projects
       </h3>
       <p className="max-w-prose mb-4 text-sm text-base-content/70">

--- a/web/client/src/test/routes/(authenticated)/accrual-overview.test.tsx
+++ b/web/client/src/test/routes/(authenticated)/accrual-overview.test.tsx
@@ -47,7 +47,7 @@ const mockAccrualAssumptions = {
 };
 
 describe('vacation accrual overview route', () => {
-  it('renders the department selector with departments alphabetized and the overview option last', async () => {
+  it('renders the department selector cards with View All first and departments alphabetized', async () => {
     server.use(
       http.get('/api/user/me', () => HttpResponse.json(mockUser)),
       http.get('/api/accrual/overview', () =>
@@ -95,7 +95,7 @@ describe('vacation accrual overview route', () => {
       expect(await screen.findByText('View All')).toBeInTheDocument();
 
       const selector = screen
-        .getByRole('heading', { name: 'Select a Department' })
+        .getByRole('heading', { name: 'Vacation accruals' })
         .closest('section');
       expect(selector).not.toBeNull();
 

--- a/web/client/src/test/routes/(authenticated)/accrual-overview.test.tsx
+++ b/web/client/src/test/routes/(authenticated)/accrual-overview.test.tsx
@@ -575,6 +575,14 @@ describe('vacation accrual overview route', () => {
         await screen.findByText('Saichaie,Amanda M')
       ).toBeInTheDocument();
 
+      await user.click(screen.getByRole('button', { name: /expand table/i }));
+      expect(screen.getByTestId('datatable-backdrop')).toBeInTheDocument();
+
+      await user.click(screen.getByRole('button', { name: /collapse table/i }));
+      expect(
+        screen.getByRole('button', { name: /expand table/i })
+      ).toBeInTheDocument();
+
       const employeeSearch = screen.getByPlaceholderText('Search by name or ID...');
       await user.type(employeeSearch, 'Amanda');
 

--- a/web/client/src/test/routes/(authenticated)/accrual-overview.test.tsx
+++ b/web/client/src/test/routes/(authenticated)/accrual-overview.test.tsx
@@ -92,9 +92,7 @@ describe('vacation accrual overview route', () => {
     const { cleanup } = renderRoute({ initialPath: '/accruals' });
 
     try {
-      expect(
-        await screen.findByRole('heading', { name: 'Select a Department' })
-      ).toBeInTheDocument();
+      expect(await screen.findByText('View All')).toBeInTheDocument();
 
       const selector = screen
         .getByRole('heading', { name: 'Select a Department' })
@@ -103,13 +101,18 @@ describe('vacation accrual overview route', () => {
 
       const links = within(selector!).getAllByRole('link');
       expect(links.map((link) => link.textContent)).toEqual([
+        expect.stringContaining('View All'),
         expect.stringContaining('NUTRITION'),
         expect.stringContaining('PLANT SCIENCES'),
-        expect.stringContaining('All departments overview'),
       ]);
-      expect(links[0]).toHaveAttribute('href', '/accruals/department/030090');
-      expect(links[1]).toHaveAttribute('href', '/accruals/department/030003');
-      expect(links[2]).toHaveAttribute('href', '/accruals/overview');
+      expect(links[0]).toHaveTextContent('33 employees');
+      expect(links[1]).toHaveTextContent('12 employees');
+      expect(links[2]).toHaveTextContent('21 employees');
+      expect(links[1]).toHaveTextContent('030090');
+      expect(links[1]).not.toHaveTextContent('Department 030090');
+      expect(links[0]).toHaveAttribute('href', '/accruals/overview');
+      expect(links[1]).toHaveAttribute('href', '/accruals/department/030090');
+      expect(links[2]).toHaveAttribute('href', '/accruals/department/030003');
     } finally {
       cleanup();
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Reworked vacation accrual selector into a pageable data table with a leading "View All", alphabetized departments, and clear per-department employee counts; department and overview links updated.
  * Restructured accrual page header (subtitle, new report-note blocks, simplified assumptions layout) and redesigned formula area for clarity.
  * Normalized muted text styling and adjusted spacing across dashboard, personnel, and activity cards.
  * Department detail now allows row expansion by default.

* **Tests**
  * Updated UI tests to match new selector ordering, "View All" behavior, link targets, and table expand/collapse interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->