### PR TITLE
Department Balances table shows only Revenue, Expenses, and Ending Balance

### DIFF
--- a/web/client/src/lib/departmentBalances.ts
+++ b/web/client/src/lib/departmentBalances.ts
@@ -19,14 +19,13 @@ export const DIMENSIONS: DimensionDef[] = [
 ];
 
 export interface MeasureDef {
-  key: 'assets' | 'liabilities' | 'netPosition' | 'revenue' | 'expenses' | 'endingBalance';
+  key: 'revenue' | 'expenses' | 'endingBalance';
   label: string;
 }
 
+// Displayed measures only; the API also returns assets/liabilities/net position,
+// which the report intentionally omits.
 export const MEASURES: MeasureDef[] = [
-  { key: 'assets', label: 'Assets' },
-  { key: 'liabilities', label: 'Liabilities' },
-  { key: 'netPosition', label: 'Net Position' },
   { key: 'revenue', label: 'Revenue' },
   { key: 'expenses', label: 'Expenses' },
   { key: 'endingBalance', label: 'Ending Balance' },

--- a/web/client/src/test/lib/departmentBalances.test.ts
+++ b/web/client/src/test/lib/departmentBalances.test.ts
@@ -23,9 +23,9 @@ describe('DIMENSIONS', () => {
 });
 
 describe('MEASURES', () => {
-  it('exposes the balance measures in display order', () => {
+  it('exposes only the displayed measures in display order', () => {
     expect(MEASURES.map((m) => m.key)).toEqual([
-      'assets', 'liabilities', 'netPosition', 'revenue', 'expenses', 'endingBalance',
+      'revenue', 'expenses', 'endingBalance',
     ]);
   });
 });


### PR DESCRIPTION
Trims the Department Balances report's measure columns to Revenue, Expenses, and Ending Balance. Assets, Liabilities, and Net Position are no longer displayed.

The table columns, footer totals, and CSV export all derive from the shared `MEASURES` catalog in `lib/departmentBalances.ts`, so the change is a single trim of that list (plus its type union and test). The API response still carries all six measures; only the display changes.

Follow-up to #343.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Department balance reports now display only Revenue, Expenses, and Ending Balance.
  * Assets, Liabilities, and Net Position measures have been removed from the displayed report options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->