### PR TITLE
GL PPM Alerts only for internal

### DIFF
--- a/web/client/src/components/alerts/ProjectAlerts.tsx
+++ b/web/client/src/components/alerts/ProjectAlerts.tsx
@@ -93,8 +93,9 @@ export function ProjectAlerts({
   summary,
 }: ProjectAlertsProps) {
   const alerts = getAlertsForProject(summary, prefix);
+  const showReconciliationStatus = summary.isInternal;
 
-  if (reconciliationStatus === 'discrepancy') {
+  if (showReconciliationStatus && reconciliationStatus === 'discrepancy') {
     alerts.push({
       id: `reconciliation-issue-${summary.projectNumber}`,
       message: `${prefix ?? 'This project '}has a GL/PPM reconciliation discrepancy. Click here to view details.`,
@@ -103,7 +104,7 @@ export function ProjectAlerts({
     });
   }
 
-  if (reconciliationStatus === 'balanced') {
+  if (showReconciliationStatus && reconciliationStatus === 'balanced') {
     alerts.push({
       id: `reconciliation-balanced-${summary.projectNumber}`,
       message: `${prefix ?? ''}GL/PPM is Balanced. Click here to view.`,

--- a/web/client/src/routes/(authenticated)/projects/$iamId/$projectNumber/index.tsx
+++ b/web/client/src/routes/(authenticated)/projects/$iamId/$projectNumber/index.tsx
@@ -58,7 +58,7 @@ function ProjectContent({
     user.employeeId
   );
   const reconciliationState = useProjectDiscrepancyState(
-    canSeeDiscrepancy ? [summary.projectNumber] : []
+    summary.isInternal && canSeeDiscrepancy ? [summary.projectNumber] : []
   );
   const reconciliationStatus = reconciliationState.hasData
     ? reconciliationState.discrepancies.has(summary.projectNumber)

--- a/web/client/src/test/routes/(authenticated)/project-detail.test.tsx
+++ b/web/client/src/test/routes/(authenticated)/project-detail.test.tsx
@@ -308,53 +308,108 @@ describe('project detail page', () => {
       );
     };
 
-    it.each(['Internal', 'Sponsored'] as const)(
-      'shows balanced reconciliation alert for authorized project managers on %s project details',
-      async (projectType) => {
-        const projectNumber = `P-${projectType}`;
-        const projects = [
-          createProject({
-            pmEmployeeId: '1000',
-            projectNumber,
-            projectType,
-          }),
-        ];
-        setupDetailHandlers({
-          projects,
-          reconciliation: [],
-          user: {
-            employeeId: '1000',
-            name: 'PM User',
-            roles: [],
-          },
-        });
+    it('shows balanced reconciliation alert for authorized project managers on internal project details', async () => {
+      const projectNumber = 'P-Internal';
+      const projects = [
+        createProject({
+          pmEmployeeId: '1000',
+          projectNumber,
+          projectType: 'Internal',
+        }),
+      ];
+      setupDetailHandlers({
+        projects,
+        reconciliation: [],
+        user: {
+          employeeId: '1000',
+          name: 'PM User',
+          roles: [],
+        },
+      });
 
-        const { cleanup } = renderRoute({
-          initialPath: `/projects/1000/${projectNumber}`,
-        });
+      const { cleanup } = renderRoute({
+        initialPath: `/projects/1000/${projectNumber}`,
+      });
 
-        try {
-          expect(
-            await screen.findByText('Project Number', {}, { timeout: 3000 })
-          ).toBeInTheDocument();
+      try {
+        expect(
+          await screen.findByText('Project Number', {}, { timeout: 3000 })
+        ).toBeInTheDocument();
 
-          const message = await screen.findByText(
-            'GL/PPM is Balanced. Click here to view.',
-            {},
-            { timeout: 3000 }
-          );
-          const alert = message.closest('[role="alert"]');
+        const message = await screen.findByText(
+          'GL/PPM is Balanced. Click here to view.',
+          {},
+          { timeout: 3000 }
+        );
+        const alert = message.closest('[role="alert"]');
 
-          expect(alert).toHaveClass('alert-success');
-          expect(message.closest('a')).toHaveAttribute(
-            'href',
-            `/reports/reconciliation/${projectNumber}`
-          );
-        } finally {
-          cleanup();
-        }
+        expect(alert).toHaveClass('alert-success');
+        expect(message.closest('a')).toHaveAttribute(
+          'href',
+          `/reports/reconciliation/${projectNumber}`
+        );
+      } finally {
+        cleanup();
       }
-    );
+    });
+
+    it('hides balanced reconciliation alert on sponsored project details', async () => {
+      const projects = [
+        createProject({
+          pmEmployeeId: '1000',
+          projectType: 'Sponsored',
+        }),
+      ];
+      setupDetailHandlers({
+        projects,
+        reconciliation: [],
+        user: {
+          employeeId: '1000',
+          name: 'PM User',
+          roles: [],
+        },
+      });
+
+      const { cleanup } = renderRoute({ initialPath: '/projects/1000/P1' });
+
+      try {
+        await screen.findByText('Project Number');
+        expect(
+          screen.queryByText('GL/PPM is Balanced. Click here to view.')
+        ).not.toBeInTheDocument();
+      } finally {
+        cleanup();
+      }
+    });
+
+    it('hides discrepancy reconciliation alert on sponsored project details', async () => {
+      const projects = [
+        createProject({
+          pmEmployeeId: '1000',
+          projectType: 'Sponsored',
+        }),
+      ];
+      setupDetailHandlers({
+        projects,
+        reconciliation: discrepantReconciliation,
+        user: {
+          employeeId: '1000',
+          name: 'PM User',
+          roles: [],
+        },
+      });
+
+      const { cleanup } = renderRoute({ initialPath: '/projects/1000/P1' });
+
+      try {
+        await screen.findByText('Project Number');
+        expect(
+          screen.queryByText(/has a gl\/ppm reconciliation discrepancy/i)
+        ).not.toBeInTheDocument();
+      } finally {
+        cleanup();
+      }
+    });
 
     it('hides reconciliation alert for PI viewing own internal project', async () => {
       const projects = [
@@ -379,6 +434,5 @@ describe('project detail page', () => {
         cleanup();
       }
     });
-
   });
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reconciliation discrepancy and balanced status alerts now only display for internal projects, preventing them from appearing on sponsored projects.

* **Tests**
  * Refactored reconciliation alert tests to verify proper gating by project type and user permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->