### PR TITLE
Grant GlSummaryBalances tables to pipeline/app roles

### DIFF
--- a/datamart/Scripts/Script.PostDeployment.sql
+++ b/datamart/Scripts/Script.PostDeployment.sql
@@ -44,6 +44,7 @@ GRANT SELECT ON [dbo].[PpmPersonRoles] TO [WalterAppRole];
 GRANT SELECT ON [dbo].[PpmProjects] TO [WalterAppRole];
 GRANT SELECT ON [dbo].[PpmProjectAwards] TO [WalterAppRole];
 GRANT SELECT ON [dbo].[GlProjectMonthlyActuals] TO [WalterAppRole];
+GRANT SELECT ON [dbo].[GlSummaryBalances] TO [WalterAppRole];
 GRANT SELECT ON [dbo].[ExpenditureTypeByAccount] TO [WalterAppRole];
 
 -- Grant pipeline role permissions
@@ -71,6 +72,10 @@ GRANT INSERT, SELECT, UPDATE, DELETE ON [dbo].[PpmProjectAwards_Staging] TO [Wal
 -- which does not honor ownership chaining.
 GRANT INSERT, SELECT, UPDATE, DELETE ON [dbo].[GlProjectMonthlyActuals] TO [WalterPipelineRole];
 GRANT INSERT, SELECT, UPDATE, DELETE ON [dbo].[GlProjectMonthlyActuals_Staging] TO [WalterPipelineRole];
+-- pl_gl_balances_loader loads GlSummaryBalances_Staging (pre-copy DELETE + bulk insert), then
+-- usp_SwapStagingTable snapshot-swaps it into GlSummaryBalances — same dynamic-SQL caveat as above.
+GRANT INSERT, SELECT, UPDATE, DELETE ON [dbo].[GlSummaryBalances] TO [WalterPipelineRole];
+GRANT INSERT, SELECT, UPDATE, DELETE ON [dbo].[GlSummaryBalances_Staging] TO [WalterPipelineRole];
 
 
 


### PR DESCRIPTION
Follow-up to #336: the GlSummaryBalances tables shipped without role grants, so `pl_gl_balances_loader`'s pre-copy `DELETE FROM dbo.GlSummaryBalances_Staging` fails with permission denied (SqlErrorNumber 229).

Adds to Script.PostDeployment.sql, mirroring the GlProjectMonthlyActuals pattern:
- `WalterPipelineRole`: INSERT/SELECT/UPDATE/DELETE on `GlSummaryBalances` and `GlSummaryBalances_Staging` (final-table DML required because `usp_SwapStagingTable` uses dynamic SQL — no ownership chaining).
- `WalterAppRole`: SELECT on `GlSummaryBalances`.

Post-deployment runs on every deploy, so merging applies this to WalterDev via CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded database access for the GlSummaryBalances dataset, including read access for application roles and full data management permissions for pipeline processing.
  * Added support for a staging-based load and swap flow for GlSummaryBalances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->