### PR TITLE
GlSummaryBalances: nightly AE GL summary balances from CAES Datamart

### DIFF
--- a/datamart/StoredProcedures/usp_SwapStagingTable.sql
+++ b/datamart/StoredProcedures/usp_SwapStagingTable.sql
@@ -26,6 +26,7 @@ BEGIN
     INSERT INTO @AllowedTables ([TableName])
     VALUES
         (N'GlProjectMonthlyActuals'),
+        (N'GlSummaryBalances'),
         (N'People'),
         (N'PpmAwards'),
         (N'PpmPeople'),

--- a/datamart/Tables/GlSummaryBalances.sql
+++ b/datamart/Tables/GlSummaryBalances.sql
@@ -1,0 +1,46 @@
+-- Nightly snapshot of AE GL summary balances at the full chart-string grain
+-- (latest snapshot per accounting period; zero-balance rows suppressed at the
+-- source). Sourced from the scheduled "UCD GL Summary Balances" report email,
+-- landed in the CAES Datamart (Fabric), and loaded here by
+-- pl_gl_balances_loader via GlSummaryBalances_Staging + usp_SwapStagingTable
+-- (full replace). Supersedes the GlSegmentMonthlyActuals design from the
+-- college/dept financial summaries work: same fact space, but balance-report
+-- measures (assets/liabilities/beginning balance/revenue/expenses/other
+-- changes/ending balance) instead of sign-normalized income/expense, and the
+-- leaf financial department only (join the Erp*Hierarchy tables for rollups).
+create table dbo.GlSummaryBalances
+(
+    PeriodName      varchar(10)    not null,  -- GL period as landed, e.g. 'Jul-26'
+    Entity          varchar(20)    not null,
+    EntityDesc      nvarchar(1000) not null,
+    Fund            varchar(20)    not null,
+    FundDesc        nvarchar(1000) not null,
+    Dept            varchar(20)    not null,
+    DeptDesc        nvarchar(1000) not null,
+    Account         varchar(20)    not null,
+    AccountDesc     nvarchar(1000) not null,
+    Purpose         varchar(20)    not null,
+    PurposeDesc     nvarchar(1000) not null,
+    Program         varchar(20)    not null,
+    ProgramDesc     nvarchar(1000) not null,
+    Project         varchar(20)    not null,
+    ProjectDesc     nvarchar(1000) not null,
+    Activity        varchar(20)    not null,
+    ActivityDesc    nvarchar(1000) not null,
+    InterEnt        varchar(20)    not null,
+    InterEntDesc    nvarchar(1000) not null,
+    AssetAmt        decimal(18, 2) not null,
+    LiabAmt         decimal(18, 2) not null,
+    OwnersEquityAmt decimal(18, 2) not null,
+    RevenueAmt      decimal(18, 2) not null,
+    ExpenseAmt      decimal(18, 2) not null,
+    RevEightAmt     decimal(18, 2) not null,
+    EndBalWEight    decimal(18, 2) not null,
+    EndBal          decimal(18, 2) not null,
+    LoadedAt        datetime2(3)   not null
+)
+go
+
+create clustered index IX_GlSummaryBalances_PeriodDeptAccount
+    on dbo.GlSummaryBalances (PeriodName, Dept, Account)
+go

--- a/datamart/Tables/Staging/GlSummaryBalances_Staging.sql
+++ b/datamart/Tables/Staging/GlSummaryBalances_Staging.sql
@@ -1,0 +1,36 @@
+-- Staging twin of dbo.GlSummaryBalances. Fully reloaded by
+-- pl_gl_balances_loader each night, then swapped in via usp_SwapStagingTable.
+-- Column definitions MUST stay identical to dbo.GlSummaryBalances or the
+-- swap proc's schema check (error 51002) will reject the swap.
+create table dbo.GlSummaryBalances_Staging
+(
+    PeriodName      varchar(10)    not null,
+    Entity          varchar(20)    not null,
+    EntityDesc      nvarchar(1000) not null,
+    Fund            varchar(20)    not null,
+    FundDesc        nvarchar(1000) not null,
+    Dept            varchar(20)    not null,
+    DeptDesc        nvarchar(1000) not null,
+    Account         varchar(20)    not null,
+    AccountDesc     nvarchar(1000) not null,
+    Purpose         varchar(20)    not null,
+    PurposeDesc     nvarchar(1000) not null,
+    Program         varchar(20)    not null,
+    ProgramDesc     nvarchar(1000) not null,
+    Project         varchar(20)    not null,
+    ProjectDesc     nvarchar(1000) not null,
+    Activity        varchar(20)    not null,
+    ActivityDesc    nvarchar(1000) not null,
+    InterEnt        varchar(20)    not null,
+    InterEntDesc    nvarchar(1000) not null,
+    AssetAmt        decimal(18, 2) not null,
+    LiabAmt         decimal(18, 2) not null,
+    OwnersEquityAmt decimal(18, 2) not null,
+    RevenueAmt      decimal(18, 2) not null,
+    ExpenseAmt      decimal(18, 2) not null,
+    RevEightAmt     decimal(18, 2) not null,
+    EndBalWEight    decimal(18, 2) not null,
+    EndBal          decimal(18, 2) not null,
+    LoadedAt        datetime2(3)   not null
+)
+go


### PR DESCRIPTION
## Summary

Adds `dbo.GlSummaryBalances` (+ staging twin) and registers it in
`usp_SwapStagingTable`'s allowlist, for a new nightly ETL feed from the
CAES Datamart (Fabric).

- **`GlSummaryBalances`**: a nightly snapshot of AE GL summary balances at
  the full chart-string grain (Entity/Fund/Dept/Account/Purpose/Program/
  Project/Activity/InterEnt), latest snapshot per accounting period,
  zero-balance rows suppressed at the source. Sourced from the scheduled
  "UCD GL Summary Balances" report email, landed in the CAES Datamart, and
  loaded here by the Datamart's `pl_gl_balances_loader` via
  `GlSummaryBalances_Staging` + `usp_SwapStagingTable` (full replace).
- **`GlSummaryBalances_Staging`**: identical column list, no index — the
  swap proc's schema-compatibility check compares `sys.columns` exactly
  and hard-fails (error 51002) on any drift, so the two tables must stay
  in lockstep.
- **`usp_SwapStagingTable`**: added `GlSummaryBalances` to the
  `@AllowedTables` allowlist (alphabetical position after
  `GlProjectMonthlyActuals`). No other change to that proc.

## Heads-up for `college-dept-financial-summaries`

This table **supersedes** that branch's (unmerged, main-only-adjacent)
`GlSegmentMonthlyActuals` design — same fact space, but:

- Balance-report measures (assets / liabilities / owners' equity /
  revenue / expense / rev-eight / ending-balance-with-eight / ending
  balance) instead of sign-normalized income/expense.
- Leaf financial department only — for hierarchy rollups, join the
  `Erp*Hierarchy` tables rather than expecting pre-rolled-up segments.

`GlSegmentMonthlyActuals` doesn't exist on `main`, so there's nothing to
drop here; that branch will need to adapt its consumer
(`usp_GetGlSegmentSummary`) to this table's shape when it lands.

## Test plan

- [x] New table/staging DDL follows the house style in
      `datamart/Tables/GlProjectMonthlyActuals.sql` (lowercase `create
      table`, block comment header, `varchar` codes / `nvarchar`
      descriptions, `datetime2(3)` `LoadedAt`).
- [x] Staging and final column lists verified identical (schema-check
      compatibility with `usp_SwapStagingTable`).
- [ ] `dotnet build walter.sqlproj` — not verified locally due to a local
      SDK environment issue (`NuGet.Build.Tasks.Pack.targets` missing for
      the installed dotnet 10.0.101 SDK), unrelated to this change; CI
      will build on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for storing nightly GL summary balances in a new table, including detailed chart-string dimensions and balance amounts.
  * Added a matching staging table for nightly reloads and swap-based publishing.
  * Enabled the new balance table in the staging swap process.

* **Performance**
  * Added an index to improve lookups by period, department, and account.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->