### PR TITLE
Drop orphaned objects on Test/Prod DACPAC publish

### DIFF
--- a/datamart/azure-pipelines.datamart.yml
+++ b/datamart/azure-pipelines.datamart.yml
@@ -124,7 +124,9 @@ stages:
               & $sqlPackage /Action:Publish `
                 /SourceFile:$dacpac `
                 /TargetConnectionString:$connectionString `
-                /p:IncludeCompositeObjects=true
+                /p:IncludeCompositeObjects=true `
+                /p:DropObjectsNotInSource=true `
+                /p:DoNotDropObjectTypes="Users;Logins;RoleMembership;Permissions"
 
               if ($LASTEXITCODE -ne 0) {
                 Write-Error "Deployment failed"
@@ -167,7 +169,9 @@ stages:
                 /SourceFile:$dacpac `
                 /TargetConnectionString:$connectionString `
                 /OutputPath:$outputScript `
-                /p:IncludeCompositeObjects=true
+                /p:IncludeCompositeObjects=true `
+                /p:DropObjectsNotInSource=true `
+                /p:DoNotDropObjectTypes="Users;Logins;RoleMembership;Permissions"
 
               if ($LASTEXITCODE -ne 0) {
                 Write-Error "Script generation failed"
@@ -219,7 +223,9 @@ stages:
                     & $sqlPackage /Action:Publish `
                       /SourceFile:$dacpac `
                       /TargetConnectionString:$connectionString `
-                      /p:IncludeCompositeObjects=true
+                      /p:IncludeCompositeObjects=true `
+                      /p:DropObjectsNotInSource=true `
+                      /p:DoNotDropObjectTypes="Users;Logins;RoleMembership;Permissions"
 
                     if ($LASTEXITCODE -ne 0) {
                       Write-Error "Production deployment failed"


### PR DESCRIPTION
## Summary

Enables automatic cleanup of retired schema objects on the **Test** and **Prod** DACPAC deploys, so things like the `TransactionalListing` remnants from #293 don't linger in the target databases. **Dev is intentionally left additive** — it's a playground that holds out-of-source scratch objects.

## What changed

`datamart/azure-pipelines.datamart.yml` — added to the `DeployTest`, `ReviewProd`, and `DeployProd` SqlPackage invocations:

```
/p:DropObjectsNotInSource=true
/p:DoNotDropObjectTypes="Users;Logins;RoleMembership;Permissions"
```

- **`DropObjectsNotInSource=true`** → objects deleted from source are dropped from the target (no more stale cruft).
- **`DoNotDropObjectTypes=...`** → shields database principals that are managed **outside** source control. Without this, the bare flag emits `DROP USER` for `walter_adf` (ADF ETL), the deploy login, and the app/pipeline users — breaking ETL, app access, and the deploy itself. Roles (`WalterAppRole`/`WalterPipelineRole`) are in source and unaffected.
- **`BlockOnPossibleDataLoss`** left at its default (`true`): a drop of a data-bearing table halts the deploy until acknowledged.
- **DeployDev unchanged** (plain additive publish).


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced database deployment process configuration to improve control over object management during updates while maintaining security protections for critical database elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->