### PR TITLE
Project projection horizon runs through the award end date

### DIFF
--- a/datamart/StoredProcedures/usp_GetProjectProjection.sql
+++ b/datamart/StoredProcedures/usp_GetProjectProjection.sql
@@ -1,8 +1,9 @@
 -- Monthly per-expenditure-category budget burndown for a single project.
 -- Returns two result sets:
 --   1. Per-category budget header (budget, spent-to-date, committed, current remaining, award end date).
---   2. Period x category grid: 3 trailing actual months, the current (blended) month, and 12
---      projected months, each with actual spend, projected spend, and the running budget
+--   2. Period x category grid: 3 trailing actual months, the current (blended) month, and
+--      projected months through the award end date (12 when the award end date is unknown),
+--      each with actual spend, projected spend, and the running budget
 --      remaining (burndown).
 -- All inputs are local: GL actuals from dbo.GlProjectMonthlyActuals, the natural-account ->
 -- category crosswalk from dbo.ExpenditureTypeByAccount, personnel from dbo.PositionBudgets +
@@ -23,8 +24,8 @@ BEGIN
     DECLARE @ParametersJSON NVARCHAR(MAX);
 
     -- "Now" anchors the whole window: 3 trailing actual months, the current (blended) month,
-    -- and 12 projected months. Current-month non-personnel projection is prorated by the days
-    -- remaining in the month.
+    -- and projected months through the award end date. Current-month non-personnel projection
+    -- is prorated by the days remaining in the month.
     DECLARE @Today          DATE = CAST(GETDATE() AS DATE);
     DECLARE @CurrMonthStart DATE = DATEFROMPARTS(YEAR(@Today), MONTH(@Today), 1);
     DECLARE @DaysInMonth    INT  = DAY(EOMONTH(@Today));
@@ -43,14 +44,36 @@ BEGIN
 
         EXEC dbo.usp_ValidateAggieEnterpriseProject @ProjectId;
 
-        /* Period dimension: offsets -3..+12 from the current month. */
+        /* Horizon end: project through the award end date's month; when the award end date
+           is unknown, fall back to 12 projected months. A past/current end date yields no
+           projected months (history + the blended current month only). */
+        DECLARE @AwardEndDate DATE = (
+            SELECT MAX(f.AwardEndDate)
+            FROM dbo.FacultyDeptPortfolio f
+            WHERE f.ProjectNumber = @ProjectId
+        );
+        DECLARE @ProjMonths INT =
+            CASE WHEN @AwardEndDate IS NULL THEN 12
+                 ELSE DATEDIFF(MONTH, @CurrMonthStart,
+                               DATEFROMPARTS(YEAR(@AwardEndDate), MONTH(@AwardEndDate), 1))
+            END;
+        IF @ProjMonths < 0 SET @ProjMonths = 0;
+
+        /* Period dimension: 3 trailing actual months (n = -3..-1), the blended current month
+           (n = 0), and projected months (n = 1..@ProjMonths). The tally reads from
+           sys.all_objects, which bounds even a corrupt far-future end date to a finite window. */
         DROP TABLE IF EXISTS #periods;
+        ;WITH n AS (
+            SELECT TOP (@ProjMonths + 4)
+                   ROW_NUMBER() OVER (ORDER BY (SELECT NULL)) - 4 AS n
+            FROM sys.all_objects
+        )
         SELECT
-            DATEADD(MONTH, n, @CurrMonthStart) AS MonthStart,
-            FORMAT(DATEADD(MONTH, n, @CurrMonthStart), 'MMM-yy') AS DisplayPeriod,
-            CASE WHEN n < 0 THEN 'actual' WHEN n = 0 THEN 'blended' ELSE 'projected' END AS Kind
+            DATEADD(MONTH, n.n, @CurrMonthStart) AS MonthStart,
+            FORMAT(DATEADD(MONTH, n.n, @CurrMonthStart), 'MMM-yy') AS DisplayPeriod,
+            CASE WHEN n.n < 0 THEN 'actual' WHEN n.n = 0 THEN 'blended' ELSE 'projected' END AS Kind
         INTO #periods
-        FROM (VALUES (-3),(-2),(-1),(0),(1),(2),(3),(4),(5),(6),(7),(8),(9),(10),(11),(12)) v(n);
+        FROM n;
 
         /* GL actuals, filtered to expense accounts (parent rollup '5%') and mapped from natural
            account to expenditure category. Unmapped expense accounts fall into


### PR DESCRIPTION
## What

Extends the project burndown so its projection runs to the project's award end date instead of a fixed 12 months.

## Why

The burndown previously always projected exactly 12 months forward regardless of when the award ends. Analysts want the projection to run through the actual award end date (and only fall back to 12 months when no end date is known), so the burndown reflects the real remaining life of the project.

## Changes

- **`usp_GetProjectProjection`** — Derive the projected-month count from `FacultyDeptPortfolio.AwardEndDate` (MAX per project): project through that month; fall back to 12 when the end date is NULL; zero projected months once the award has ended (history + the blended current month only). `#periods` is now built from a tally instead of a static `VALUES (-3)..(12)` list. At a 12-month horizon it reproduces the previous window exactly. Downstream temp tables, both result sets, and the burndown running-remaining math are unchanged.

## Not in this PR

- The summary table `GlProjectMonthlyActuals` is already loaded by the existing `pl_aedwh_loader` Fabric pipeline (aggregates at the AE DWH source joined to `erp_account`, swaps via `usp_SwapStagingTable`, scheduled daily). No loader change is needed here.
- A follow-up chart tweak: with the horizon now ending on the award end date, the "Project End" reference line sits at the right plot edge and its label needs to end-align to stay inside the plot. That change is parked on `rpm/burndown-project-end-label` for a separate PR.

## Verification

- `usp_GetProjectProjection` run in WalterDev against three cases: future award end date (projected periods end at that month), NULL end date (12 projected months, unchanged), past/current end date (history + blended only, zero projected). All correct.
- DACPAC build compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
