### PR TITLE
Default LastUpdated/LoadDate on EmployeeAccrualBalances

### DIFF
--- a/datamart/Tables/EmployeeAccrualBalances.sql
+++ b/datamart/Tables/EmployeeAccrualBalances.sql
@@ -41,8 +41,10 @@ create table dbo.EmployeeAccrualBalances
     Level4DeptDesc             nvarchar(100),
     Level5Dept                 nvarchar(10),
     Level5DeptDesc             nvarchar(100),
-    LoadDate                   datetime2(3),
-    LastUpdated                datetime2(3) not null,
+    LoadDate                   datetime2(3)
+        constraint DF_EmployeeAccrualBalances_LoadDate default sysutcdatetime(),
+    LastUpdated                datetime2(3) not null
+        constraint DF_EmployeeAccrualBalances_LastUpdated default sysutcdatetime(),
     constraint PK_EmployeeAccrualBalances
         primary key (EmployeeId, AsOfDate, PositionNumber)
 )


### PR DESCRIPTION
## Problem

The `RefreshEmployeeAccrualBalances` ADF pipeline failed on the SQL sink with:

> Cannot insert the value NULL into column 'LastUpdated', table 'WalterDev.dbo.EmployeeAccrualBalances'; column does not allow nulls.

The Copy activity uses ADF's auto-mapping (no explicit column list in the `TabularTranslator`), and the source sproc `usp_GetEmployeeAccrualBalances` doesn't return `LastUpdated` or `LoadDate`. So the upsert MERGE omits those columns. `LastUpdated` is `NOT NULL` with no default, so the insert blew up.

## Fix

Add `DEFAULT SYSUTCDATETIME()` to both `LastUpdated` and `LoadDate` so the DB stamps the load time when ADF omits the columns. `LastUpdated` stays `NOT NULL`.

A trigger was considered but rejected: the `NOT NULL` check fires before an `AFTER INSERT` trigger, so it wouldn't help without an `INSTEAD OF` trigger — heavier and more surprising than a default.

## Deploy note

For the existing table, the constraints can be applied directly:

```sql
ALTER TABLE dbo.EmployeeAccrualBalances
ADD CONSTRAINT DF_EmployeeAccrualBalances_LastUpdated DEFAULT SYSUTCDATETIME() FOR LastUpdated;

ALTER TABLE dbo.EmployeeAccrualBalances
ADD CONSTRAINT DF_EmployeeAccrualBalances_LoadDate DEFAULT SYSUTCDATETIME() FOR LoadDate;
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced database record management by implementing automatic UTC timestamp recording for employee accrual balance entries, ensuring consistent data tracking across the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->