### PR TITLE
Remove award-PI fallback from portfolio access check

### DIFF
--- a/web/server/Controllers/ProjectController.cs
+++ b/web/server/Controllers/ProjectController.cs
@@ -508,17 +508,13 @@ public sealed class ProjectController : ApiControllerBase
             piEmployeeId, PpmRole.PrincipalInvestigator, cancellationToken);
         var piData = piResult.ReadData();
 
-
-
-        // Check if the requester is PI or PM on any of those projects. It also now looks in the awards personnel in case the requester is only listed there as PI while not being on the project team directly
+        // The requester must be a project team member (PI or PM) on at least one of the
+        // target's projects. Being award PI on a covering award is intentionally not
+        // sufficient: it must not grant access to the target PI's portfolio (issue #335).
         return piData.PpmProjectByProjectTeamMemberEmployeeId
             .Any(project =>
                 project.TeamMembers.Any(m =>
                     (m.RoleName == PpmRole.PrincipalInvestigator || m.RoleName == PpmRole.ProjectManager) &&
-                    string.Equals(m.EmployeeId, requesterEmployeeId, StringComparison.OrdinalIgnoreCase)) ||
-                project.Awards.Any(award =>
-                    award.Personnel.Any(person =>
-                        person.RoleName == PpmRole.PrincipalInvestigator &&
-                        string.Equals(person.EmployeeId, requesterEmployeeId, StringComparison.OrdinalIgnoreCase))));
+                    string.Equals(m.EmployeeId, requesterEmployeeId, StringComparison.OrdinalIgnoreCase)));
     }
 }

--- a/web/tests/server.tests/Controllers/ProjectControllerTests.cs
+++ b/web/tests/server.tests/Controllers/ProjectControllerTests.cs
@@ -16,6 +16,7 @@ using server.Services;
 using Server.Tests;
 using server.core.Data;
 using server.core.Domain;
+using server.tests.Fakes;
 
 namespace server.tests.Controllers;
 
@@ -227,6 +228,125 @@ public sealed class ProjectControllerTests
     }
 
     [Fact]
+    public async Task GetByIamId_forbids_requester_who_is_only_award_pi_on_target_pi_project()
+    {
+        using AppDbContext ctx = TestDbContextFactory.CreateInMemory();
+        var requester = SeedUser(ctx, employeeId: "EAWARDPI");
+
+        var controller = CreatePortfolioController(
+            ctx,
+            targetPerson: new SearchablePersonRecord { IamId = "IAM-PI", EmployeeId = "EPI", Name = "Target PI" },
+            projects: [TargetPiProjectWithAwardPi(awardPiEmployeeId: "EAWARDPI")],
+            user: CreateUser(roles: [], objectId: requester.Id));
+
+        var result = await controller.GetByIamIdAsync("IAM-PI", CancellationToken.None);
+
+        result.Should().BeOfType<ForbidResult>();
+    }
+
+    [Fact]
+    public async Task GetPersonnelForProjects_forbids_requester_who_is_only_award_pi_on_target_pi_project()
+    {
+        using AppDbContext ctx = TestDbContextFactory.CreateInMemory();
+        var requester = SeedUser(ctx, employeeId: "EAWARDPI");
+
+        var controller = CreatePortfolioController(
+            ctx,
+            targetPerson: new SearchablePersonRecord { IamId = "IAM-PI", EmployeeId = "EPI", Name = "Target PI" },
+            projects: [TargetPiProjectWithAwardPi(awardPiEmployeeId: "EAWARDPI")],
+            user: CreateUser(roles: [], objectId: requester.Id));
+
+        var result = await controller.GetPersonnelForProjects(
+            CancellationToken.None,
+            iamId: "IAM-PI",
+            projectCodes: "SP001");
+
+        result.Should().BeOfType<ForbidResult>();
+    }
+
+    [Fact]
+    public async Task GetByIamId_allows_team_project_manager_of_target_pi()
+    {
+        using AppDbContext ctx = TestDbContextFactory.CreateInMemory();
+        var requester = SeedUser(ctx, employeeId: "EPM");
+
+        var controller = CreatePortfolioController(
+            ctx,
+            targetPerson: new SearchablePersonRecord { IamId = "IAM-PI", EmployeeId = "EPI", Name = "Target PI" },
+            projects: [TargetPiProjectWithAwardPi(awardPiEmployeeId: "EAWARDPI")],
+            user: CreateUser(roles: [], objectId: requester.Id),
+            portfolio: [new FacultyPortfolioRecord { ProjectNumber = "SP001", ProjectStatus = "ACTIVE" }]);
+
+        var result = await controller.GetByIamIdAsync("IAM-PI", CancellationToken.None);
+
+        var projects = result.Should().BeOfType<OkObjectResult>().Which.Value
+            .Should().BeAssignableTo<IEnumerable<FacultyPortfolioRecord>>().Which;
+        projects.Should().ContainSingle(p => p.ProjectNumber == "SP001");
+    }
+
+    [Fact]
+    public async Task GetByIamId_self_lookup_includes_projects_where_user_is_award_pi()
+    {
+        using AppDbContext ctx = TestDbContextFactory.CreateInMemory();
+        var requester = SeedUser(ctx, employeeId: "EAWARDPI");
+
+        var controller = CreatePortfolioController(
+            ctx,
+            targetPerson: new SearchablePersonRecord { IamId = "IAM-AWARDPI", EmployeeId = "EAWARDPI", Name = "Award PI" },
+            projects: [TargetPiProjectWithAwardPi(awardPiEmployeeId: "EAWARDPI")],
+            user: CreateUser(roles: [], objectId: requester.Id),
+            portfolio: [new FacultyPortfolioRecord { ProjectNumber = "SP001", ProjectStatus = "ACTIVE" }]);
+
+        var result = await controller.GetByIamIdAsync("IAM-AWARDPI", CancellationToken.None);
+
+        var projects = result.Should().BeOfType<OkObjectResult>().Which.Value
+            .Should().BeAssignableTo<IEnumerable<FacultyPortfolioRecord>>().Which;
+        projects.Should().ContainSingle(p => p.ProjectNumber == "SP001");
+    }
+
+    /// <summary>
+    /// A project owned by team PI "EPI" (with team PM "EPM") whose award lists the given
+    /// employee as award PI without them being on the project team.
+    /// </summary>
+    private static FakeFinancialProject TargetPiProjectWithAwardPi(string awardPiEmployeeId)
+    {
+        return new FakeFinancialProject(
+            ProjectNumber: "SP001",
+            TeamMembers:
+            [
+                new FakeFinancialProjectTeamMember(PpmRole.PrincipalInvestigator, "Target PI", "EPI", null),
+                new FakeFinancialProjectTeamMember(PpmRole.ProjectManager, "Team PM", "EPM", null),
+            ],
+            AwardPersonnel:
+            [
+                new FakeFinancialProjectTeamMember(PpmRole.PrincipalInvestigator, "Award PI", awardPiEmployeeId, null),
+            ]);
+    }
+
+    private ProjectController CreatePortfolioController(
+        AppDbContext ctx,
+        SearchablePersonRecord targetPerson,
+        IReadOnlyList<FakeFinancialProject> projects,
+        ClaimsPrincipal user,
+        IReadOnlyList<FacultyPortfolioRecord>? portfolio = null)
+    {
+        return new ProjectController(
+            new FakeFinancialApiService(
+                projectManagerEmployeeIds: [],
+                projectTeamMembersByProjectNumber: null,
+                projects: projects),
+            new ResolvingDatamartService(targetPerson, portfolio: portfolio),
+            CreateAuthorizationService(),
+            new UserService(NullLogger<UserService>.Instance, ctx))
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext { User = user },
+            },
+        };
+    }
+
+    [Fact]
     public void Project_routes_do_not_expose_employee_id_lookup_contracts()
     {
         var templates = typeof(ProjectController)
@@ -253,11 +373,30 @@ public sealed class ProjectControllerTests
         return provider.GetRequiredService<IAuthorizationService>();
     }
 
-    private static ClaimsPrincipal CreateUser(IReadOnlyList<string> roles)
+    private static ClaimsPrincipal CreateUser(IReadOnlyList<string> roles, Guid? objectId = null)
     {
         var claims = roles.Select(r => new Claim(ClaimTypes.Role, r)).ToList();
+        if (objectId is not null)
+        {
+            claims.Add(new Claim(Microsoft.Identity.Web.ClaimConstants.ObjectId, objectId.Value.ToString()));
+        }
+
         var identity = new ClaimsIdentity(claims, authenticationType: "Test");
         return new ClaimsPrincipal(identity);
+    }
+
+    private static User SeedUser(AppDbContext ctx, string employeeId)
+    {
+        var user = new User
+        {
+            Id = Guid.NewGuid(),
+            Kerberos = "testuser",
+            IamId = $"IAM-{employeeId}",
+            EmployeeId = employeeId,
+        };
+        ctx.Users.Add(user);
+        ctx.SaveChanges();
+        return user;
     }
 
     private sealed class ThrowingFinancialApiService : IFinancialApiService
@@ -272,13 +411,16 @@ public sealed class ProjectControllerTests
     {
         private readonly SearchablePersonRecord? _person;
         private readonly ProjectProjectionResult? _projection;
+        private readonly IReadOnlyList<FacultyPortfolioRecord>? _portfolio;
 
         public ResolvingDatamartService(
             SearchablePersonRecord? person = null,
-            ProjectProjectionResult? projection = null)
+            ProjectProjectionResult? projection = null,
+            IReadOnlyList<FacultyPortfolioRecord>? portfolio = null)
         {
             _person = person;
             _projection = projection;
+            _portfolio = portfolio;
         }
 
         public Task<IReadOnlyList<SearchablePersonRecord>> SearchPeopleAsync(
@@ -332,7 +474,14 @@ public sealed class ProjectControllerTests
             string? emulatingUser = null,
             CancellationToken ct = default)
         {
-            throw new InvalidOperationException("Datamart should not be called for unauthorized users.");
+            if (_portfolio is null)
+            {
+                throw new InvalidOperationException("Datamart should not be called for unauthorized users.");
+            }
+
+            var requested = new HashSet<string>(projectNumbers, StringComparer.OrdinalIgnoreCase);
+            return Task.FromResult<IReadOnlyList<FacultyPortfolioRecord>>(
+                _portfolio.Where(p => requested.Contains(p.ProjectNumber)).ToList());
         }
 
         public Task<IReadOnlyList<PositionBudgetRecord>> GetPositionBudgetsAsync(

--- a/web/tests/server.tests/Fakes/FakeFinancialApi.cs
+++ b/web/tests/server.tests/Fakes/FakeFinancialApi.cs
@@ -14,6 +14,7 @@ public sealed class FakeFinancialApiService : IFinancialApiService
 {
     private readonly HashSet<string> _projectManagerEmployeeIds;
     private readonly Dictionary<string, IReadOnlyList<FakeFinancialProjectTeamMember>> _projectTeamMembersByProjectNumber;
+    private readonly IReadOnlyList<FakeFinancialProject> _projects;
 
     public FakeFinancialApiService()
         : this(Array.Empty<string>()) { }
@@ -23,7 +24,8 @@ public sealed class FakeFinancialApiService : IFinancialApiService
 
     public FakeFinancialApiService(
         IEnumerable<string> projectManagerEmployeeIds,
-        IReadOnlyDictionary<string, IReadOnlyList<FakeFinancialProjectTeamMember>>? projectTeamMembersByProjectNumber)
+        IReadOnlyDictionary<string, IReadOnlyList<FakeFinancialProjectTeamMember>>? projectTeamMembersByProjectNumber,
+        IReadOnlyList<FakeFinancialProject>? projects = null)
     {
         _projectManagerEmployeeIds = new HashSet<string>(
             projectManagerEmployeeIds,
@@ -33,6 +35,7 @@ public sealed class FakeFinancialApiService : IFinancialApiService
             : new Dictionary<string, IReadOnlyList<FakeFinancialProjectTeamMember>>(
                 projectTeamMembersByProjectNumber,
                 StringComparer.OrdinalIgnoreCase);
+        _projects = projects ?? Array.Empty<FakeFinancialProject>();
     }
 
     public IAggieEnterpriseClient GetClient()
@@ -41,7 +44,7 @@ public sealed class FakeFinancialApiService : IFinancialApiService
         {
             if (method.Name == "get_PpmProjectByProjectTeamMemberEmployeeId")
             {
-                return new FakePpmProjectByProjectTeamMemberEmployeeIdQuery(_projectManagerEmployeeIds);
+                return new FakePpmProjectByProjectTeamMemberEmployeeIdQuery(_projectManagerEmployeeIds, _projects);
             }
 
             if (method.Name == "get_PpmProjectTeamMembers")
@@ -60,13 +63,26 @@ public sealed record FakeFinancialProjectTeamMember(
     string EmployeeId,
     string? Email);
 
+/// <summary>
+/// A synthetic PPM project for <see cref="FakeFinancialApiService"/>. Award personnel model the
+/// people on the project's awards (the real query matches team members OR award personnel).
+/// </summary>
+public sealed record FakeFinancialProject(
+    string ProjectNumber,
+    IReadOnlyList<FakeFinancialProjectTeamMember> TeamMembers,
+    IReadOnlyList<FakeFinancialProjectTeamMember> AwardPersonnel);
+
 internal sealed class FakePpmProjectByProjectTeamMemberEmployeeIdQuery : IPpmProjectByProjectTeamMemberEmployeeIdQuery
 {
     private readonly ISet<string> _projectManagerEmployeeIds;
+    private readonly IReadOnlyList<FakeFinancialProject> _projects;
 
-    public FakePpmProjectByProjectTeamMemberEmployeeIdQuery(ISet<string> projectManagerEmployeeIds)
+    public FakePpmProjectByProjectTeamMemberEmployeeIdQuery(
+        ISet<string> projectManagerEmployeeIds,
+        IReadOnlyList<FakeFinancialProject> projects)
     {
         _projectManagerEmployeeIds = projectManagerEmployeeIds;
+        _projects = projects;
     }
 
     public Type ResultType => typeof(IPpmProjectByProjectTeamMemberEmployeeIdResult);
@@ -86,17 +102,82 @@ internal sealed class FakePpmProjectByProjectTeamMemberEmployeeIdQuery : IPpmPro
         string? roleName,
         CancellationToken cancellationToken)
     {
+        // Mirrors the real query: a project matches if the person has the role as a
+        // project team member OR as award personnel (verified against the live API).
+        var matchedProjects = _projects
+            .Where(project =>
+                project.TeamMembers.Concat(project.AwardPersonnel).Any(person =>
+                    string.Equals(person.EmployeeId, employeeId, StringComparison.OrdinalIgnoreCase) &&
+                    (roleName is null || string.Equals(person.RoleName, roleName, StringComparison.OrdinalIgnoreCase))))
+            .Select(CreateProject);
+
         var isPmLookup = roleName == PpmRole.ProjectManager
             && _projectManagerEmployeeIds.Contains(employeeId);
 
         var projects = isPmLookup
-            ? new[] { ProxyFactory.CreateProxy<IPpmProjectByProjectTeamMemberEmployeeId_PpmProjectByProjectTeamMemberEmployeeId>(
-                (_, _) => throw new NotImplementedException("Fake project items do not expose fields.")) }
-            : Array.Empty<IPpmProjectByProjectTeamMemberEmployeeId_PpmProjectByProjectTeamMemberEmployeeId>();
+            ? matchedProjects.Append(ProxyFactory.CreateProxy<IPpmProjectByProjectTeamMemberEmployeeId_PpmProjectByProjectTeamMemberEmployeeId>(
+                (_, _) => throw new NotImplementedException("Fake project items do not expose fields."))).ToArray()
+            : matchedProjects.ToArray();
 
         var result = new PpmProjectByProjectTeamMemberEmployeeIdResult(projects);
         return Task.FromResult<IOperationResult<IPpmProjectByProjectTeamMemberEmployeeIdResult>>(
             new FakeOperationResult<IPpmProjectByProjectTeamMemberEmployeeIdResult>(result));
+    }
+
+    private static IPpmProjectByProjectTeamMemberEmployeeId_PpmProjectByProjectTeamMemberEmployeeId CreateProject(
+        FakeFinancialProject project)
+    {
+        var teamMembers = project.TeamMembers.Select(CreateTeamMember).ToArray();
+        var awards = new[] { CreateAward(project.AwardPersonnel) };
+
+        return ProxyFactory.CreateProxy<IPpmProjectByProjectTeamMemberEmployeeId_PpmProjectByProjectTeamMemberEmployeeId>((method, _) =>
+            method.Name switch
+            {
+                "get_ProjectNumber" => project.ProjectNumber,
+                "get_ProjectStatus" => "ACTIVE",
+                "get_TeamMembers" => teamMembers,
+                "get_Awards" => awards,
+                _ => throw new NotImplementedException($"{method.Name} is not implemented for this fake."),
+            });
+    }
+
+    private static IPpmProjectByProjectTeamMemberEmployeeId_PpmProjectByProjectTeamMemberEmployeeId_TeamMembers CreateTeamMember(
+        FakeFinancialProjectTeamMember member)
+    {
+        return ProxyFactory.CreateProxy<IPpmProjectByProjectTeamMemberEmployeeId_PpmProjectByProjectTeamMemberEmployeeId_TeamMembers>((method, _) =>
+            method.Name switch
+            {
+                "get_EmployeeId" => member.EmployeeId,
+                "get_Name" => member.Name,
+                "get_RoleName" => member.RoleName,
+                _ => throw new NotImplementedException($"{method.Name} is not implemented for this fake."),
+            });
+    }
+
+    private static IPpmProjectByProjectTeamMemberEmployeeId_PpmProjectByProjectTeamMemberEmployeeId_Awards CreateAward(
+        IReadOnlyList<FakeFinancialProjectTeamMember> personnel)
+    {
+        var awardPersonnel = personnel.Select(CreateAwardPerson).ToArray();
+
+        return ProxyFactory.CreateProxy<IPpmProjectByProjectTeamMemberEmployeeId_PpmProjectByProjectTeamMemberEmployeeId_Awards>((method, _) =>
+            method.Name switch
+            {
+                "get_Personnel" => awardPersonnel,
+                _ => throw new NotImplementedException($"{method.Name} is not implemented for this fake."),
+            });
+    }
+
+    private static IPpmProjectByProjectTeamMemberEmployeeId_PpmProjectByProjectTeamMemberEmployeeId_Awards_Personnel CreateAwardPerson(
+        FakeFinancialProjectTeamMember person)
+    {
+        return ProxyFactory.CreateProxy<IPpmProjectByProjectTeamMemberEmployeeId_PpmProjectByProjectTeamMemberEmployeeId_Awards_Personnel>((method, _) =>
+            method.Name switch
+            {
+                "get_EmployeeId" => person.EmployeeId,
+                "get_Name" => person.Name,
+                "get_RoleName" => person.RoleName,
+                _ => throw new NotImplementedException($"{method.Name} is not implemented for this fake."),
+            });
     }
 
     public IObservable<IOperationResult<IPpmProjectByProjectTeamMemberEmployeeIdResult>> Watch(


### PR DESCRIPTION
Fixes #335

## Problem

The award-PI fallback in `IsOnAnyProjectForPiAsync` was overly broad: being award PI on an award covering **any one** of a target PI's projects granted access to that PI's **entire portfolio** (confirmed too broad by Shannon Tanguay, 2026-07-07).

## Change

- Removed the award-personnel fallback from the portfolio access check. A requester without financial access must now be a project **team member** (PI or PM) on at least one of the target's projects. Self-lookup and `CanViewFinancials` paths are unchanged.

## Why part 2 of the issue needs no code

The issue also asked for award-PI projects to appear in the user's **own** portfolio. That already works: despite its name, the AE query `ppmProjectByProjectTeamMemberEmployeeId` matches **award personnel as well as team members** (per the [API docs](https://ucdavis-adminit.github.io/erp-api-docs/api/index.html#query-ppmProjectByProjectTeamMemberEmployeeId), and verified against the live API — an award-PI-only employee gets the project back with the `roleName: "Principal Investigator"` filter). The own-portfolio and accessible-project-numbers paths query by the owner's own employee ID, so award-PI projects are already included there.

## Tests

Extended `FakeFinancialApiService` so seeded projects carry team members and award personnel with the same team-OR-award matching semantics as the real API, and added:

- Award-PI requester viewing another PI's portfolio → `Forbid` (`by-iam` and `personnel`) — failed before the fix
- Team PM of the target PI can still view the portfolio
- Self-lookup includes projects where the user is only the award PI

Full suite: 128/128 passing.

Known cosmetic edge (deferred): `OwnerName` resolves from team members only, so it's null for a portfolio consisting solely of award-PI projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)