### PR TITLE
chart color fix

### DIFF
--- a/web/client/src/components/project/ProjectBurndownChart.tsx
+++ b/web/client/src/components/project/ProjectBurndownChart.tsx
@@ -12,6 +12,7 @@ import {
 import { formatCurrency } from '@/lib/currency.ts';
 import {
   PROJECT_PERSONNEL_COLOR,
+  buildProjectCategoryColorMap,
   projectNonPersonnelCategoryColor,
   projectSeriesColor,
 } from '@/components/project/projectChartColors.ts';
@@ -200,17 +201,6 @@ function filterCategorySpend(
   return categorySpend;
 }
 
-function buildCategorySpendColors(
-  nonPersonnelCategorySeries: ProjectionSeries[]
-) {
-  return new Map(
-    nonPersonnelCategorySeries.map((entry, index) => [
-      entry.key,
-      projectNonPersonnelCategoryColor(index),
-    ])
-  );
-}
-
 interface BurndownTooltipProps {
   active?: boolean;
   categorySpendByMonth: Map<string, CategorySpend[]>;
@@ -334,9 +324,9 @@ export function ProjectBurndownSection({
     () => (result ? buildNonPersonnelCategorySeries(result) : []),
     [result]
   );
-  const categorySpendColors = useMemo(
-    () => buildCategorySpendColors(nonPersonnelCategorySeries),
-    [nonPersonnelCategorySeries]
+  const categoryColors = useMemo(
+    () => (result ? buildProjectCategoryColorMap(result.categories) : new Map()),
+    [result]
   );
   const chartSeries = useMemo(
     () => [...series, ...nonPersonnelCategorySeries],
@@ -378,6 +368,12 @@ export function ProjectBurndownSection({
     )
       ? selectedNonPersonnelCategory
       : null;
+  const nonPersonnelCategoryColor = (
+    expenditureCategory: string,
+    fallbackIndex: number
+  ) =>
+    categoryColors.get(expenditureCategory) ??
+    projectNonPersonnelCategoryColor(fallbackIndex);
 
   if (projectionQuery.isSuccess && series.length === 0) {
     return null;
@@ -394,14 +390,14 @@ export function ProjectBurndownSection({
       ? activeSelectedNonPersonnelCategory
         ? nonPersonnelCategorySeries
             .map((entry, index) => ({
-              color: projectNonPersonnelCategoryColor(index),
+              color: nonPersonnelCategoryColor(entry.key, index),
               key: entry.key,
             }))
             .filter(({ key }) => key === activeSelectedNonPersonnelCategory)
         : [
             ...selectedRollupSeries,
             ...nonPersonnelCategorySeries.map((entry, index) => ({
-              color: projectNonPersonnelCategoryColor(index),
+              color: nonPersonnelCategoryColor(entry.key, index),
               key: entry.key,
               strokeWidth: 1.75,
             })),
@@ -520,7 +516,7 @@ export function ProjectBurndownSection({
                     content={
                       <BurndownTooltip
                         categorySpendByMonth={categorySpendByMonth}
-                        categorySpendColors={categorySpendColors}
+                        categorySpendColors={categoryColors}
                         selectedKey={selectedKey}
                         selectedNonPersonnelCategory={
                           activeSelectedNonPersonnelCategory
@@ -619,7 +615,7 @@ export function ProjectBurndownSection({
                             className="inline-block h-3 w-3 rounded-sm mr-2"
                             style={{
                               backgroundColor:
-                                projectNonPersonnelCategoryColor(index),
+                                nonPersonnelCategoryColor(entry.key, index),
                             }}
                           />
                           {entry.key}

--- a/web/client/src/components/project/ProjectBurndownChart.tsx
+++ b/web/client/src/components/project/ProjectBurndownChart.tsx
@@ -11,9 +11,7 @@ import {
 } from 'recharts';
 import { formatCurrency } from '@/lib/currency.ts';
 import {
-  PROJECT_PERSONNEL_COLOR,
-  buildProjectCategoryColorMap,
-  projectNonPersonnelCategoryColor,
+  projectExpenditureCategoryColor,
   projectSeriesColor,
 } from '@/components/project/projectChartColors.ts';
 import {
@@ -204,7 +202,6 @@ function filterCategorySpend(
 interface BurndownTooltipProps {
   active?: boolean;
   categorySpendByMonth: Map<string, CategorySpend[]>;
-  categorySpendColors: Map<string, string>;
   payload?: Array<{ payload?: ChartRow }>;
   selectedKey: string;
   selectedNonPersonnelCategory: string | null;
@@ -214,7 +211,6 @@ interface BurndownTooltipProps {
 function BurndownTooltip({
   active,
   categorySpendByMonth,
-  categorySpendColors,
   payload,
   selectedKey,
   selectedNonPersonnelCategory,
@@ -287,8 +283,7 @@ function BurndownTooltip({
                     className="inline-block h-3 w-3 shrink-0 rounded-sm"
                     style={{
                       backgroundColor:
-                        categorySpendColors.get(expenditureCategory) ??
-                        PROJECT_PERSONNEL_COLOR,
+                        projectExpenditureCategoryColor(expenditureCategory),
                     }}
                   />
                   <span className="truncate">{expenditureCategory}</span>
@@ -322,10 +317,6 @@ export function ProjectBurndownSection({
   );
   const nonPersonnelCategorySeries = useMemo(
     () => (result ? buildNonPersonnelCategorySeries(result) : []),
-    [result]
-  );
-  const categoryColors = useMemo(
-    () => (result ? buildProjectCategoryColorMap(result.categories) : new Map()),
     [result]
   );
   const chartSeries = useMemo(
@@ -368,20 +359,14 @@ export function ProjectBurndownSection({
     )
       ? selectedNonPersonnelCategory
       : null;
-  const nonPersonnelCategoryColor = (
-    expenditureCategory: string,
-    fallbackIndex: number
-  ) =>
-    categoryColors.get(expenditureCategory) ??
-    projectNonPersonnelCategoryColor(fallbackIndex);
 
   if (projectionQuery.isSuccess && series.length === 0) {
     return null;
   }
 
   const selectedRollupSeries: VisibleSeries[] = series
-    .map((entry, index) => ({
-      color: projectSeriesColor(index),
+    .map((entry) => ({
+      color: projectSeriesColor(entry.key),
       key: entry.key,
     }))
     .filter(({ key }) => key === selectedKey);
@@ -389,15 +374,15 @@ export function ProjectBurndownSection({
     selectedKey === NON_PERSONNEL_SERIES
       ? activeSelectedNonPersonnelCategory
         ? nonPersonnelCategorySeries
-            .map((entry, index) => ({
-              color: nonPersonnelCategoryColor(entry.key, index),
+            .map((entry) => ({
+              color: projectExpenditureCategoryColor(entry.key),
               key: entry.key,
             }))
             .filter(({ key }) => key === activeSelectedNonPersonnelCategory)
         : [
             ...selectedRollupSeries,
-            ...nonPersonnelCategorySeries.map((entry, index) => ({
-              color: nonPersonnelCategoryColor(entry.key, index),
+            ...nonPersonnelCategorySeries.map((entry) => ({
+              color: projectExpenditureCategoryColor(entry.key),
               key: entry.key,
               strokeWidth: 1.75,
             })),
@@ -516,7 +501,6 @@ export function ProjectBurndownSection({
                     content={
                       <BurndownTooltip
                         categorySpendByMonth={categorySpendByMonth}
-                        categorySpendColors={categoryColors}
                         selectedKey={selectedKey}
                         selectedNonPersonnelCategory={
                           activeSelectedNonPersonnelCategory
@@ -561,7 +545,7 @@ export function ProjectBurndownSection({
             </div>
 
             <div className="tabs tabs-box mt-4 inline-flex" role="tablist">
-              {series.map((entry, index) => {
+              {series.map((entry) => {
                 const isSelected = entry.key === selectedKey;
                 return (
                   <button
@@ -579,7 +563,7 @@ export function ProjectBurndownSection({
                   >
                     <span
                       className="inline-block h-3 w-3 rounded-sm mr-2"
-                      style={{ backgroundColor: projectSeriesColor(index) }}
+                      style={{ backgroundColor: projectSeriesColor(entry.key) }}
                     />
                     {entry.key}
                   </button>
@@ -595,7 +579,7 @@ export function ProjectBurndownSection({
                     className="tabs tabs-box flex w-fit flex-wrap"
                     role="tablist"
                   >
-                    {nonPersonnelCategorySeries.map((entry, index) => {
+                    {nonPersonnelCategorySeries.map((entry) => {
                       const isSelected =
                         activeSelectedNonPersonnelCategory === entry.key;
                       return (
@@ -615,7 +599,7 @@ export function ProjectBurndownSection({
                             className="inline-block h-3 w-3 rounded-sm mr-2"
                             style={{
                               backgroundColor:
-                                nonPersonnelCategoryColor(entry.key, index),
+                                projectExpenditureCategoryColor(entry.key),
                             }}
                           />
                           {entry.key}

--- a/web/client/src/components/project/ProjectExpenditureProgress.tsx
+++ b/web/client/src/components/project/ProjectExpenditureProgress.tsx
@@ -1,8 +1,8 @@
 import { useId, useMemo, useState } from 'react';
 import { ChevronDownIcon, ChevronUpIcon } from '@heroicons/react/24/outline';
 import {
-  PROJECT_PERSONNEL_COLOR,
-  projectNonPersonnelCategoryColor,
+  buildProjectCategoryColorMap,
+  hasProjectCategoryProgressData,
 } from '@/components/project/projectChartColors.ts';
 import { formatCurrency } from '@/lib/currency.ts';
 import {
@@ -79,15 +79,6 @@ interface ProjectExpenditureProgressSectionProps {
 
 function categoryDisplayName(expenditureCategory: string) {
   return expenditureCategory.replace(/^\d+\s*-\s*/, '');
-}
-
-function categoryColor(
-  category: ProjectProjectionCategory,
-  nonPersonnelIndex: number
-) {
-  return category.isPersonnel === 1
-    ? PROJECT_PERSONNEL_COLOR
-    : projectNonPersonnelCategoryColor(nonPersonnelIndex);
 }
 
 function commitmentColor(color: string) {
@@ -262,25 +253,17 @@ function getBudgetProgressRow(
 function buildCategoryProgressRows(
   categories: ProjectProjectionCategory[]
 ): CategoryProgressRow[] {
-  let nonPersonnelIndex = 0;
+  const categoryColors = buildProjectCategoryColorMap(categories);
 
   return categories
-    .filter(
-      (category) =>
-        category.budget !== 0 ||
-        category.committed !== 0 ||
-        category.remainingNow !== 0 ||
-        category.spentToDate !== 0
-    )
+    .filter(hasProjectCategoryProgressData)
     .sort((a, b) => a.expenditureCategory.localeCompare(b.expenditureCategory))
     .map((category) => {
       const { available, budget, committed, overrun, spent, total } =
         getCategoryBudgetProgress(category);
-      const baseColor = categoryColor(category, nonPersonnelIndex);
-
-      if (category.isPersonnel !== 1) {
-        nonPersonnelIndex += 1;
-      }
+      const baseColor =
+        categoryColors.get(category.expenditureCategory) ??
+        'var(--color-primary)';
 
       const segments = [
         {

--- a/web/client/src/components/project/ProjectExpenditureProgress.tsx
+++ b/web/client/src/components/project/ProjectExpenditureProgress.tsx
@@ -1,9 +1,6 @@
 import { useId, useMemo, useState } from 'react';
 import { ChevronDownIcon, ChevronUpIcon } from '@heroicons/react/24/outline';
-import {
-  buildProjectCategoryColorMap,
-  hasProjectCategoryProgressData,
-} from '@/components/project/projectChartColors.ts';
+import { projectExpenditureCategoryColor } from '@/components/project/projectChartColors.ts';
 import { formatCurrency } from '@/lib/currency.ts';
 import {
   getCategoryBudgetProgress,
@@ -79,6 +76,15 @@ interface ProjectExpenditureProgressSectionProps {
 
 function categoryDisplayName(expenditureCategory: string) {
   return expenditureCategory.replace(/^\d+\s*-\s*/, '');
+}
+
+function hasCategoryProgressData(category: ProjectProjectionCategory) {
+  return (
+    category.budget !== 0 ||
+    category.committed !== 0 ||
+    category.remainingNow !== 0 ||
+    category.spentToDate !== 0
+  );
 }
 
 function commitmentColor(color: string) {
@@ -253,17 +259,15 @@ function getBudgetProgressRow(
 function buildCategoryProgressRows(
   categories: ProjectProjectionCategory[]
 ): CategoryProgressRow[] {
-  const categoryColors = buildProjectCategoryColorMap(categories);
-
   return categories
-    .filter(hasProjectCategoryProgressData)
+    .filter(hasCategoryProgressData)
     .sort((a, b) => a.expenditureCategory.localeCompare(b.expenditureCategory))
     .map((category) => {
       const { available, budget, committed, overrun, spent, total } =
         getCategoryBudgetProgress(category);
-      const baseColor =
-        categoryColors.get(category.expenditureCategory) ??
-        'var(--color-primary)';
+      const baseColor = projectExpenditureCategoryColor(
+        category.expenditureCategory
+      );
 
       const segments = [
         {

--- a/web/client/src/components/project/projectChartColors.ts
+++ b/web/client/src/components/project/projectChartColors.ts
@@ -19,6 +19,19 @@ const NON_PERSONNEL_SERIES_COLOR_START = 3;
 const PROJECT_NON_PERSONNEL_CATEGORY_COLORS = PROJECT_SERIES_COLORS.slice(
   NON_PERSONNEL_SERIES_COLOR_START
 );
+const PROJECT_NON_PERSONNEL_CATEGORY_CODES = [
+  '03',
+  '04',
+  '05',
+  '06',
+  '07',
+  '08',
+  '09',
+  '99',
+] as const;
+const PROJECT_NON_PERSONNEL_CATEGORY_CODE_LIST: readonly string[] = [
+  ...PROJECT_NON_PERSONNEL_CATEGORY_CODES,
+];
 
 type ProjectCategoryColorSource = {
   budget: number;
@@ -43,6 +56,22 @@ function wrapColorIndex(index: number, length: number) {
   return ((index % length) + length) % length;
 }
 
+function stableCategoryIndex(expenditureCategory: string) {
+  const code = /^\s*(\d{2})\s*-/.exec(expenditureCategory)?.[1];
+  const codeIndex = PROJECT_NON_PERSONNEL_CATEGORY_CODE_LIST.indexOf(
+    code ?? ''
+  );
+
+  if (codeIndex >= 0) {
+    return codeIndex;
+  }
+
+  return [...expenditureCategory].reduce(
+    (hash, character) => hash + character.charCodeAt(0),
+    0
+  );
+}
+
 export const PROJECT_PERSONNEL_COLOR = projectSeriesColorByName('Personnel');
 
 export function projectSeriesColor(index: number) {
@@ -62,6 +91,14 @@ export function projectNonPersonnelCategoryColor(index: number) {
   return entry.color;
 }
 
+export function projectNonPersonnelCategoryColorByCategory(
+  expenditureCategory: string
+) {
+  return projectNonPersonnelCategoryColor(
+    stableCategoryIndex(expenditureCategory)
+  );
+}
+
 export function hasProjectCategoryProgressData(
   category: ProjectCategoryColorSource
 ) {
@@ -76,7 +113,6 @@ export function hasProjectCategoryProgressData(
 export function buildProjectCategoryColorMap(
   categories: ProjectCategoryColorSource[]
 ) {
-  let nonPersonnelIndex = 0;
   const colorsByCategory = new Map<string, string>();
 
   for (const category of categories
@@ -91,9 +127,8 @@ export function buildProjectCategoryColorMap(
 
     colorsByCategory.set(
       category.expenditureCategory,
-      projectNonPersonnelCategoryColor(nonPersonnelIndex)
+      projectNonPersonnelCategoryColorByCategory(category.expenditureCategory)
     );
-    nonPersonnelIndex += 1;
   }
 
   return colorsByCategory;

--- a/web/client/src/components/project/projectChartColors.ts
+++ b/web/client/src/components/project/projectChartColors.ts
@@ -1,135 +1,44 @@
-export const PROJECT_SERIES_COLORS = [
-  { color: 'var(--color-primary)', name: 'All Expenses' },
-  { color: 'var(--color-ucd-poppy)', name: 'Personnel' },
-  { color: 'var(--color-ucd-arboretum)', name: 'Non-Personnel' },
-  { color: 'var(--color-ucd-tahoe)', name: '03 Supplies' },
-  { color: 'var(--color-ucd-cabernet)', name: '04 Equipment' },
-  {
-    color: 'var(--color-ucd-sunflower)',
-    name: '05 Contracts',
-  },
-  { color: 'var(--color-ucd-sage)', name: '06 UC Multi-Campus' },
-  { color: 'var(--color-ucd-putahcreek)', name: '07 Travel' },
-  { color: 'var(--color-ucd-redbud)', name: '08 Fellowship' },
-  { color: 'var(--color-ucd-farmersmarket)', name: '09 Indirect' },
-  { color: 'var(--color-ucd-rose)', name: '99 Uncategorized' },
-] as const;
+export const PROJECT_SERIES_COLORS = {
+  'All Expenses': 'var(--color-primary)',
+  'Non-Personnel': 'var(--color-ucd-arboretum)',
+  Personnel: 'var(--color-ucd-poppy)',
+} as const;
 
-const NON_PERSONNEL_SERIES_COLOR_START = 3;
-const PROJECT_NON_PERSONNEL_CATEGORY_COLORS = PROJECT_SERIES_COLORS.slice(
-  NON_PERSONNEL_SERIES_COLOR_START
-);
-const PROJECT_NON_PERSONNEL_CATEGORY_CODES = [
-  '03',
-  '04',
-  '05',
-  '06',
-  '07',
-  '08',
-  '09',
-  '99',
-] as const;
-const PROJECT_NON_PERSONNEL_CATEGORY_CODE_LIST: readonly string[] = [
-  ...PROJECT_NON_PERSONNEL_CATEGORY_CODES,
-];
+export const PROJECT_EXPENDITURE_CATEGORY_COLORS = {
+  '01 - Salaries and Wages': PROJECT_SERIES_COLORS.Personnel,
+  '02 - Fringe Benefits': PROJECT_SERIES_COLORS.Personnel,
+  '03 - Supplies / Services / Other Expenses': 'var(--color-ucd-tahoe)',
+  '04 - Equipment and Facilities': 'var(--color-ucd-cabernet)',
+  '05 - Contracts (Subrecipients)': 'var(--color-ucd-sunflower)',
+  '06 - UC Multi-Campus': 'var(--color-ucd-sage)',
+  '07 - Travel': 'var(--color-ucd-putahcreek)',
+  '08 - Fellowship & Scholarships': 'var(--color-ucd-redbud)',
+  '09 - Indirect Costs': 'var(--color-ucd-farmersmarket)',
+  '99 - Uncategorized': 'var(--color-ucd-rose)',
 
-type ProjectCategoryColorSource = {
-  budget: number;
-  committed: number;
-  expenditureCategory: string;
-  isPersonnel: number;
-  remainingNow: number;
-  spentToDate: number;
-};
+  // Legacy/test labels still seen in local fixtures.
+  '04 - Supplies': 'var(--color-ucd-cabernet)',
+  '04 - Travel': 'var(--color-ucd-cabernet)',
+  '05 - Fellowship & Scholarships': 'var(--color-ucd-sunflower)',
+  '05 - Travel': 'var(--color-ucd-sunflower)',
+  '06 - Indirect Costs': 'var(--color-ucd-sage)',
+  '07 - Fellowships': 'var(--color-ucd-putahcreek)',
+} as const;
 
-function projectSeriesColorByName(name: string) {
-  const entry = PROJECT_SERIES_COLORS.find((color) => color.name === name);
+export const PROJECT_PERSONNEL_COLOR = PROJECT_SERIES_COLORS.Personnel;
+const PROJECT_UNKNOWN_CATEGORY_COLOR = 'var(--color-ucd-rose)';
 
-  if (!entry) {
-    throw new Error(`Missing project chart color for "${name}".`);
-  }
-
-  return entry.color;
-}
-
-function wrapColorIndex(index: number, length: number) {
-  return ((index % length) + length) % length;
-}
-
-function stableCategoryIndex(expenditureCategory: string) {
-  const code = /^\s*(\d{2})\s*-/.exec(expenditureCategory)?.[1];
-  const codeIndex = PROJECT_NON_PERSONNEL_CATEGORY_CODE_LIST.indexOf(
-    code ?? ''
-  );
-
-  if (codeIndex >= 0) {
-    return codeIndex;
-  }
-
-  return [...expenditureCategory].reduce(
-    (hash, character) => hash + character.charCodeAt(0),
-    0
-  );
-}
-
-export const PROJECT_PERSONNEL_COLOR = projectSeriesColorByName('Personnel');
-
-export function projectSeriesColor(index: number) {
-  return PROJECT_SERIES_COLORS[index % PROJECT_SERIES_COLORS.length].color;
-}
-
-export function projectNonPersonnelCategoryColor(index: number) {
-  const entry =
-    PROJECT_NON_PERSONNEL_CATEGORY_COLORS[
-      wrapColorIndex(index, PROJECT_NON_PERSONNEL_CATEGORY_COLORS.length)
-    ];
-
-  if (!entry) {
-    throw new Error('Missing project chart colors for non-personnel categories.');
-  }
-
-  return entry.color;
-}
-
-export function projectNonPersonnelCategoryColorByCategory(
-  expenditureCategory: string
-) {
-  return projectNonPersonnelCategoryColor(
-    stableCategoryIndex(expenditureCategory)
-  );
-}
-
-export function hasProjectCategoryProgressData(
-  category: ProjectCategoryColorSource
-) {
+export function projectSeriesColor(seriesName: string) {
   return (
-    category.budget !== 0 ||
-    category.committed !== 0 ||
-    category.remainingNow !== 0 ||
-    category.spentToDate !== 0
+    PROJECT_SERIES_COLORS[seriesName as keyof typeof PROJECT_SERIES_COLORS] ??
+    PROJECT_UNKNOWN_CATEGORY_COLOR
   );
 }
 
-export function buildProjectCategoryColorMap(
-  categories: ProjectCategoryColorSource[]
-) {
-  const colorsByCategory = new Map<string, string>();
-
-  for (const category of categories
-    .filter(hasProjectCategoryProgressData)
-    .sort((a, b) =>
-      a.expenditureCategory.localeCompare(b.expenditureCategory)
-    )) {
-    if (category.isPersonnel === 1) {
-      colorsByCategory.set(category.expenditureCategory, PROJECT_PERSONNEL_COLOR);
-      continue;
-    }
-
-    colorsByCategory.set(
-      category.expenditureCategory,
-      projectNonPersonnelCategoryColorByCategory(category.expenditureCategory)
-    );
-  }
-
-  return colorsByCategory;
+export function projectExpenditureCategoryColor(expenditureCategory: string) {
+  return (
+    PROJECT_EXPENDITURE_CATEGORY_COLORS[
+      expenditureCategory as keyof typeof PROJECT_EXPENDITURE_CATEGORY_COLORS
+    ] ?? PROJECT_UNKNOWN_CATEGORY_COLOR
+  );
 }

--- a/web/client/src/components/project/projectChartColors.ts
+++ b/web/client/src/components/project/projectChartColors.ts
@@ -20,6 +20,15 @@ const PROJECT_NON_PERSONNEL_CATEGORY_COLORS = PROJECT_SERIES_COLORS.slice(
   NON_PERSONNEL_SERIES_COLOR_START
 );
 
+type ProjectCategoryColorSource = {
+  budget: number;
+  committed: number;
+  expenditureCategory: string;
+  isPersonnel: number;
+  remainingNow: number;
+  spentToDate: number;
+};
+
 function projectSeriesColorByName(name: string) {
   const entry = PROJECT_SERIES_COLORS.find((color) => color.name === name);
 
@@ -51,4 +60,41 @@ export function projectNonPersonnelCategoryColor(index: number) {
   }
 
   return entry.color;
+}
+
+export function hasProjectCategoryProgressData(
+  category: ProjectCategoryColorSource
+) {
+  return (
+    category.budget !== 0 ||
+    category.committed !== 0 ||
+    category.remainingNow !== 0 ||
+    category.spentToDate !== 0
+  );
+}
+
+export function buildProjectCategoryColorMap(
+  categories: ProjectCategoryColorSource[]
+) {
+  let nonPersonnelIndex = 0;
+  const colorsByCategory = new Map<string, string>();
+
+  for (const category of categories
+    .filter(hasProjectCategoryProgressData)
+    .sort((a, b) =>
+      a.expenditureCategory.localeCompare(b.expenditureCategory)
+    )) {
+    if (category.isPersonnel === 1) {
+      colorsByCategory.set(category.expenditureCategory, PROJECT_PERSONNEL_COLOR);
+      continue;
+    }
+
+    colorsByCategory.set(
+      category.expenditureCategory,
+      projectNonPersonnelCategoryColor(nonPersonnelIndex)
+    );
+    nonPersonnelIndex += 1;
+  }
+
+  return colorsByCategory;
 }

--- a/web/client/src/test/components/project/projectChartColors.test.ts
+++ b/web/client/src/test/components/project/projectChartColors.test.ts
@@ -1,49 +1,47 @@
 import { describe, expect, it } from 'vitest';
 import {
-  buildProjectCategoryColorMap,
-  projectNonPersonnelCategoryColor,
+  PROJECT_EXPENDITURE_CATEGORY_COLORS,
+  PROJECT_SERIES_COLORS,
+  projectExpenditureCategoryColor,
+  projectSeriesColor,
 } from '@/components/project/projectChartColors.ts';
 
-const category = (
-  expenditureCategory: string,
-  isPersonnel = 0
-) => ({
-  budget: 100,
-  committed: 0,
-  expenditureCategory,
-  isPersonnel,
-  remainingNow: 80,
-  spentToDate: 20,
-});
-
 describe('project chart colors', () => {
-  it('keeps category colors stable when burndown periods omit earlier categories', () => {
-    const fullCategoryColors = buildProjectCategoryColorMap([
-      category('03 - Supplies / Services / Other Expenses'),
-      category('07 - Travel'),
-      category('09 - Indirect Costs'),
-    ]);
-    const prunedCategoryColors = buildProjectCategoryColorMap([
-      category('07 - Travel'),
-      category('09 - Indirect Costs'),
-    ]);
-
-    expect(fullCategoryColors.get('09 - Indirect Costs')).toBe(
-      prunedCategoryColors.get('09 - Indirect Costs')
-    );
-    expect(fullCategoryColors.get('09 - Indirect Costs')).toBe(
-      projectNonPersonnelCategoryColor(6)
-    );
+  it('defines category colors in one explicit map', () => {
+    expect(PROJECT_EXPENDITURE_CATEGORY_COLORS).toMatchObject({
+      '01 - Salaries and Wages': PROJECT_SERIES_COLORS.Personnel,
+      '02 - Fringe Benefits': PROJECT_SERIES_COLORS.Personnel,
+      '03 - Supplies / Services / Other Expenses': 'var(--color-ucd-tahoe)',
+      '09 - Indirect Costs': 'var(--color-ucd-farmersmarket)',
+    });
   });
 
-  it('uses the personnel color for all personnel categories', () => {
-    const expenditureChartColors = buildProjectCategoryColorMap([
-      category('01 - Salaries and Wages', 1),
-      category('02 - Fringe Benefits', 1),
-    ]);
+  it('keeps category colors stable when category lists are pruned', () => {
+    const fullCategoryList = [
+      '03 - Supplies / Services / Other Expenses',
+      '07 - Travel',
+      '09 - Indirect Costs',
+    ];
+    const prunedCategoryList = ['07 - Travel', '09 - Indirect Costs'];
 
-    expect(expenditureChartColors.get('01 - Salaries and Wages')).toBe(
-      expenditureChartColors.get('02 - Fringe Benefits')
+    const fullIndirectColor = projectExpenditureCategoryColor(
+      fullCategoryList[2]
+    );
+    const prunedIndirectColor = projectExpenditureCategoryColor(
+      prunedCategoryList[1]
+    );
+
+    expect(fullIndirectColor).toBe(prunedIndirectColor);
+    expect(fullIndirectColor).toBe('var(--color-ucd-farmersmarket)');
+  });
+
+  it('looks up rollup series colors by series name', () => {
+    expect(projectSeriesColor('All Expenses')).toBe(
+      PROJECT_SERIES_COLORS['All Expenses']
+    );
+    expect(projectSeriesColor('Personnel')).toBe(PROJECT_SERIES_COLORS.Personnel);
+    expect(projectSeriesColor('Non-Personnel')).toBe(
+      PROJECT_SERIES_COLORS['Non-Personnel']
     );
   });
 });

--- a/web/client/src/test/components/project/projectChartColors.test.ts
+++ b/web/client/src/test/components/project/projectChartColors.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildProjectCategoryColorMap,
+  projectNonPersonnelCategoryColor,
+} from '@/components/project/projectChartColors.ts';
+
+describe('project chart colors', () => {
+  it('keeps category colors stable when burndown periods omit earlier categories', () => {
+    const expenditureChartColors = buildProjectCategoryColorMap([
+      {
+        budget: 100,
+        committed: 0,
+        expenditureCategory: '03 - Supplies / Services / Other Expenses',
+        isPersonnel: 0,
+        remainingNow: 80,
+        spentToDate: 20,
+      },
+      {
+        budget: 100,
+        committed: 0,
+        expenditureCategory: '07 - Travel',
+        isPersonnel: 0,
+        remainingNow: 80,
+        spentToDate: 20,
+      },
+      {
+        budget: 100,
+        committed: 0,
+        expenditureCategory: '09 - Indirect Costs',
+        isPersonnel: 0,
+        remainingNow: 80,
+        spentToDate: 20,
+      },
+    ]);
+
+    expect(expenditureChartColors.get('09 - Indirect Costs')).toBe(
+      projectNonPersonnelCategoryColor(2)
+    );
+    expect(expenditureChartColors.get('09 - Indirect Costs')).not.toBe(
+      projectNonPersonnelCategoryColor(1)
+    );
+  });
+
+  it('uses the personnel color for all personnel categories', () => {
+    const expenditureChartColors = buildProjectCategoryColorMap([
+      {
+        budget: 100,
+        committed: 0,
+        expenditureCategory: '01 - Salaries and Wages',
+        isPersonnel: 1,
+        remainingNow: 80,
+        spentToDate: 20,
+      },
+      {
+        budget: 100,
+        committed: 0,
+        expenditureCategory: '02 - Fringe Benefits',
+        isPersonnel: 1,
+        remainingNow: 80,
+        spentToDate: 20,
+      },
+    ]);
+
+    expect(expenditureChartColors.get('01 - Salaries and Wages')).toBe(
+      expenditureChartColors.get('02 - Fringe Benefits')
+    );
+  });
+});

--- a/web/client/src/test/components/project/projectChartColors.test.ts
+++ b/web/client/src/test/components/project/projectChartColors.test.ts
@@ -4,61 +4,42 @@ import {
   projectNonPersonnelCategoryColor,
 } from '@/components/project/projectChartColors.ts';
 
+const category = (
+  expenditureCategory: string,
+  isPersonnel = 0
+) => ({
+  budget: 100,
+  committed: 0,
+  expenditureCategory,
+  isPersonnel,
+  remainingNow: 80,
+  spentToDate: 20,
+});
+
 describe('project chart colors', () => {
   it('keeps category colors stable when burndown periods omit earlier categories', () => {
-    const expenditureChartColors = buildProjectCategoryColorMap([
-      {
-        budget: 100,
-        committed: 0,
-        expenditureCategory: '03 - Supplies / Services / Other Expenses',
-        isPersonnel: 0,
-        remainingNow: 80,
-        spentToDate: 20,
-      },
-      {
-        budget: 100,
-        committed: 0,
-        expenditureCategory: '07 - Travel',
-        isPersonnel: 0,
-        remainingNow: 80,
-        spentToDate: 20,
-      },
-      {
-        budget: 100,
-        committed: 0,
-        expenditureCategory: '09 - Indirect Costs',
-        isPersonnel: 0,
-        remainingNow: 80,
-        spentToDate: 20,
-      },
+    const fullCategoryColors = buildProjectCategoryColorMap([
+      category('03 - Supplies / Services / Other Expenses'),
+      category('07 - Travel'),
+      category('09 - Indirect Costs'),
+    ]);
+    const prunedCategoryColors = buildProjectCategoryColorMap([
+      category('07 - Travel'),
+      category('09 - Indirect Costs'),
     ]);
 
-    expect(expenditureChartColors.get('09 - Indirect Costs')).toBe(
-      projectNonPersonnelCategoryColor(2)
+    expect(fullCategoryColors.get('09 - Indirect Costs')).toBe(
+      prunedCategoryColors.get('09 - Indirect Costs')
     );
-    expect(expenditureChartColors.get('09 - Indirect Costs')).not.toBe(
-      projectNonPersonnelCategoryColor(1)
+    expect(fullCategoryColors.get('09 - Indirect Costs')).toBe(
+      projectNonPersonnelCategoryColor(6)
     );
   });
 
   it('uses the personnel color for all personnel categories', () => {
     const expenditureChartColors = buildProjectCategoryColorMap([
-      {
-        budget: 100,
-        committed: 0,
-        expenditureCategory: '01 - Salaries and Wages',
-        isPersonnel: 1,
-        remainingNow: 80,
-        spentToDate: 20,
-      },
-      {
-        budget: 100,
-        committed: 0,
-        expenditureCategory: '02 - Fringe Benefits',
-        isPersonnel: 1,
-        remainingNow: 80,
-        spentToDate: 20,
-      },
+      category('01 - Salaries and Wages', 1),
+      category('02 - Fringe Benefits', 1),
     ]);
 
     expect(expenditureChartColors.get('01 - Salaries and Wages')).toBe(


### PR DESCRIPTION
fixing chart colors to be consistent across number

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved expenditure and burndown charts to use consistent, deterministic colors for expense categories across tooltips, series tabs, and subcategory indicators.
  * Category row visibility was refined to exclude categories with no progress data from expenditure progress displays.
* **Tests**
  * Added/updated tests to verify stable category→color mappings and correct series color lookup by series name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->