### PR TITLE
Add cache headers for static assets and SPA fallback

### DIFF
--- a/web/server/Program.cs
+++ b/web/server/Program.cs
@@ -119,8 +119,41 @@ using (var scope = app.Services.CreateScope())
 
 app.UseForwardedHeaders();
 
+app.Use(async (context, next) =>
+{
+    context.Response.OnStarting(() =>
+    {
+        if (context.Response.StatusCode == StatusCodes.Status404NotFound &&
+            IsAssetRequest(context.Request.Path))
+        {
+            ApplyNoStoreHeaders(context);
+        }
+
+        return Task.CompletedTask;
+    });
+
+    await next();
+});
+
+var staticFileOptions = new StaticFileOptions
+{
+    OnPrepareResponse = context =>
+    {
+        if (string.Equals(context.File.Name, "index.html", StringComparison.OrdinalIgnoreCase))
+        {
+            ApplyNoStoreHeaders(context.Context);
+            return;
+        }
+
+        if (IsAssetRequest(context.Context.Request.Path))
+        {
+            context.Context.Response.Headers.CacheControl = "public,max-age=31536000,immutable";
+        }
+    }
+};
+
 app.UseDefaultFiles();
-app.UseStaticFiles();
+app.UseStaticFiles(staticFileOptions);
 
 app.UseResponseCaching();
 
@@ -159,6 +192,21 @@ healthEndpoint.WithMetadata(new ResponseCacheAttribute
 });
 
 
-app.MapFallbackToFile("/index.html");
+app.MapFallbackToFile("/index.html", staticFileOptions);
 
 app.Run();
+
+static bool IsAssetRequest(PathString path)
+{
+    var value = path.Value;
+    return value is not null &&
+           (string.Equals(value, "/assets", StringComparison.OrdinalIgnoreCase) ||
+            value.StartsWith("/assets/", StringComparison.OrdinalIgnoreCase));
+}
+
+static void ApplyNoStoreHeaders(HttpContext context)
+{
+    context.Response.Headers.CacheControl = "no-store,max-age=0";
+    context.Response.Headers.Pragma = "no-cache";
+    context.Response.Headers.Expires = "0";
+}


### PR DESCRIPTION
## Summary
- Set long-lived immutable caching for `/assets` responses.
- Apply `no-store` headers to `index.html` and 404s for asset paths to avoid stale client caching.
- Reuse the same static file response behavior for the SPA fallback route.

## Testing
- Not run (not requested).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced static asset caching strategy for improved performance. Static resources are now cached long-term, while HTML pages remain uncached to ensure users always receive the latest version. 404 responses for asset requests are handled with appropriate cache directives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->