### PR TITLE
Fix expenditure progress summary balance

### DIFF
--- a/web/client/src/lib/projectProgress.ts
+++ b/web/client/src/lib/projectProgress.ts
@@ -118,24 +118,13 @@ export function getBudgetProgressSummary(
     (sum, category) => sum + category.committed,
     0
   );
-  const remaining = categoryProgress.reduce(
-    (sum, category) => sum + category.available,
+  const netRemaining = categoryProgress.reduce(
+    (sum, category) => sum + category.available - category.overrun,
     0
   );
-  const overrun = categoryProgress.reduce(
-    (sum, category) => sum + category.overrun,
-    0
-  );
-  const displaySpent =
-    overrun > 0 ? Math.max(spent, budget + overrun - committed) : spent;
-  const displayRemaining = overrun > 0 ? 0 : remaining;
-  const total =
-    overrun > 0
-      ? Math.max(displaySpent + committed, 1)
-      : Math.max(
-          categoryProgress.reduce((sum, category) => sum + category.total, 0),
-          1
-        );
+  const overrun = nonnegative(-netRemaining);
+  const remaining = nonnegative(netRemaining);
+  const total = Math.max(spent + committed + remaining, budget + overrun, 1);
   const percentTotal = overrun > 0 && budget > 0 ? budget : total;
 
   return {
@@ -144,10 +133,10 @@ export function getBudgetProgressSummary(
     committedPercent: progressPercent(committed, percentTotal),
     overrun,
     overrunPercent: progressPercent(overrun, percentTotal),
-    remaining: displayRemaining,
-    remainingPercent: progressPercent(displayRemaining, percentTotal),
-    spent: displaySpent,
-    spentPercent: progressPercent(displaySpent, percentTotal),
+    remaining,
+    remainingPercent: progressPercent(remaining, percentTotal),
+    spent,
+    spentPercent: progressPercent(spent, percentTotal),
   };
 }
 

--- a/web/client/src/test/components/project/ProjectExpenditureProgress.test.tsx
+++ b/web/client/src/test/components/project/ProjectExpenditureProgress.test.tsx
@@ -19,44 +19,66 @@ const category = (
 });
 
 describe('ProjectExpenditureProgress', () => {
-  it('shows aggregate overruns as spent budget and a full summary bar', () => {
+  it('nets detail balances in the aggregate expense summary', () => {
     render(
       <ProjectExpenditureProgress
         awardEndDate={null}
         awardStartDate={null}
         categories={[
           category({
-            budget: 60_000,
+            budget: 45_830,
             expenditureCategory: '01 - Salaries and Wages',
-            remainingNow: 20_000,
-            spentToDate: 40_000,
+            remainingNow: -2841.36,
+            spentToDate: 48_671.36,
           }),
           category({
-            budget: 3100,
-            expenditureCategory: '04 - Supplies',
+            budget: 26_437,
+            expenditureCategory: '02 - Fringe Benefits',
+            remainingNow: 9872.77,
+            spentToDate: 16_564.23,
+          }),
+          category({
+            budget: 0,
+            expenditureCategory: '03 - Supplies / Services / Other Expenses',
             isPersonnel: 0,
-            remainingNow: -16_648.39,
-            spentToDate: 18_128.21,
+            remainingNow: -5411.86,
+            spentToDate: 5411.86,
+          }),
+          category({
+            budget: 0,
+            expenditureCategory: '04 - Travel',
+            isPersonnel: 0,
+            remainingNow: -44.22,
+            spentToDate: 44.22,
+          }),
+          category({
+            budget: 0,
+            expenditureCategory: '05 - Fellowship & Scholarships',
+            isPersonnel: 0,
+            remainingNow: 2067.91,
+            spentToDate: 0,
+          }),
+          category({
+            budget: 26_667,
+            expenditureCategory: '06 - Indirect Costs',
+            isPersonnel: 0,
+            remainingNow: -2753.19,
+            spentToDate: 29_420.19,
           }),
         ]}
       />
     );
 
     expect(
-      screen.getByText('$79,748.39 (126%) spent')
+      screen.getByText('$100,111.86 (99%) spent')
     ).toBeInTheDocument();
     expect(
       screen.getByText('$0.00 (0%) committed')
     ).toBeInTheDocument();
-    expect(screen.getByText('$16,648.39 (26%) over')).toHaveClass(
-      'font-proxima-bold'
-    );
-    expect(screen.getByText('$16,648.39 (537%) over')).toHaveClass(
-      'font-proxima-bold'
-    );
+    expect(screen.getByText('$890.05 (1%)')).not.toHaveClass('text-error');
     expect(
       screen.getByRole('img', {
-        name: /All Expenses: \$79,748\.39 \(126%\) spent, \$0\.00 \(0%\) committed, \$16,648\.39 \(26%\) over/,
+        name: /All Expenses: \$100,111\.86 \(99%\) spent, \$0\.00 \(0%\) committed, \$890\.05 \(1%\), \$98,934\.00 budget/,
       })
     ).toBeInTheDocument();
   });

--- a/web/client/src/test/lib/projectProgress.test.ts
+++ b/web/client/src/test/lib/projectProgress.test.ts
@@ -59,27 +59,79 @@ describe('getBudgetProgressSummary', () => {
     expect(progress.remainingPercent).toBe(0);
   });
 
-  it('rolls lower-category overruns into aggregate spent progress', () => {
+  it('nets category surpluses against category overruns in aggregate balance', () => {
     const progress = getBudgetProgressSummary([
       category({
-        budget: 60_000,
-        remainingNow: 20_000,
-        spentToDate: 40_000,
+        budget: 1000,
+        remainingNow: 100,
+        spentToDate: 900,
       }),
       category({
-        budget: 3100,
-        remainingNow: -16_648.39,
-        spentToDate: 18_128.21,
+        budget: 100,
+        remainingNow: -50,
+        spentToDate: 150,
       }),
     ]);
 
-    expect(progress.budget).toBe(63_100);
-    expect(progress.overrun).toBeCloseTo(16_648.39, 2);
-    expect(progress.overrunPercent).toBeCloseTo(26.38, 2);
-    expect(progress.remaining).toBe(0);
-    expect(progress.spent).toBeCloseTo(79_748.39, 2);
-    expect(progress.spentPercent).toBeCloseTo(126.38, 2);
-    expect(progress.remainingPercent).toBe(0);
+    expect(progress.budget).toBe(1100);
+    expect(progress.overrun).toBe(0);
+    expect(progress.overrunPercent).toBe(0);
+    expect(progress.remaining).toBe(50);
+    expect(progress.spent).toBe(1050);
+    expect(progress.spentPercent).toBeCloseTo(95.45, 2);
+    expect(progress.remainingPercent).toBeCloseTo(4.55, 2);
+  });
+
+  it('matches aggregate expense and balance totals to the detail rows', () => {
+    const progress = getBudgetProgressSummary([
+      category({
+        budget: 45_830,
+        remainingNow: -2841.36,
+        spentToDate: 48_671.36,
+      }),
+      category({
+        budget: 26_437,
+        expenditureCategory: '02 - Fringe Benefits',
+        remainingNow: 9872.77,
+        spentToDate: 16_564.23,
+      }),
+      category({
+        budget: 0,
+        expenditureCategory: '03 - Supplies / Services / Other Expenses',
+        isPersonnel: 0,
+        remainingNow: -5411.86,
+        spentToDate: 5411.86,
+      }),
+      category({
+        budget: 0,
+        expenditureCategory: '04 - Travel',
+        isPersonnel: 0,
+        remainingNow: -44.22,
+        spentToDate: 44.22,
+      }),
+      category({
+        budget: 0,
+        expenditureCategory: '05 - Fellowship & Scholarships',
+        isPersonnel: 0,
+        remainingNow: 2067.91,
+        spentToDate: 0,
+      }),
+      category({
+        budget: 26_667,
+        expenditureCategory: '06 - Indirect Costs',
+        isPersonnel: 0,
+        remainingNow: -2753.19,
+        spentToDate: 29_420.19,
+      }),
+    ]);
+
+    expect(progress.budget).toBe(98_934);
+    expect(progress.committed).toBe(0);
+    expect(progress.overrun).toBe(0);
+    expect(progress.remaining).toBeCloseTo(890.05, 2);
+    expect(progress.spent).toBeCloseTo(100_111.86, 2);
+    expect(progress.spentPercent).toBeCloseTo(99.12, 2);
+    expect(progress.remainingPercent).toBeCloseTo(0.88, 2);
   });
 });
 


### PR DESCRIPTION
## Summary
- net category surpluses against category overruns in the expenditure progress summary
- keep All Expenses spent as the sum of actual detail expenses instead of inflating it from category overruns
- add regression coverage for the surplus/overrun mix reported on the expenditure progress page

## Tests
- npm test -- --run src/test/lib/projectProgress.test.ts src/test/components/project/ProjectExpenditureProgress.test.tsx
- npm test -- --run 'src/test/routes/(authenticated)/project-detail.test.tsx'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved project budget summaries to accurately net category surpluses against overruns.
  * Updated remaining, spent, committed, and percentage totals for more consistent aggregate calculations.
  * Corrected expense progress displays so totals and overrun styling reflect the calculated net balance.

* **Tests**
  * Added coverage for multi-category budget calculations, including surplus and overrun scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->