### PR TITLE
[codex] Fix TRS notification URL

### DIFF
--- a/web/server.core/Views/Emails/AccrualEmployeeNotification_mjml.cshtml
+++ b/web/server.core/Views/Emails/AccrualEmployeeNotification_mjml.cshtml
@@ -14,7 +14,7 @@
     var lostCostYear = AccrualEmailTemplateFormatting.Currency(payload.LostCostMonth * 12m);
     var capStatus = isAtCap ? "at maximum" : "near maximum";
     const string aggieServiceUrl = "https://aggieservice.ucdavis.edu";
-    const string trsUrl = "https://trs.ucdavis.edu/timesheet";
+    const string trsUrl = "https://trs.ucdavis.edu/";
 }
 
 <mj-section padding="34px 34px 16px 34px">

--- a/web/server.core/Views/Emails/AccrualEmployeeNotification_text.cshtml
+++ b/web/server.core/Views/Emails/AccrualEmployeeNotification_text.cshtml
@@ -12,7 +12,7 @@
     var lostCostYear = AccrualEmailTemplateFormatting.Currency(payload.LostCostMonth * 12m);
     var capStatus = isAtCap ? "at maximum" : "near maximum";
     const string aggieServiceUrl = "https://aggieservice.ucdavis.edu";
-    const string trsUrl = "https://trs.ucdavis.edu/timesheet";
+    const string trsUrl = "https://trs.ucdavis.edu/";
 }
 Dear @Html.Raw(Model.GreetingName),
 

--- a/web/tests/server.tests/Services/AccrualOutboundMessageRendererTests.cs
+++ b/web/tests/server.tests/Services/AccrualOutboundMessageRendererTests.cs
@@ -51,7 +51,7 @@ public sealed class AccrualOutboundMessageRendererTests
         rendered.TextBody.Should().Contain("Hours to Take");
         rendered.TextBody.Should().Contain("$500");
         rendered.TextBody.Should().Contain("Open TRS Time Reporting");
-        rendered.TextBody.Should().Contain("https://trs.ucdavis.edu/timesheet");
+        rendered.TextBody.Should().Contain("https://trs.ucdavis.edu/");
         rendered.TextBody.Should().Contain("of 240 hrs");
         rendered.HtmlBody.Should().Contain("Walter");
         rendered.HtmlBody.Should().Contain("Dear Staff Member,");
@@ -59,7 +59,7 @@ public sealed class AccrualOutboundMessageRendererTests
         rendered.HtmlBody.Should().Contain("Hours to Take");
         rendered.HtmlBody.Should().Contain("$500");
         rendered.HtmlBody.Should().Contain("Open TRS Time Reporting");
-        rendered.HtmlBody.Should().Contain("https://trs.ucdavis.edu/timesheet");
+        rendered.HtmlBody.Should().Contain("https://trs.ucdavis.edu/");
         rendered.HtmlBody.Should().Contain("of 240 hrs");
         rendered.HtmlBody.Should().NotContain("<mjml");
     }


### PR DESCRIPTION
## Summary
- Replace the TRS notification link from `https://trs.ucdavis.edu/timesheet` to `https://trs.ucdavis.edu/` in both text and MJML email templates.
- Update the accrual outbound message renderer test expectations for the corrected URL.

## Validation
- `rg -n "https://trs\.ucdavis\.edu/timesheet|trs\.ucdavis\.edu/timesheet" .` returns no matches.
- `git diff --check` passes.
- `dotnet test web/tests/server.tests/server.tests.csproj --filter AccrualOutboundMessageRendererTests` could not run because `dotnet` is not installed in this environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated the TRS Time Reporting link in employee notification emails to direct to the correct base URL, ensuring users can properly access the Time Reporting System.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->