### PR TITLE
Moving AWARD info to above personnel table

### DIFF
--- a/web/client/src/components/project/ProjectAdditionalInfo.tsx
+++ b/web/client/src/components/project/ProjectAdditionalInfo.tsx
@@ -8,6 +8,7 @@ import { tooltipDefinitions } from '@/shared/tooltips.ts';
 interface Field {
   label: string;
   tooltip?: string;
+  truncateWithTooltip?: boolean;
   value: string;
 }
 
@@ -16,13 +17,10 @@ const fieldRowClassName =
 
 function buildPrimaryFields(summary: ProjectSummary): Field[] {
   return [
-    { label: 'Award Number', value: summary.awardNumber ?? '—' },
-    { label: 'Award Name', value: summary.awardName ?? '—' },
-    { label: 'Award PI', value: summary.awardPi ?? '—' },
-    { label: 'Award Start Date', value: formatDate(summary.awardStartDate) },
     { label: 'Award End Date', value: formatDate(summary.awardEndDate) },
     {
       label: 'Primary Sponsor Name',
+      truncateWithTooltip: true,
       value: summary.primarySponsorName ?? '—',
     },
     {
@@ -37,6 +35,34 @@ function buildPrimaryFields(summary: ProjectSummary): Field[] {
         : '—',
     },
   ];
+}
+
+function buildFeaturedFields(summary: ProjectSummary): Field[] {
+  return [
+    { label: 'Award Number', value: summary.awardNumber ?? '—' },
+    {
+      label: 'Award Name',
+      truncateWithTooltip: true,
+      value: summary.awardName ?? '—',
+    },
+    { label: 'Award PI', value: summary.awardPi ?? '—' },
+    { label: 'Award Start Date', value: formatDate(summary.awardStartDate) },
+  ];
+}
+
+function StatValue({ field }: { field: Field }) {
+  if (field.truncateWithTooltip && field.value !== '—') {
+    return (
+      <TooltipLabel
+        className="min-w-0 max-w-full"
+        label={field.value}
+        labelClassName="block max-w-full truncate"
+        tooltip={field.value}
+      />
+    );
+  }
+
+  return field.value;
 }
 
 function buildSecondaryFields(summary: ProjectSummary): Field[] {
@@ -116,9 +142,7 @@ interface ProjectAdditionalInfoProps {
   summary: ProjectSummary;
 }
 
-export function ProjectAdditionalInfo({
-  summary,
-}: ProjectAdditionalInfoProps) {
+export function ProjectAdditionalInfo({ summary }: ProjectAdditionalInfoProps) {
   const [expanded, setExpanded] = React.useState(false);
 
   if (!summary.awardNumber) {
@@ -126,6 +150,7 @@ export function ProjectAdditionalInfo({
   }
 
   const primaryFields = buildPrimaryFields(summary);
+  const featuredFields = buildFeaturedFields(summary);
   const secondaryFields = buildSecondaryFields(summary);
   const renderLabel = (field: Field) =>
     field.tooltip ? (
@@ -138,14 +163,29 @@ export function ProjectAdditionalInfo({
     <section className="section-margin">
       <h2 className="h2 mb-4">Award Information</h2>
 
-      <div className="grid grid-cols-1 gap-x-4 gap-y-2 xl:grid-cols-2">
-        {primaryFields.map((field) => (
-          <div className={fieldRowClassName} key={field.label}>
-            <div className="font-proxima-bold">{renderLabel(field)}</div>
-            <div className="min-w-0">{field.value}</div>
+      <dl className="grid grid-cols-1 gap-4 mb-6 sm:grid-cols-2 xl:grid-cols-4">
+        {featuredFields.map((field) => (
+          <div key={field.label}>
+            <dd className="stat-label">{renderLabel(field)}</dd>
+            <dt className="stat-value min-w-0 break-words">
+              <StatValue field={field} />
+            </dt>
           </div>
         ))}
+      </dl>
 
+      <dl className="grid grid-cols-1 gap-4 mb-6 sm:grid-cols-2 xl:grid-cols-4">
+        {primaryFields.map((field) => (
+          <div key={field.label}>
+            <dd className="stat-label">{renderLabel(field)}</dd>
+            <dt className="stat-value min-w-0 break-words">
+              <StatValue field={field} />
+            </dt>
+          </div>
+        ))}
+      </dl>
+
+      <div className="grid grid-cols-1 gap-x-4 gap-y-2 xl:grid-cols-2">
         {expanded &&
           secondaryFields.map((field) => (
             <div className={fieldRowClassName} key={field.label}>

--- a/web/client/src/components/project/ProjectAdditionalInfo.tsx
+++ b/web/client/src/components/project/ProjectAdditionalInfo.tsx
@@ -166,10 +166,10 @@ export function ProjectAdditionalInfo({ summary }: ProjectAdditionalInfoProps) {
       <dl className="grid grid-cols-1 gap-4 mb-6 sm:grid-cols-2 xl:grid-cols-4">
         {featuredFields.map((field) => (
           <div key={field.label}>
-            <dd className="stat-label">{renderLabel(field)}</dd>
-            <dt className="stat-value min-w-0 break-words">
+            <dt className="stat-label">{renderLabel(field)}</dt>
+            <dd className="stat-value min-w-0 break-words">
               <StatValue field={field} />
-            </dt>
+            </dd>
           </div>
         ))}
       </dl>
@@ -177,10 +177,10 @@ export function ProjectAdditionalInfo({ summary }: ProjectAdditionalInfoProps) {
       <dl className="grid grid-cols-1 gap-4 mb-6 sm:grid-cols-2 xl:grid-cols-4">
         {primaryFields.map((field) => (
           <div key={field.label}>
-            <dd className="stat-label">{renderLabel(field)}</dd>
-            <dt className="stat-value min-w-0 break-words">
+            <dt className="stat-label">{renderLabel(field)}</dt>
+            <dd className="stat-value min-w-0 break-words">
               <StatValue field={field} />
-            </dt>
+            </dd>
           </div>
         ))}
       </dl>

--- a/web/client/src/routes/(authenticated)/projects/$iamId/$projectNumber/index.tsx
+++ b/web/client/src/routes/(authenticated)/projects/$iamId/$projectNumber/index.tsx
@@ -135,7 +135,6 @@ function ProjectContent({
         summary={summary}
       />
       <FinancialDetails summary={summary} />
-      <ProjectAdditionalInfo summary={summary} />
 
       <section className="section-margin">
         {summary.isInternal ? (
@@ -166,6 +165,8 @@ function ProjectContent({
           </>
         )}
       </section>
+
+      <ProjectAdditionalInfo summary={summary} />
 
       <section className="section-margin">
         <h2 className="h2 mb-2">Personnel</h2>

--- a/web/client/src/test/components/project/ProjectAdditionalInfo.test.tsx
+++ b/web/client/src/test/components/project/ProjectAdditionalInfo.test.tsx
@@ -74,6 +74,80 @@ describe('ProjectAdditionalInfo', () => {
     expect(screen.getByText('26.5%')).toBeInTheDocument();
   });
 
+  it('features key award fields as stat values', () => {
+    render(<ProjectAdditionalInfo summary={createSummary()} />);
+
+    for (const value of [
+      'AWD-100',
+      'Test Award',
+      'Smith, Jane',
+      '01.01.2024',
+    ]) {
+      expect(screen.getByText(value).closest('dt')).toHaveClass('stat-value');
+    }
+  });
+
+  it('features remaining primary award fields as stat values', () => {
+    render(<ProjectAdditionalInfo summary={createSummary()} />);
+
+    for (const value of [
+      '12.31.2026',
+      'National Science Foundation',
+      'NSF-2024-001',
+      '26.5%',
+    ]) {
+      expect(screen.getByText(value).closest('dt')).toHaveClass('stat-value');
+    }
+  });
+
+  it('truncates the award name and reveals the full name in a tooltip', async () => {
+    const user = userEvent.setup();
+    const awardName =
+      'Long Running Multidisciplinary Sponsored Award for Regional Climate Resilience and Agricultural Water Systems';
+
+    render(
+      <ProjectAdditionalInfo
+        summary={createSummary({
+          awardName,
+        })}
+      />
+    );
+
+    const awardNameValue = screen.getByText(awardName);
+
+    expect(awardNameValue).toHaveClass('truncate');
+    expect(awardNameValue).toHaveClass('tooltip-label');
+
+    await user.hover(awardNameValue.parentElement as HTMLElement);
+
+    expect(await screen.findByRole('tooltip')).toHaveTextContent(awardName);
+  });
+
+  it('truncates the primary sponsor name and reveals the full name in a tooltip', async () => {
+    const user = userEvent.setup();
+    const primarySponsorName =
+      'United States Department of Agriculture National Institute of Food and Agriculture';
+
+    render(
+      <ProjectAdditionalInfo
+        summary={createSummary({
+          primarySponsorName,
+        })}
+      />
+    );
+
+    const sponsorNameValue = screen.getByText(primarySponsorName);
+
+    expect(sponsorNameValue).toHaveClass('truncate');
+    expect(sponsorNameValue).toHaveClass('tooltip-label');
+
+    await user.hover(sponsorNameValue.parentElement as HTMLElement);
+
+    expect(await screen.findByRole('tooltip')).toHaveTextContent(
+      primarySponsorName
+    );
+  });
+
   it('hides secondary fields by default', () => {
     render(<ProjectAdditionalInfo summary={createSummary()} />);
 
@@ -84,7 +158,9 @@ describe('ProjectAdditionalInfo', () => {
   it('shows Show more button for all users', () => {
     render(<ProjectAdditionalInfo summary={createSummary()} />);
 
-    expect(screen.getByRole('button', { name: 'Show more' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Show more' })
+    ).toBeInTheDocument();
   });
 
   it('reveals hidden fields when Show more is clicked', async () => {
@@ -172,9 +248,9 @@ describe('ProjectAdditionalInfo', () => {
     render(
       <ProjectAdditionalInfo
         summary={createSummary({
+          flowThroughFundsAmount: '500000',
           flowThroughFundsPrimarySponsor: null,
           flowThroughFundsReferenceAwardName: 'Parent Award XYZ',
-          flowThroughFundsAmount: '500000',
         })}
       />
     );
@@ -202,11 +278,11 @@ describe('ProjectAdditionalInfo', () => {
     render(
       <ProjectAdditionalInfo
         summary={createSummary({
+          flowThroughFundsAmount: '1234567',
+          flowThroughFundsEndDate: '2027-06-30',
           flowThroughFundsPrimarySponsor: 'Harvard University',
           flowThroughFundsReferenceAwardName: 'H-2024-001',
           flowThroughFundsStartDate: '2024-07-01',
-          flowThroughFundsEndDate: '2027-06-30',
-          flowThroughFundsAmount: '1234567',
         })}
       />
     );
@@ -226,11 +302,11 @@ describe('ProjectAdditionalInfo', () => {
     render(
       <ProjectAdditionalInfo
         summary={createSummary({
+          flowThroughFundsAmount: null,
+          flowThroughFundsEndDate: null,
           flowThroughFundsPrimarySponsor: 'Harvard University',
           flowThroughFundsReferenceAwardName: null,
           flowThroughFundsStartDate: null,
-          flowThroughFundsEndDate: null,
-          flowThroughFundsAmount: null,
         })}
       />
     );

--- a/web/client/src/test/components/project/ProjectAdditionalInfo.test.tsx
+++ b/web/client/src/test/components/project/ProjectAdditionalInfo.test.tsx
@@ -83,7 +83,7 @@ describe('ProjectAdditionalInfo', () => {
       'Smith, Jane',
       '01.01.2024',
     ]) {
-      expect(screen.getByText(value).closest('dt')).toHaveClass('stat-value');
+      expect(screen.getByText(value).closest('dd')).toHaveClass('stat-value');
     }
   });
 
@@ -96,7 +96,7 @@ describe('ProjectAdditionalInfo', () => {
       'NSF-2024-001',
       '26.5%',
     ]) {
-      expect(screen.getByText(value).closest('dt')).toHaveClass('stat-value');
+      expect(screen.getByText(value).closest('dd')).toHaveClass('stat-value');
     }
   });
 

--- a/web/client/src/test/routes/(authenticated)/project-detail.test.tsx
+++ b/web/client/src/test/routes/(authenticated)/project-detail.test.tsx
@@ -557,7 +557,9 @@ describe('project detail page', () => {
           'budget-vs-time-current-month-marker'
         )
       ).toBeInTheDocument();
-      expect(within(expenditureProgress).getByText('Today')).toBeInTheDocument();
+      expect(
+        within(expenditureProgress).getByText('Today')
+      ).toBeInTheDocument();
       expect(
         within(expenditureProgress).getByText('912 months total')
       ).toBeInTheDocument();
@@ -598,17 +600,16 @@ describe('project detail page', () => {
           name: /Supplies: \$20\.00 \(20%\) spent, \$10\.00 committed, \$70\.00 \(70%\) available, \$100\.00 budget/,
         })
       ).toBeInTheDocument();
-      for (const label of screen.getAllByText('Switchable Projection Project')) {
+      for (const label of screen.getAllByText(
+        'Switchable Projection Project'
+      )) {
         expect(label.closest('a')).toHaveAttribute(
           'href',
           '/expenditureprogress/1000/P2'
         );
       }
       for (const label of screen.getAllByText('Internal Operations Project')) {
-        expect(label.closest('a')).toHaveAttribute(
-          'href',
-          '/projects/1000/P3'
-        );
+        expect(label.closest('a')).toHaveAttribute('href', '/projects/1000/P3');
       }
     } finally {
       cleanup();
@@ -689,17 +690,16 @@ describe('project detail page', () => {
       expect(
         screen.queryByTestId('project-expenditure-progress')
       ).not.toBeInTheDocument();
-      for (const label of screen.getAllByText('Switchable Projection Project')) {
+      for (const label of screen.getAllByText(
+        'Switchable Projection Project'
+      )) {
         expect(label.closest('a')).toHaveAttribute(
           'href',
           '/projectburndown/1000/P2'
         );
       }
       for (const label of screen.getAllByText('Internal Operations Project')) {
-        expect(label.closest('a')).toHaveAttribute(
-          'href',
-          '/projects/1000/P3'
-        );
+        expect(label.closest('a')).toHaveAttribute('href', '/projects/1000/P3');
       }
 
       // Single-select: All Expenses is first and selected by default.
@@ -928,6 +928,38 @@ describe('project detail page', () => {
       expect(
         screen.queryByRole('link', { name: 'Details' })
       ).not.toBeInTheDocument();
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('places Award Information below the breakdown and above Personnel', async () => {
+    const projects = [createProject({ pmEmployeeId: '2000' })];
+    setupHandlers({ employeeId: '1000', name: 'PI User' }, projects);
+
+    const { cleanup } = renderRoute({
+      initialPath: '/projects/1000/P1',
+    });
+
+    try {
+      const breakdownHeading = await screen.findByRole('heading', {
+        name: 'Expenditure Category Breakdown',
+      });
+      const awardHeading = screen.getByRole('heading', {
+        name: 'Award Information',
+      });
+      const personnelHeading = screen.getByRole('heading', {
+        name: 'Personnel',
+      });
+
+      expect(
+        breakdownHeading.compareDocumentPosition(awardHeading) &
+          Node.DOCUMENT_POSITION_FOLLOWING
+      ).toBeTruthy();
+      expect(
+        awardHeading.compareDocumentPosition(personnelHeading) &
+          Node.DOCUMENT_POSITION_FOLLOWING
+      ).toBeTruthy();
     } finally {
       cleanup();
     }


### PR DESCRIPTION
rearranging award content and location

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Long award and sponsor names are now automatically truncated, with tooltips that reveal the full text.
  * Award information is presented in an improved stat-based layout for clearer readability.
* **Layout Improvements**
  * On project detail pages, “Award Information” now appears after “Expenditure Category Breakdown” and before “Personnel.”
* **Tests**
  * Added and updated UI assertions to verify the new truncation and page ordering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->