### PR TITLE
Add OpenTelemetry to notifications worker

### DIFF
--- a/web/workers/notifications/Program.cs
+++ b/web/workers/notifications/Program.cs
@@ -160,5 +160,11 @@ static string ResolveServiceVersion()
         return informationalVersion;
     }
 
-    return FileVersionInfo.GetVersionInfo(assembly.Location).ProductVersion ?? "unknown";
+    var assemblyLocation = assembly.Location;
+    if (string.IsNullOrEmpty(assemblyLocation))
+    {
+        return assembly.GetName().Version?.ToString() ?? "unknown";
+    }
+
+    return FileVersionInfo.GetVersionInfo(assemblyLocation).ProductVersion ?? "unknown";
 }

--- a/web/workers/notifications/Program.cs
+++ b/web/workers/notifications/Program.cs
@@ -1,16 +1,36 @@
 using Mjml.Net;
+using Microsoft.Azure.Functions.Worker.OpenTelemetry;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using OpenTelemetry;
+using OpenTelemetry.Logs;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
 using Razor.Templating.Core;
 using server.core.Data;
 using server.core.Services;
+using System.Diagnostics;
+using System.Reflection;
 using Walter.Workers.Notifications;
 
 var host = new HostBuilder()
     .ConfigureFunctionsWorkerDefaults()
+    .ConfigureLogging(logging =>
+    {
+        logging.AddOpenTelemetry(logOptions =>
+        {
+            logOptions.IncludeFormattedMessage = true;
+            logOptions.IncludeScopes = true;
+            logOptions.ParseStateValues = true;
+            logOptions.SetResourceBuilder(BuildResourceBuilder());
+            logOptions.AddOtlpExporter();
+        });
+    })
     .ConfigureAppConfiguration((context, config) =>
     {
         config
@@ -27,6 +47,27 @@ var host = new HostBuilder()
         {
             throw new InvalidOperationException("No database connection string configured. Set DB_CONNECTION.");
         }
+
+        var sampler = context.HostingEnvironment.IsDevelopment()
+            ? new ParentBasedSampler(new AlwaysOnSampler())
+            : new ParentBasedSampler(new TraceIdRatioBasedSampler(0.2));
+
+        services.AddOpenTelemetry()
+            .ConfigureResource(resource => resource.AddService(
+                serviceName: "walter-notifications",
+                serviceVersion: ResolveServiceVersion()))
+            .UseFunctionsWorkerDefaults()
+            .WithTracing(tracing => tracing
+                .SetSampler(sampler)
+                .AddHttpClientInstrumentation()
+                .AddSqlClientInstrumentation(options =>
+                {
+                    options.RecordException = true;
+                }))
+            .WithMetrics(metrics => metrics
+                .AddHttpClientInstrumentation()
+                .AddSqlClientInstrumentation())
+            .UseOtlpExporter();
 
         services.Configure<NotificationWorkerOptions>(
             context.Configuration.GetSection(NotificationWorkerOptions.SectionName));
@@ -98,3 +139,26 @@ var host = new HostBuilder()
     .Build();
 
 await host.RunAsync();
+
+static ResourceBuilder BuildResourceBuilder()
+{
+    return ResourceBuilder.CreateDefault()
+        .AddService(
+            serviceName: "walter-notifications",
+            serviceVersion: ResolveServiceVersion());
+}
+
+static string ResolveServiceVersion()
+{
+    var assembly = Assembly.GetExecutingAssembly();
+    var informationalVersion = assembly
+        .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+        ?.InformationalVersion;
+
+    if (!string.IsNullOrWhiteSpace(informationalVersion))
+    {
+        return informationalVersion;
+    }
+
+    return FileVersionInfo.GetVersionInfo(assembly.Location).ProductVersion ?? "unknown";
+}

--- a/web/workers/notifications/README.md
+++ b/web/workers/notifications/README.md
@@ -62,6 +62,11 @@ Required now:
 - `NOTIFICATIONS_ACCRUAL_GENERATION_SCHEDULE`: NCRONTAB schedule for monthly accrual generation.
 - `Notifications__SenderEnabled`: must be `true` before sender processing will run.
 - `Notifications__AccrualGenerationEnabled`: must be `true` before monthly accrual generation will run.
+- `OTEL_EXPORTER_OTLP_ENDPOINT`: OTLP endpoint used for worker and Functions host telemetry.
+- `OTEL_EXPORTER_OTLP_HEADERS`: OTLP authentication headers.
+- `OTEL_EXPORTER_OTLP_PROTOCOL`: OTLP protocol, typically `grpc`.
+- `OTEL_SERVICE_NAME`: stable service name for the Function App, typically `walter-notifications`.
+- `OTEL_RESOURCE_ATTRIBUTES`: additional resource attributes, for example `deployment.environment=test`.
 
 Optional:
 

--- a/web/workers/notifications/host.json
+++ b/web/workers/notifications/host.json
@@ -1,9 +1,16 @@
 {
   "version": "2.0",
+  "telemetryMode": "OpenTelemetry",
   "logging": {
     "logLevel": {
       "Default": "Information",
       "Microsoft": "Warning"
+    },
+    "OpenTelemetry": {
+      "logLevel": {
+        "Default": "Information",
+        "Microsoft": "Warning"
+      }
     }
   }
 }

--- a/web/workers/notifications/notifications.csproj
+++ b/web/workers/notifications/notifications.csproj
@@ -11,8 +11,13 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.0.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.3.1" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.OpenTelemetry" Version="1.2.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.0" OutputItemType="Analyzer" PrivateAssets="all" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.21" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.16.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.16.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.15.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- enable Azure Functions host OpenTelemetry mode for the notifications worker
- add OTEL log, trace, and metric export from the isolated worker
- document required Function App OTEL settings

## Testing
- /usr/local/share/dotnet/dotnet build web/workers/notifications/notifications.csproj --configuration Release

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled OpenTelemetry for distributed tracing, metrics, and structured logging, with OTLP export and environment-based trace sampling.

* **Documentation**
  * Updated the worker README to document required OpenTelemetry environment variables (including OTLP endpoint, headers, protocol, service name, and resource attributes).

* **Configuration**
  * Set telemetry mode to OpenTelemetry and added corresponding OpenTelemetry logging settings to align with existing log level configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->