### PR TITLE
Disable accrual viewer report emails

### DIFF
--- a/web/server.core/Services/AccrualNotificationGenerator.cs
+++ b/web/server.core/Services/AccrualNotificationGenerator.cs
@@ -44,6 +44,8 @@ public enum AccrualNotificationGenerationStatus
 
 public sealed class AccrualNotificationGenerator : IAccrualNotificationGenerator
 {
+    private const bool GenerateViewerReportEmails = false;
+
     private readonly IAccrualReportDataSource _accrualReportDataSource;
     private readonly IAccrualViewerRecipientProvider _viewerRecipientProvider;
     private readonly AccrualNotificationMessageBuilder _messageBuilder;
@@ -105,10 +107,14 @@ public sealed class AccrualNotificationGenerator : IAccrualNotificationGenerator
         }
 
         var employeeCandidates = AccrualOverviewCalculator.BuildNotificationCandidates(records);
-        var viewerRecipients = await _viewerRecipientProvider.GetActiveAccrualViewersAsync(cancellationToken);
+        IReadOnlyList<AccrualViewerRecipient> viewerRecipients = GenerateViewerReportEmails
+            ? await _viewerRecipientProvider.GetActiveAccrualViewersAsync(cancellationToken)
+            : [];
 
         var employeeBuild = _messageBuilder.BuildEmployeeMessages(runId, employeeCandidates, nowUtc);
-        var viewerBuild = _messageBuilder.BuildViewerReportMessages(runId, overview, viewerRecipients, nowUtc);
+        var viewerBuild = GenerateViewerReportEmails
+            ? _messageBuilder.BuildViewerReportMessages(runId, overview, viewerRecipients, nowUtc)
+            : new AccrualMessageBuildResult([], []);
         var drafts = employeeBuild.Messages
             .Concat(viewerBuild.Messages)
             .ToList();

--- a/web/tests/server.tests/Services/AccrualNotificationGeneratorTests.cs
+++ b/web/tests/server.tests/Services/AccrualNotificationGeneratorTests.cs
@@ -8,7 +8,7 @@ namespace server.tests.Services;
 public sealed class AccrualNotificationGeneratorTests
 {
     [Fact]
-    public async Task GenerateMonthlyAsync_builds_and_enqueues_employee_and_viewer_messages()
+    public async Task GenerateMonthlyAsync_builds_and_enqueues_employee_messages()
     {
         var now = new DateTime(2026, 5, 7, 20, 0, 0, DateTimeKind.Utc);
         var runId = Guid.NewGuid();
@@ -54,27 +54,25 @@ public sealed class AccrualNotificationGeneratorTests
         result.RunId.Should().Be(runId);
         result.SnapshotAsOfDate.Should().Be(new DateTime(2026, 4, 30));
         result.EmployeeCandidateCount.Should().Be(2);
-        result.ViewerRecipientCount.Should().Be(2);
-        result.DraftCount.Should().Be(2);
-        result.SkippedCount.Should().Be(2);
-        result.EnqueuedCount.Should().Be(2);
+        result.ViewerRecipientCount.Should().Be(0);
+        result.DraftCount.Should().Be(1);
+        result.SkippedCount.Should().Be(1);
+        result.EnqueuedCount.Should().Be(1);
         result.DuplicateCount.Should().Be(0);
 
         queue.EnqueueCalled.Should().BeTrue();
         queue.NowUtc.Should().Be(now);
-        queue.Messages.Should().HaveCount(2);
+        queue.Messages.Should().ContainSingle();
         queue.Messages.Should().Contain(message =>
             message.RunId == runId &&
             message.NotificationType == AccrualNotificationMessageBuilder.EmployeeNotificationType &&
             message.RecipientType == OutboundMessage.RecipientTypes.Employee &&
             message.DedupeKey == "accrual:employee:E001:2026-04-30");
-        queue.Messages.Should().Contain(message =>
-            message.RunId == runId &&
-            message.NotificationType == AccrualNotificationMessageBuilder.ViewerReportNotificationType &&
-            message.RecipientType == OutboundMessage.RecipientTypes.AccrualViewer &&
-            message.DedupeKey == $"accrual:viewer-report:{viewerId}:2026-04-30");
+        queue.Messages.Should().NotContain(message =>
+            message.NotificationType == AccrualNotificationMessageBuilder.ViewerReportNotificationType);
+        viewerProvider.CallCount.Should().Be(0);
         result.Skipped.Select(skip => skip.RecipientType).Should().BeEquivalentTo(
-            [OutboundMessage.RecipientTypes.Employee, OutboundMessage.RecipientTypes.AccrualViewer]);
+            [OutboundMessage.RecipientTypes.Employee]);
     }
 
     [Fact]
@@ -102,10 +100,11 @@ public sealed class AccrualNotificationGeneratorTests
             new AccrualNotificationGenerationOptions { DryRun = true });
 
         result.Status.Should().Be(AccrualNotificationGenerationStatus.DryRun);
-        result.DraftCount.Should().Be(2);
+        result.DraftCount.Should().Be(1);
         result.EnqueuedCount.Should().Be(0);
         result.DuplicateCount.Should().Be(0);
         queue.EnqueueCalled.Should().BeFalse();
+        viewerProvider.CallCount.Should().Be(0);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Stop generating accrual viewer report emails behind a hard-coded off switch
- Keep employee accrual notifications enabled
- Update unit tests to reflect the employee-only path and confirm viewer recipients are not queried

## Testing
- Updated unit tests for monthly generation and dry-run behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Viewer-report notifications for accruals are now conditionally generated based on system settings, allowing more granular control over notification delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->