### PR TITLE
Fix SQL injection via project IDs in usp_ParseProjectIdFilter

### DIFF
--- a/datamart/StoredProcedures/usp_ParseProjectIdFilter.sql
+++ b/datamart/StoredProcedures/usp_ParseProjectIdFilter.sql
@@ -5,40 +5,33 @@ AS
 BEGIN
     SET NOCOUNT ON;
 
-    DECLARE @ProjectId VARCHAR(15);
-    DECLARE @ValidatedProjects TABLE (ProjectId VARCHAR(15));
+    -- Parse comma-separated list into table, filtering out empty strings and literal 'null' values.
+    -- Stage at full width so an over-length element is rejected by the format check below rather
+    -- than being silently truncated into a valid-looking id.
+    DECLARE @Projects TABLE (ProjectId VARCHAR(4000));
 
-    -- Parse comma-separated list into table, filtering out empty strings and literal 'null' values
-    INSERT INTO @ValidatedProjects (ProjectId)
+    INSERT INTO @Projects (ProjectId)
     SELECT TRIM(value)
     FROM STRING_SPLIT(@ProjectIds, ',')
     WHERE TRIM(value) <> '' AND LOWER(TRIM(value)) <> 'null';
 
     -- Validate that at least one project ID was provided
-    IF NOT EXISTS (SELECT 1 FROM @ValidatedProjects)
-    BEGIN
-        RAISERROR('No valid project IDs provided', 16, 1);
-        RETURN;
-    END;
+    IF NOT EXISTS (SELECT 1 FROM @Projects)
+        THROW 50000, 'No valid project IDs provided', 1;
 
-    -- Validate each project ID format
-    DECLARE ProjectCursor CURSOR FOR
-        SELECT ProjectId FROM @ValidatedProjects;
-    OPEN ProjectCursor;
-    FETCH NEXT FROM ProjectCursor INTO @ProjectId;
-    WHILE @@FETCH_STATUS = 0
-    BEGIN
-        EXEC dbo.usp_ValidateAggieEnterpriseProject @ProjectId;
-        FETCH NEXT FROM ProjectCursor INTO @ProjectId;
-    END;
-    CLOSE ProjectCursor;
-    DEALLOCATE ProjectCursor;
+    -- Security boundary: every id is quoted and concatenated into the IN (...) clause of dynamic
+    -- SQL that callers run locally and against the Redshift/Oracle linked servers. Reject the whole
+    -- request unless every id is exactly 10 alphanumeric characters, so a value carrying quotes or
+    -- parentheses can never reach the generated query. THROW aborts before the filter is built.
+    IF EXISTS (SELECT 1 FROM @Projects
+               WHERE LEN(ProjectId) <> 10 OR ProjectId LIKE '%[^A-Za-z0-9]%')
+        THROW 50000, 'Invalid Project ID format (must be exactly 10 alphanumeric characters)', 1;
 
-    -- Build IN clause filter string (e.g., 'K30GS7777','K30GS8888')
+    -- Build IN clause filter string (e.g., 'FPAFST5328','K30BND3F03').
     -- CAST the element to NVARCHAR(MAX) so STRING_AGG returns a LOB result; with a non-MAX
     -- input the aggregate caps at 8000 bytes and silently truncates large project lists,
     -- producing a malformed IN clause.
     SELECT @ProjectIdFilter = STRING_AGG(CAST('''' + ProjectId + '''' AS NVARCHAR(MAX)), ',')
-    FROM @ValidatedProjects;
+    FROM @Projects;
 END;
 GO


### PR DESCRIPTION
## Problem

`usp_ParseProjectIdFilter` validated each parsed project ID by calling `usp_ValidateAggieEnterpriseProject`, which flagged bad IDs with a **severity-16 `RAISERROR`**. `RAISERROR` at that severity does not abort the batch, and the offending row was **never removed** — so a malformed value survived into the `STRING_AGG` that builds the `IN (...)` filter string.

Callers concatenate that filter into dynamic SQL executed **locally** (`sp_executesql`) and against the **Redshift and Oracle HCM linked servers** (`EXEC ... AT` / `OPENQUERY`). A user with `CanViewFinancials` could therefore submit a project code containing quotes/parens (e.g. `x')OR(1=1)--`) and break out of the quoted literal to alter the backend queries under the linked-server service credential.

Reachable via `ProjectController` (`byNumber`, `transactions`, `gl-ppm-reconciliation`, `personnel`), all of which feed raw `projectCodes` into this proc. `CallerCanAccessProjectsAsync` returns `true` for any `CanViewFinancials` holder regardless of the codes, so the malformed input reaches the proc.

## Fix

Replace the per-row cursor + advisory validation with a **set-based check that `THROW`s** unless every ID is exactly 10 alphanumeric characters. `THROW` aborts before the filter is built, so a value carrying quotes or parentheses can never reach the generated query. Removing the global cursor also avoids leaking it across pooled connections once validation starts aborting.

No signature change — **all six sinks are fixed with this one proc, no caller edits**. The validator's other two callers (`usp_GetProjectProjection`, `usp_GetPositionBudgetsLocal`) were never injectable (parameterized value / static join), so they're untouched.

## Behavior change

Malformed/empty input now `THROW`s straight to the client (the parse proc is called outside the callers' `TRY`), so these input-validation failures are no longer written to `usp_LogProcedureExecution`. Previously a malformed list injected silently and an empty list logged a downstream `IN ()` syntax failure.

## Testing

Verified in the DB via `CREATE OR ALTER`:

- `'FPAFST5328,K30BND3F03'` → returns `'FPAFST5328','K30BND3F03'`
- `x')OR(1=1)--` → `THROW 50000 'Invalid Project ID format...'`
- 9-char id → rejected
- empty / `null`-only → `THROW 50000 'No valid project IDs provided'`

## Follow-ups (not in this PR)

- `@FinancialDept` path relies on `usp_ValidateFinancialDept` (same advisory-`RAISERROR` pattern) plus `usp_SanitizeInputString` — worth aligning for consistency.
- Consider whether input-validation failures should be logged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of project ID filters so requests are rejected unless every ID is a valid 10-character alphanumeric value.
  * Added clearer failure handling when no usable project IDs are provided.
  * Prevented malformed or empty values from being included in project ID filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->